### PR TITLE
Python integration test framework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ Makefile.in
 *.lo
 *.la
 *.trs
+*.pyc

--- a/configure.ac
+++ b/configure.ac
@@ -27,7 +27,8 @@ PKG_CHECK_MODULES([ZMQ], [libzmq])
 AC_CONFIG_FILES([
   Makefile \
   xayagame/Makefile \
-  mover/Makefile
+  mover/Makefile \
+  mover/gametest/Makefile
 ])
 AC_OUTPUT
 

--- a/mover/Makefile.am
+++ b/mover/Makefile.am
@@ -1,3 +1,5 @@
+SUBDIRS = gametest
+
 noinst_LTLIBRARIES = libmover.la
 bin_PROGRAMS = moverd
 

--- a/mover/gametest/Makefile.am
+++ b/mover/gametest/Makefile.am
@@ -1,0 +1,8 @@
+AM_TESTS_ENVIRONMENT = \
+  PYTHONPATH=$(top_srcdir)
+
+TESTS = \
+  basic.py \
+  catching_up.py \
+  reorg.py \
+  stopped_xayad.py

--- a/mover/gametest/basic.py
+++ b/mover/gametest/basic.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python
+# Copyright (C) 2018 The Xaya developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+from mover import MoverTest
+
+"""
+Tests basic game operation with some moves and the resulting game state.
+"""
+
+
+class BasicTest (MoverTest):
+
+  def run (self):
+    self.generate (101)
+    self.expectGameState ({"players": {}})
+
+    self.move ("a", "k", 2)
+    self.move ("b", "y", 1)
+
+    # Without confirming the transactions, the game state should not be changed.
+    self.expectGameState ({"players": {}})
+
+    self.generate (1)
+    self.expectGameState ({"players": {
+      "a": {"x": 0, "y": 1, "dir": "up", "steps": 1},
+      "b": {"x": -1, "y": 1},
+    }})
+
+    self.move ("a", "l", 2)
+    self.generate (1)
+    self.expectGameState ({"players": {
+      "a": {"x": 1, "y": 1,  "dir": "right", "steps": 1},
+      "b": {"x": -1, "y": 1},
+    }})
+
+    # Send an invalid move, which should be ignored.
+    self.sendMove ("a", {"d": "h", "n": 1000001})
+    self.generate (1)
+    self.expectGameState ({"players": {
+      "a": {"x": 2, "y": 1},
+      "b": {"x": -1, "y": 1},
+    }})
+
+
+if __name__ == "__main__":
+  BasicTest ().main ()

--- a/mover/gametest/catching_up.py
+++ b/mover/gametest/catching_up.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python
+# Copyright (C) 2018 The Xaya developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+from mover import MoverTest
+
+import time
+
+"""
+Tests catching up of the game if it gets out of sync.
+"""
+
+
+class CatchingUpTest (MoverTest):
+
+  def run (self):
+    self.generate (101)
+    self.expectGameState ({"players": {}})
+    oldState = self.rpc.game.getcurrentstate ()
+
+    # Disable tracking of the game, so it won't get notified about changes
+    # we make and get out of sync.
+    self.log.info ("Untracking g/mv")
+    self.rpc.xaya.trackedgames ("remove", "mv")
+    self.move ("a", "k", 2)
+    self.generate (1)
+
+    # We cannot use expectGameState / getGameState, as that would wait for
+    # the game to catch up (which it doesn't do).  So just sleep a short time
+    # and hope this is good enough the ensure that the game would have caught
+    # up if there were some issue with the test.
+    time.sleep (0.1)
+    state = self.rpc.game.getcurrentstate ()
+    assert state == oldState
+
+    # Start to track the game again and mine another block.  This should make
+    # the game catch up.
+    self.log.info ("Tracking g/mv again")
+    self.rpc.xaya.trackedgames ("add", "mv")
+    self.generate (1)
+    self.expectGameState ({"players": {
+      "a": {"x": 0, "y": 2},
+    }})
+
+    # Now stop the game daemon and let it catch up later when restarted.  Note
+    # that this leads to a sync from scratch with the MemoryStorage, but that
+    # doesn't matter here.
+    self.log.info ("Stopping game daemon")
+    self.stopGameDaemon ()
+    self.move ("a", "l", 1)
+    self.generate (1)
+
+    # Start the game daemon again and check that it catches up correctly.
+    self.log.info ("Restarting game daemon")
+    self.startGameDaemon ()
+    self.expectGameState ({"players": {
+      "a": {"x": 1, "y": 2},
+    }})
+
+
+if __name__ == "__main__":
+  CatchingUpTest ().main ()

--- a/mover/gametest/mover.py
+++ b/mover/gametest/mover.py
@@ -1,0 +1,28 @@
+# Copyright (C) 2018 The Xaya developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+from xayagametest.testcase import XayaGameTest
+
+import os
+import os.path
+
+
+class MoverTest (XayaGameTest):
+  """
+  An integration test for the Mover game.
+  """
+
+  def __init__ (self):
+    srcdir = os.getenv ("srcdir")
+    if srcdir is None:
+      srcdir = "."
+    moverd = os.path.join (srcdir, "..", "moverd")
+    super (MoverTest, self).__init__ ("mv", moverd)
+
+  def move (self, name, direction, steps):
+    """
+    Utility method to send a Mover move.
+    """
+
+    self.sendMove (name, {"d": direction, "n": steps})

--- a/mover/gametest/reorg.py
+++ b/mover/gametest/reorg.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python
+# Copyright (C) 2018 The Xaya developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+from mover import MoverTest
+
+"""
+Tests reorgs with the Mover game.
+"""
+
+
+class ReorgTest (MoverTest):
+
+  def run (self):
+    self.generate (101)
+    self.expectGameState ({"players": {}})
+
+    self.move ("a", "k", 5)
+    self.generate (1)
+    self.expectGameState ({"players": {
+      "a": {"x": 0, "y": 1, "dir": "up", "steps": 4},
+    }})
+
+    # Form a branch which moves "a" and registers "b" as new name.  Make it
+    # so long that the transactions depend on block rewards from the fork, so
+    # that they won't be remined later.  This also means that we will naturally
+    # reorg back to this chain later.
+    self.generate (1)
+    blk = self.rpc.xaya.getbestblockhash ()
+    consolidationTxs = []
+    for _ in range (11):
+      # We have to consolidate in steps to avoid errors because of a too large
+      # transaction being generated.
+      consolidationTxs.append (self.consolidateCoins ())
+      self.generate (10)
+    consolidationTxs.append (self.consolidateCoins ())
+    self.move ("a", "h", 1)
+    self.move ("b", "l", 1)
+    self.generate (10)
+    self.expectGameState ({"players": {
+      "a": {"x": -1, "y": 5},
+      "b": {"x": 1, "y": 0},
+    }})
+
+    # Invalidate the branch and create another one with different transactions.
+    self.rpc.xaya.invalidateblock (blk)
+    assert self.rpc.xaya.getrawmempool () == []
+    for txid in consolidationTxs:
+      # We need to explicitly abandon transactions that involve the orphaned
+      # block rewards.  Otherwise the funds won't be marked as available again
+      # in the wallet.  See https://github.com/bitcoin/bitcoin/issues/14148.
+      self.rpc.xaya.abandontransaction (txid)
+    assert self.rpc.xaya.getbalance () > 0
+    self.expectGameState ({"players": {
+      "a": {"x": 0, "y": 1, "dir": "up", "steps": 4},
+    }})
+    self.generate (1)
+    self.move ("a", "l", 1)
+    self.move ("b", "y", 2)
+    self.generate (2)
+    self.expectGameState ({"players": {
+      "a": {"x": 1, "y": 2},
+      "b": {"x": -2, "y": 2},
+    }})
+
+    # Reorg back to the longer branch.
+    self.rpc.xaya.reconsiderblock (blk)
+    self.expectGameState ({"players": {
+      "a": {"x": -1, "y": 5},
+      "b": {"x": 1, "y": 0},
+    }})
+
+  def consolidateCoins (self):
+    """
+    Send all the available balance as a single output back to the wallet.
+    This is used to create "dependency" between transactions, so that some
+    transactions cannot be remined after detaching a chain part.
+    """
+
+    balance = self.rpc.xaya.getbalance ()
+    addr = self.rpc.xaya.getnewaddress ()
+    self.log.info ("Sending all %.8f CHI to %s" % (balance, addr))
+    return self.rpc.xaya.sendtoaddress (addr, balance, "", "", True)
+
+
+if __name__ == "__main__":
+  ReorgTest ().main ()

--- a/mover/gametest/stopped_xayad.py
+++ b/mover/gametest/stopped_xayad.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python
+# Copyright (C) 2018 The Xaya developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+from mover import MoverTest
+
+import time
+
+"""
+Tests how the moverd reacts if xayad is stopped and restarted intermittantly.
+"""
+
+
+class StoppedXayadTest (MoverTest):
+
+  def run (self):
+    self.generate (101)
+    self.expectGameState ({"players": {}})
+
+    self.move ("a", "k", 2)
+    self.generate (1)
+    self.expectGameState ({"players": {
+      "a": {"x": 0, "y": 1, "dir": "up", "steps": 1},
+    }})
+
+    # Stop and restart the Xaya Core daemon.  This should not impact the game
+    # daemon, at least not as long as it does not try to send a JSON-RPC
+    # message while xayad is down.  The ZMQ subscription should be back up
+    # again automatically.
+    self.log.info ("Restarting Xaya daemon")
+    self.stopXayaDaemon ()
+    self.startXayaDaemon ()
+
+    # Track the game again and sleep a short time, which ensures that the
+    # ZMQ subscription has indeed had time to catch up again.
+    self.rpc.xaya.trackedgames ("add", "mv")
+    time.sleep (0.1)
+
+    # Mine another block and verify that the game updates.
+    self.generate (1)
+    self.expectGameState ({"players": {
+      "a": {"x": 0, "y": 2},
+    }})
+
+
+if __name__ == "__main__":
+  StoppedXayadTest ().main ()

--- a/xayagametest/.gitignore
+++ b/xayagametest/.gitignore
@@ -1,0 +1,2 @@
+__pycache__
+*.pyc

--- a/xayagametest/.gitignore
+++ b/xayagametest/.gitignore
@@ -1,2 +1,1 @@
 __pycache__
-*.pyc

--- a/xayagametest/game.py
+++ b/xayagametest/game.py
@@ -1,0 +1,79 @@
+# Copyright (C) 2018 The Xaya developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+"""
+Code for running a game daemon as component in an integration test.
+"""
+
+import jsonrpclib
+import logging
+import os
+import os.path
+import shutil
+import subprocess
+import time
+
+
+RPC_PORT = 28110
+
+
+class Node ():
+  """
+  An instance of a game daemon that is connected to a regtest Xaya Core node
+  and used in an integration test.
+
+  It is implemented for the Mover game daemon included with libxayagame, but
+  other game daemons are supported as well if they:
+
+  - Have the --xaya_rpc_url and --game_rpc_port flags that moverd has, and
+  - provide at least the "stop" and "getcurrentstate" RPC methods.
+  """
+
+  def __init__ (self, basedir, binary):
+    self.log = logging.getLogger ("xayagametest.gamenode")
+    self.datadir = os.path.join (basedir, "gamenode")
+    self.binary = binary
+
+    self.log.info ("Creating fresh data directory for the game node in %s"
+                    % self.datadir)
+    shutil.rmtree (self.datadir, ignore_errors=True)
+    os.mkdir (self.datadir)
+
+    self.proc = None
+
+  def start (self, xayarpc):
+    if self.proc is not None:
+      self.log.error ("Game process is already running, not starting again")
+      return
+
+    self.log.info ("Starting new game process")
+    args = [self.binary]
+    args.append ("--xaya_rpc_url=%s" % xayarpc)
+    args.append ("--game_rpc_port=%d" % RPC_PORT)
+    envVars = dict (os.environ)
+    envVars["GLOG_log_dir"] = self.datadir
+    self.proc = subprocess.Popen (args, env=envVars)
+
+    self.rpc = jsonrpclib.Server ("http://localhost:%d" % RPC_PORT)
+
+    self.log.info ("Waiting for the JSON-RPC server to be up...")
+    while True:
+      try:
+        data = self.rpc.getcurrentstate ()
+        self.log.info ("Game daemon is up, chain = %s" % data["chain"])
+        break
+      except:
+        time.sleep (1)
+
+  def stop (self):
+    if self.proc is None:
+      self.log.error ("No game process is running cannot stop it")
+      return
+
+    self.log.info ("Stopping game process")
+    self.rpc._notify.stop ()
+
+    self.log.info ("Waiting for game process to stop...")
+    self.proc.wait ()
+    self.proc = None

--- a/xayagametest/game.py
+++ b/xayagametest/game.py
@@ -15,9 +15,6 @@ import subprocess
 import time
 
 
-RPC_PORT = 28110
-
-
 class Node ():
   """
   An instance of a game daemon that is connected to a regtest Xaya Core node
@@ -30,9 +27,10 @@ class Node ():
   - provide at least the "stop" and "getcurrentstate" RPC methods.
   """
 
-  def __init__ (self, basedir, binary):
+  def __init__ (self, basedir, port, binary):
     self.log = logging.getLogger ("xayagametest.gamenode")
     self.datadir = os.path.join (basedir, "gamenode")
+    self.port = port
     self.binary = binary
 
     self.log.info ("Creating fresh data directory for the game node in %s"
@@ -50,12 +48,12 @@ class Node ():
     self.log.info ("Starting new game process")
     args = [self.binary]
     args.append ("--xaya_rpc_url=%s" % xayarpc)
-    args.append ("--game_rpc_port=%d" % RPC_PORT)
+    args.append ("--game_rpc_port=%d" % self.port)
     envVars = dict (os.environ)
     envVars["GLOG_log_dir"] = self.datadir
     self.proc = subprocess.Popen (args, env=envVars)
 
-    self.rpc = jsonrpclib.Server ("http://localhost:%d" % RPC_PORT)
+    self.rpc = jsonrpclib.Server ("http://localhost:%d" % self.port)
 
     self.log.info ("Waiting for the JSON-RPC server to be up...")
     while True:

--- a/xayagametest/testcase.py
+++ b/xayagametest/testcase.py
@@ -1,0 +1,95 @@
+# Copyright (C) 2018 The Xaya developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+"""
+Basic framework for integration tests of Xaya games.
+"""
+
+import game
+import xaya
+
+import logging
+import os.path
+import shutil
+import sys
+import time
+
+
+XAYAD_BINARY_DEFAULT = "/usr/local/bin/xayad"
+TMPDIR = "/tmp"
+DIR_PREFIX = "xayagametest_"
+
+
+class XayaGameTest (object):
+  """
+  Base class for integration test cases of Xaya games.  This manages the
+  Xaya Core daemon, the game daemon, basic logging and the data directory.
+
+  The actual test should override the "run" method with its test logic.  It
+  can control the Xaya Core daemon through rpc.xaya and the game daemon through
+  rpc.game.
+  """
+
+  def __init__ (self, game_binary_default):
+    self.game_binary_default = game_binary_default
+
+  def main (self):
+    # TODO: Parse flags to override stuff.
+
+    timefmt = "%Y%m%d_%H%M%S"
+    self.basedir = os.path.join (TMPDIR, DIR_PREFIX + time.strftime (timefmt))
+    shutil.rmtree (self.basedir, ignore_errors=True)
+    os.mkdir (self.basedir)
+
+    logfile = os.path.join (self.basedir, "xayagametest.log")
+    logHandler = logging.FileHandler (logfile)
+    logFmt = "%(asctime)s %(name)s (%(levelname)s): %(message)s"
+    logHandler.setFormatter (logging.Formatter (logFmt))
+
+    rootLogger = logging.getLogger ()
+    rootLogger.setLevel (logging.INFO)
+    rootLogger.addHandler (logHandler)
+
+    self.log = logging.getLogger ("xayagametest.testcase")
+
+    mainHandler = logging.StreamHandler (sys.stderr)
+    mainHandler.setFormatter (logging.Formatter ("%(message)s"))
+
+    mainLogger = logging.getLogger ("main")
+    mainLogger.addHandler (logHandler)
+    mainLogger.addHandler (mainHandler)
+    mainLogger.info ("Base directory for integration test: %s" % self.basedir)
+
+    self.xayanode = xaya.Node (self.basedir, XAYAD_BINARY_DEFAULT)
+    self.gamenode = game.Node (self.basedir, self.game_binary_default)
+
+    class RpcHandles:
+      xaya = None
+      game = None
+    self.rpc = RpcHandles ()
+
+    self.xayanode.start ()
+    self.rpc.xaya = self.xayanode.rpc
+    cleanup = False
+    try:
+      self.gamenode.start (self.xayanode.rpcurl)
+      self.rpc.game = self.gamenode.rpc
+      try:
+        self.run ()
+        mainLogger.info ("Test succeeded")
+        cleanup = True
+      except:
+        mainLogger.exception ("Test failed")
+        self.log.info ("Not cleaning up base directory %s" % self.basedir)
+      finally:
+        self.gamenode.stop ()
+    finally:
+      self.xayanode.stop ()
+      if cleanup:
+        self.log.info ("Cleaning up base directory in %s" % self.basedir)
+        shutil.rmtree (self.basedir, ignore_errors=True)
+      logging.shutdown ()
+
+  def run (self):
+    self.log.warning ("Test 'run' method not overridden, this tests nothing")

--- a/xayagametest/testcase.py
+++ b/xayagametest/testcase.py
@@ -9,6 +9,7 @@ Basic framework for integration tests of Xaya games.
 import game
 import xaya
 
+import argparse
 import logging
 import os.path
 import shutil
@@ -17,7 +18,7 @@ import time
 
 
 XAYAD_BINARY_DEFAULT = "/usr/local/bin/xayad"
-TMPDIR = "/tmp"
+DEFAULT_DIR = "/tmp"
 DIR_PREFIX = "xayagametest_"
 
 
@@ -31,14 +32,21 @@ class XayaGameTest (object):
   rpc.game.
   """
 
-  def __init__ (self, game_binary_default):
-    self.game_binary_default = game_binary_default
+  def __init__ (self, name, gameBinaryDefault):
+    desc = "Runs an integration test for the Xaya game %s." % name
+    parser = argparse.ArgumentParser (description=desc)
+    parser.add_argument ("--xayad_binary", default=XAYAD_BINARY_DEFAULT,
+                         help="xayad binary to use in the test")
+    parser.add_argument ("--game_daemon", default=gameBinaryDefault,
+                         help="game daemon binary to use in the test")
+    parser.add_argument ("--dir", default=DEFAULT_DIR,
+                         help="base directory for test runs")
+    self.args = parser.parse_args ()
 
   def main (self):
-    # TODO: Parse flags to override stuff.
-
     timefmt = "%Y%m%d_%H%M%S"
-    self.basedir = os.path.join (TMPDIR, DIR_PREFIX + time.strftime (timefmt))
+    self.basedir = os.path.join (self.args.dir,
+                                 DIR_PREFIX + time.strftime (timefmt))
     shutil.rmtree (self.basedir, ignore_errors=True)
     os.mkdir (self.basedir)
 
@@ -61,8 +69,8 @@ class XayaGameTest (object):
     mainLogger.addHandler (mainHandler)
     mainLogger.info ("Base directory for integration test: %s" % self.basedir)
 
-    self.xayanode = xaya.Node (self.basedir, XAYAD_BINARY_DEFAULT)
-    self.gamenode = game.Node (self.basedir, self.game_binary_default)
+    self.xayanode = xaya.Node (self.basedir, self.args.xayad_binary)
+    self.gamenode = game.Node (self.basedir, self.args.game_daemon)
 
     class RpcHandles:
       xaya = None

--- a/xayagametest/testcase.py
+++ b/xayagametest/testcase.py
@@ -13,6 +13,7 @@ import argparse
 import json
 import logging
 import os.path
+import random
 import shutil
 import sys
 import time
@@ -51,9 +52,8 @@ class XayaGameTest (object):
     Executes the testcase, including setup and cleanup.
     """
 
-    timefmt = "%Y%m%d_%H%M%S"
-    self.basedir = os.path.join (self.args.dir,
-                                 DIR_PREFIX + time.strftime (timefmt))
+    randomSuffix = "%08x" % random.getrandbits (32)
+    self.basedir = os.path.join (self.args.dir, DIR_PREFIX + randomSuffix)
     shutil.rmtree (self.basedir, ignore_errors=True)
     os.mkdir (self.basedir)
 
@@ -77,8 +77,14 @@ class XayaGameTest (object):
     self.mainLogger.info ("Base directory for integration test: %s"
                             % self.basedir)
 
-    self.xayanode = xaya.Node (self.basedir, self.args.xayad_binary)
-    self.gamenode = game.Node (self.basedir, self.args.game_daemon)
+    basePort = random.randint (1024, 30000)
+    self.log.info ("Using port range %d..%d, hopefully it is free"
+        % (basePort, basePort + 2))
+
+    self.xayanode = xaya.Node (self.basedir, basePort, basePort + 1,
+                               self.args.xayad_binary)
+    self.gamenode = game.Node (self.basedir, basePort + 2,
+                               self.args.game_daemon)
 
     class RpcHandles:
       xaya = None

--- a/xayagametest/xaya.py
+++ b/xayagametest/xaya.py
@@ -1,0 +1,86 @@
+# Copyright (C) 2018 The Xaya developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+"""
+Code for running the Xaya Core daemon as component in an integration test.
+"""
+
+import jsonrpclib
+import logging
+import os
+import os.path
+import shutil
+import subprocess
+import time
+
+
+RPC_PORT = 28100
+ZMQ_PORT = 28200
+
+
+class Node ():
+  """
+  An instance of the Xaya Core daemon that is running in regtest mode and
+  used as component in an integration test of a Xaya game.
+  """
+
+  def __init__ (self, basedir, binary):
+    self.log = logging.getLogger ("xayagametest.xayanode")
+    self.datadir = os.path.join (basedir, "xayanode")
+    self.binary = binary
+
+    self.config = {
+      "rpcuser": "xayagametest",
+      "rpcpassword": "xayagametest",
+      "rpcport": RPC_PORT,
+      "zmqpubgameblocks": "tcp://127.0.0.1:%d" % ZMQ_PORT
+    }
+    self.rpcurl = ("http://%s:%s@localhost:%d"
+        % (self.config["rpcuser"], self.config["rpcpassword"],
+           self.config["rpcport"]))
+
+    self.log.info ("Creating fresh data directory for Xaya node in %s"
+                    % self.datadir)
+    shutil.rmtree (self.datadir, ignore_errors=True)
+    os.mkdir (self.datadir)
+    with open (os.path.join (self.datadir, "xaya.conf"), "wt") as f:
+      f.write ("[regtest]\n")
+      for key, value in self.config.items ():
+        f.write ("%s=%s\n" % (key, value))
+
+    self.proc = None
+
+  def start (self):
+    if self.proc is not None:
+      self.log.error ("Xaya process is already running, not starting again")
+      return
+
+    self.log.info ("Starting new Xaya process")
+    args = [self.binary]
+    args.append ("-datadir=%s" % self.datadir)
+    args.append ("-noprinttoconsole")
+    args.append ("-regtest")
+    self.proc = subprocess.Popen (args)
+    self.rpc = jsonrpclib.Server (self.rpcurl)
+
+    self.log.info ("Waiting for the JSON-RPC server to be up...")
+    while True:
+      try:
+        data = self.rpc.getnetworkinfo ()
+        self.log.info ("Daemon %s is up" % data["subversion"])
+        break
+      except:
+        time.sleep (1)
+
+  def stop (self):
+    if self.proc is None:
+      self.log.error ("No Xaya process is running cannot stop it")
+      return
+
+    self.log.info ("Stopping Xaya process")
+    self.rpc.stop ()
+
+    self.log.info ("Waiting for Xaya process to stop...")
+    self.proc.wait ()
+    self.proc = None

--- a/xayagametest/xaya.py
+++ b/xayagametest/xaya.py
@@ -15,26 +15,23 @@ import subprocess
 import time
 
 
-RPC_PORT = 28100
-ZMQ_PORT = 28200
-
-
 class Node ():
   """
   An instance of the Xaya Core daemon that is running in regtest mode and
   used as component in an integration test of a Xaya game.
   """
 
-  def __init__ (self, basedir, binary):
+  def __init__ (self, basedir, rpcPort, zmqPort, binary):
     self.log = logging.getLogger ("xayagametest.xayanode")
     self.datadir = os.path.join (basedir, "xayanode")
     self.binary = binary
 
     self.config = {
+      "listen": False,
       "rpcuser": "xayagametest",
       "rpcpassword": "xayagametest",
-      "rpcport": RPC_PORT,
-      "zmqpubgameblocks": "tcp://127.0.0.1:%d" % ZMQ_PORT
+      "rpcport": rpcPort,
+      "zmqpubgameblocks": "tcp://127.0.0.1:%d" % zmqPort
     }
     self.rpcurl = ("http://%s:%s@localhost:%d"
         % (self.config["rpcuser"], self.config["rpcpassword"],


### PR DESCRIPTION
This adds a simple integration test framework in Python (inspired by the regtest framework in Bitcoin Core but much simpler).  That way, we can test the full interaction between a real `xayad` in regtest mode and a real game daemon (`moverd` in the tests included here, but it can also be used by other games in the future).

All edge cases in the game logic should in general be tested (and easily testable) by unit tests, like those we already have for Movers.  But running real binaries connected to each other allows to verify that also all the interactions work as expected.  This is especially important for `libxayagame` itself (which is the main purpose of the Movers tests), but can also be useful for individual games to verify that their final binary works as expected in a "real" system.

This fixes #6.