### PR TITLE
Add pruning support for the Storage interface

### DIFF
--- a/xayagame/game.cpp
+++ b/xayagame/game.cpp
@@ -80,9 +80,13 @@ Game::UpdateStateForAttach (const uint256& parent, const uint256& hash,
   const GameStateData newState
       = rules->ProcessForward (oldState, blockData, undo);
 
+  const unsigned height = blockData["block"]["height"].asUInt ();
+
   storage->SetCurrentGameState (hash, newState);
-  storage->AddUndoData (hash, undo);
-  LOG (INFO) << "Current game state is for block " << hash.ToHex ();
+  storage->AddUndoData (hash, height, undo);
+  LOG (INFO)
+      << "Current game state is at height " << height
+      << " (block " << hash.ToHex () << ")";
 
   return true;
 }

--- a/xayagame/game.cpp
+++ b/xayagame/game.cpp
@@ -116,7 +116,7 @@ Game::UpdateStateForDetach (const uint256& parent, const uint256& hash,
       = rules->ProcessBackwards (newState, blockData, undo);
 
   storage->SetCurrentGameState (parent, oldState);
-  storage->RemoveUndoData (hash);
+  storage->ReleaseUndoData (hash);
   LOG (INFO)
       << "Detached " << hash.ToHex () << ", restored state for block "
       << parent.ToHex ();

--- a/xayagame/storage.cpp
+++ b/xayagame/storage.cpp
@@ -60,7 +60,7 @@ MemoryStorage::AddUndoData (const uint256& hash, const UndoData& data)
 }
 
 void
-MemoryStorage::RemoveUndoData (const uint256& hash)
+MemoryStorage::ReleaseUndoData (const uint256& hash)
 {
   undoData.erase (hash);
 }

--- a/xayagame/storage.cpp
+++ b/xayagame/storage.cpp
@@ -49,20 +49,32 @@ MemoryStorage::GetUndoData (const uint256& hash, UndoData& data) const
   if (mit == undoData.end ())
     return false;
 
-  data = mit->second;
+  data = mit->second.data;
   return true;
 }
 
 void
-MemoryStorage::AddUndoData (const uint256& hash, const UndoData& data)
+MemoryStorage::AddUndoData (const uint256& hash,
+                            const unsigned height, const UndoData& data)
 {
-  undoData.emplace (hash, data);
+  HeightAndUndoData heightAndData = {height, data};
+  undoData.emplace (hash, std::move (heightAndData));
 }
 
 void
 MemoryStorage::ReleaseUndoData (const uint256& hash)
 {
   undoData.erase (hash);
+}
+
+void
+MemoryStorage::PruneUndoData (const unsigned height)
+{
+  for (auto it = undoData.cbegin (); it != undoData.cend (); )
+    if (it->second.height <= height)
+      it = undoData.erase (it);
+    else
+      ++it;
 }
 
 } // namespace xaya

--- a/xayagame/storage.hpp
+++ b/xayagame/storage.hpp
@@ -81,7 +81,7 @@ public:
    * the given block hash.
    */
   virtual void
-  RemoveUndoData (const uint256& hash)
+  ReleaseUndoData (const uint256& hash)
   {
     /* Do nothing by default.  This function can be overridden to free space
        for no longer required data (e.g. undo data of blocks that have been
@@ -130,7 +130,7 @@ public:
 
   bool GetUndoData (const uint256& hash, UndoData& data) const override;
   void AddUndoData (const uint256& hash, const UndoData& data) override;
-  void RemoveUndoData (const uint256& hash) override;
+  void ReleaseUndoData (const uint256& hash) override;
 
 };
 

--- a/xayagame/storage_tests.cpp
+++ b/xayagame/storage_tests.cpp
@@ -85,10 +85,10 @@ TEST_F (MemoryStorageTests, UndoData)
 
   /* Removing should be ok (not crash), but otherwise no effect is guaranteed
      (in particular, not that it will actually be removed).  */
-  storage.RemoveUndoData (hash1);
+  storage.ReleaseUndoData (hash1);
   ASSERT_TRUE (storage.GetUndoData (hash2, undo));
   EXPECT_EQ (undo, undo2);
-  storage.RemoveUndoData (hash2);
+  storage.ReleaseUndoData (hash2);
 }
 
 TEST_F (MemoryStorageTests, Clear)


### PR DESCRIPTION
This extends the `Storage` interface such that undo data is stored together with the corresponding block height.  By doing so, we allow implementations to implement a new `PruneUndoData` function that removes all undo data up to a given height - which can be used to save space when blocks are confirmed many times and unlikely to be detached again.

This is a first step towards implementing #8 - namely the changes necessary to `Storage`.  It prepares the stage for the next step, namely to actually call `PruneUndoData` and `ReleaseUndoData` from the `Game` class if pruning is enabled and blocks have enough confirmations.