### PR TITLE
Batch storage-transactions when catching up

### DIFF
--- a/xayagame/Makefile.am
+++ b/xayagame/Makefile.am
@@ -20,6 +20,7 @@ libxayagame_la_SOURCES = \
   sqlitegame.cpp \
   sqlitestorage.cpp \
   storage.cpp \
+  transactionmanager.cpp \
   uint256.cpp \
   zmqsubscriber.cpp
 xayagame_HEADERS = \
@@ -32,8 +33,10 @@ xayagame_HEADERS = \
   sqlitegame.hpp \
   sqlitestorage.hpp \
   storage.hpp \
+  transactionmanager.hpp \
   uint256.hpp \
   zmqsubscriber.hpp \
+  \
   rpc-stubs/gamerpcclient.h \
   rpc-stubs/gamerpcserverstub.h \
   rpc-stubs/xayarpcclient.h \
@@ -56,6 +59,7 @@ tests_SOURCES = testutils.cpp \
   sqlitegame_tests.cpp \
   sqlitestorage_tests.cpp \
   storage_tests.cpp \
+  transactionmanager_tests.cpp \
   uint256_tests.cpp \
   zmqsubscriber_tests.cpp
 check_HEADERS = testutils.hpp storage_tests.hpp

--- a/xayagame/game.cpp
+++ b/xayagame/game.cpp
@@ -46,15 +46,15 @@ namespace
 
 /**
  * Helper class to call BeginTransaction and either CommitTransaction or
- * AbortTransaction on a storage implementation using RAII.
+ * AbortTransaction on the transaction manager using RAII.
  */
 class GameTransactionHelper
 {
 
 private:
 
-  /** The storage on which to call the functions.  */
-  StorageInterface& storage;
+  /** The manager on which to call the functions.  */
+  internal::TransactionManager& manager;
 
   /**
    * Whether the operation was successful.  If this is set to true at some
@@ -65,25 +65,18 @@ private:
 
 public:
 
-  explicit GameTransactionHelper (StorageInterface& s)
-    : storage(s)
+  explicit GameTransactionHelper (internal::TransactionManager& m)
+    : manager(m)
   {
-    VLOG (1) << "Starting storage transaction";
-    storage.BeginTransaction ();
+    manager.BeginTransaction ();
   }
 
   ~GameTransactionHelper ()
   {
     if (success)
-      {
-        VLOG (1) << "Committing storage transaction";
-        storage.CommitTransaction ();
-      }
+      manager.CommitTransaction ();
     else
-      {
-        VLOG (1) << "Aborting storage transaction";
-        storage.RollbackTransaction ();
-      }
+      manager.RollbackTransaction ();
   }
 
   void
@@ -114,7 +107,7 @@ Game::UpdateStateForAttach (const uint256& parent, const uint256& hash,
   const unsigned height = blockData["block"]["height"].asUInt ();
 
   {
-    GameTransactionHelper tx(*storage);
+    GameTransactionHelper tx(transactionManager);
 
     UndoData undo;
     const GameStateData newState
@@ -160,7 +153,7 @@ Game::UpdateStateForDetach (const uint256& parent, const uint256& hash,
   const GameStateData newState = storage->GetCurrentGameState ();
 
   {
-    GameTransactionHelper tx(*storage);
+    GameTransactionHelper tx(transactionManager);
 
     const GameStateData oldState
         = rules->ProcessBackwards (newState, blockData, undo);
@@ -393,6 +386,8 @@ Game::SetStorage (StorageInterface* s)
 
   LOG (INFO) << "Storage has been added to Game, initialising it now";
   storage->Initialise ();
+
+  transactionManager.SetStorage (*storage);
 }
 
 void
@@ -527,6 +522,7 @@ Game::SyncFromCurrentState (const Json::Value& blockchainInfo,
     {
       LOG (INFO) << "Game state matches current tip, we are up-to-date";
       state = State::UP_TO_DATE;
+      transactionManager.SetBatchSize (1);
       return;
     }
 
@@ -543,6 +539,8 @@ Game::SyncFromCurrentState (const Json::Value& blockchainInfo,
       << ", leading to block " << upd["toblock"].asString ();
 
   state = State::CATCHING_UP;
+  transactionManager.SetBatchSize (transactionBatchSize);
+
   CHECK (targetBlockHash.FromHex (upd["toblock"].asString ()));
   reqToken = upd["reqtoken"].asString ();
 }
@@ -594,7 +592,7 @@ Game::ReinitialiseState ()
     << "The game's genesis block hash and height do not match";
   storage->Clear ();
   {
-    GameTransactionHelper tx(*storage);
+    GameTransactionHelper tx(transactionManager);
     storage->SetCurrentGameState (genesisHash, genesisData);
     tx.SetSuccess ();
   }

--- a/xayagame/game.hpp
+++ b/xayagame/game.hpp
@@ -9,6 +9,7 @@
 #include "mainloop.hpp"
 #include "pruningqueue.hpp"
 #include "storage.hpp"
+#include "transactionmanager.hpp"
 #include "uint256.hpp"
 #include "zmqsubscriber.hpp"
 
@@ -120,6 +121,15 @@ private:
   /** The game rules in use.  */
   GameLogic* rules = nullptr;
 
+  /**
+   * Desired size for batches of atomic transactions while the game is
+   * catching up.  <= 1 means no batching even in these situations.
+   */
+  unsigned transactionBatchSize = 1000;
+
+  /** The manager for batched atomic transactions.  */
+  internal::TransactionManager transactionManager;
+
   /** The main loop.  */
   internal::MainLoop mainLoop;
 
@@ -225,6 +235,10 @@ public:
   /**
    * Sets the storage interface to use.  This must be called before starting
    * the main loop, and may not be called while it is running.
+   *
+   * Important:  The storage instance associated to the Game here needs to
+   * remain valid until after the Game instance has been destructed!  This is
+   * so that potentially batched transactions can still be flushed.
    */
   void SetStorage (StorageInterface* s);
 

--- a/xayagame/game_tests.cpp
+++ b/xayagame/game_tests.cpp
@@ -310,12 +310,6 @@ public:
     return res;
   }
 
-  /* Mock the transaction methods.  They are not relevant for most tests, but
-     we want to test against expectations in specific tests.  */
-  MOCK_METHOD0 (BeginTransaction, void ());
-  MOCK_METHOD0 (CommitTransaction, void ());
-  MOCK_METHOD0 (RollbackTransaction, void ());
-
 };
 
 /* ************************************************************************** */
@@ -1041,6 +1035,12 @@ public:
     MemoryStorage::SetCurrentGameState (hash, data);
   }
 
+  /* Mock the transaction methods.  They are not relevant for most tests, but
+     we want to test against expectations in specific tests.  */
+  MOCK_METHOD0 (BeginTransaction, void ());
+  MOCK_METHOD0 (CommitTransaction, void ());
+  MOCK_METHOD0 (RollbackTransaction, void ());
+
 };
 
 class GameLogicTransactionsTests : public SyncingTests
@@ -1067,9 +1067,9 @@ TEST_F (GameLogicTransactionsTests, WorkingFine)
 {
   {
     InSequence dummy;
-    EXPECT_CALL (rules, BeginTransaction ()).Times (1);
-    EXPECT_CALL (rules, CommitTransaction ()).Times (1);
-    EXPECT_CALL (rules, RollbackTransaction ()).Times (0);
+    EXPECT_CALL (fallibleStorage, BeginTransaction ()).Times (1);
+    EXPECT_CALL (fallibleStorage, CommitTransaction ()).Times (1);
+    EXPECT_CALL (fallibleStorage, RollbackTransaction ()).Times (0);
   }
 
   AttachBlock (g, BlockHash (11), Moves ("a0b1"));
@@ -1081,9 +1081,9 @@ TEST_F (GameLogicTransactionsTests, WithFailure)
 {
   {
     InSequence dummy;
-    EXPECT_CALL (rules, BeginTransaction ()).Times (1);
-    EXPECT_CALL (rules, CommitTransaction ()).Times (0);
-    EXPECT_CALL (rules, RollbackTransaction ()).Times (1);
+    EXPECT_CALL (fallibleStorage, BeginTransaction ()).Times (1);
+    EXPECT_CALL (fallibleStorage, CommitTransaction ()).Times (0);
+    EXPECT_CALL (fallibleStorage, RollbackTransaction ()).Times (1);
   }
 
   fallibleStorage.SetShouldFail (true);

--- a/xayagame/gamelogic.cpp
+++ b/xayagame/gamelogic.cpp
@@ -48,24 +48,6 @@ GameLogic::GameStateToJson (const GameStateData& state)
   return state;
 }
 
-void
-GameLogic::BeginTransaction ()
-{
-  /* Nothing is done in the default implementation.  */
-}
-
-void
-GameLogic::CommitTransaction ()
-{
-  /* Nothing is done in the default implementation.  */
-}
-
-void
-GameLogic::RollbackTransaction ()
-{
-  /* Nothing is done in the default implementation.  */
-}
-
 GameStateData
 CachingGame::ProcessForward (const GameStateData& oldState,
                              const Json::Value& blockData,

--- a/xayagame/gamelogic.hpp
+++ b/xayagame/gamelogic.hpp
@@ -43,6 +43,13 @@ std::string ChainToString (Chain c);
  * some handle (e.g. the block hash) as GameStateData.  The ProcessForward
  * and ProcessBackwards functions are then responsible for updating the
  * external data structure accordingly.
+ *
+ * To make sure that changes to the externally-kept game state are consistent
+ * with the state that libxayagame keeps, games should leverage the transactions
+ * mechanism present in StorageInterface.  For instance, they can define a
+ * custom storage implementation that keeps both the external game-state data
+ * and the libxayagame-stored data, and allows atomic transactions spanning
+ * both of them.
  */
 class GameLogic
 {
@@ -107,34 +114,6 @@ public:
   virtual GameStateData ProcessBackwards (const GameStateData& newState,
                                           const Json::Value& blockData,
                                           const UndoData& undoData) = 0;
-
-  /**
-   * Tells the game that a change to the game state is about to be made
-   * (because a new block is being attached or detached).
-   *
-   * Transactions will not be nested, i.e. this function is only called when
-   * the last transaction has either been committed or rolled back.
-   *
-   * By default, this function does nothing.  If the game logic keeps track
-   * of state in an external data structure, it can use this function together
-   * with CommitTransaction and RollbackTransaction to ensure consistency
-   * between the state it keeps and the state that libxayagame keeps in its
-   * storage.
-   */
-  virtual void BeginTransaction ();
-
-  /**
-   * Tells the game that all state changes related to the previously started
-   * transaction have been completed successfully.
-   */
-  virtual void CommitTransaction ();
-
-  /**
-   * Tells the game that there was an error during the state changes for the
-   * previously started transaction, and all changes made to internal states
-   * since then should be reverted if possible.
-   */
-  virtual void RollbackTransaction ();
 
   /**
    * Converts an encoded game state to JSON format, which can be returned as

--- a/xayagame/sqlitegame.cpp
+++ b/xayagame/sqlitegame.cpp
@@ -38,37 +38,6 @@ private:
   SQLiteGame& game;
 
   /**
-   * Set to true when we have a currently open transaction.  This is used to
-   * verify that BeginTransaction is not called in a nested way.  (Savepoints
-   * would in theory support that, but we exclude it nevertheless.)
-   */
-  bool startedTransaction = false;
-
-  void
-  BeginTransaction ()
-  {
-    CHECK (!startedTransaction);
-    startedTransaction = true;
-    StepWithNoResult (PrepareStatement ("SAVEPOINT `xayagame-sqlitegame`"));
-  }
-
-  void
-  CommitTransaction ()
-  {
-    StepWithNoResult (PrepareStatement ("RELEASE `xayagame-sqlitegame`"));
-    CHECK (startedTransaction);
-    startedTransaction = false;
-  }
-
-  void
-  RollbackTransaction ()
-  {
-    StepWithNoResult (PrepareStatement ("ROLLBACK TO `xayagame-sqlitegame`"));
-    CHECK (startedTransaction);
-    startedTransaction = false;
-  }
-
-  /**
    * Verifies that the database state corresponds to the given "current state"
    * from libxayagame.  The function also makes sure to call InitialiseState
    * if the passed-in state is the initial-keyword and the database's state
@@ -366,24 +335,6 @@ SQLiteGame::ProcessBackwards (const GameStateData& newState,
   changeset.Apply (database->GetDatabase ());
 
   return BLOCKHASH_STATE + blockData["block"]["parent"].asString ();
-}
-
-void
-SQLiteGame::BeginTransaction ()
-{
-  database->BeginTransaction ();
-}
-
-void
-SQLiteGame::CommitTransaction ()
-{
-  database->CommitTransaction ();
-}
-
-void
-SQLiteGame::RollbackTransaction ()
-{
-  database->RollbackTransaction ();
 }
 
 Json::Value

--- a/xayagame/sqlitegame.hpp
+++ b/xayagame/sqlitegame.hpp
@@ -127,10 +127,6 @@ public:
                                   const Json::Value& blockData,
                                   const UndoData& undo) override;
 
-  void BeginTransaction () override;
-  void CommitTransaction () override;
-  void RollbackTransaction () override;
-
   Json::Value GameStateToJson (const GameStateData& state) override;
 
 };

--- a/xayagame/sqlitegame_tests.cpp
+++ b/xayagame/sqlitegame_tests.cpp
@@ -240,7 +240,9 @@ InitialiseState (Game& game, ChatGame& rules)
   uint256 hash;
   ASSERT_TRUE (hash.FromHex (hashHex));
 
+  rules.GetStorage ()->BeginTransaction ();
   rules.GetStorage ()->SetCurrentGameState (hash, state);
+  rules.GetStorage ()->CommitTransaction ();
 }
 
 /**
@@ -374,7 +376,9 @@ TEST_F (GameStateStringTests, BlockHash)
 
 TEST_F (GameStateStringTests, InitialWrongHash)
 {
+  rules.GetStorage ()->BeginTransaction ();
   rules.GetStorage ()->SetCurrentGameState (BlockHash (42), "");
+  rules.GetStorage ()->CommitTransaction ();
   EXPECT_DEATH (
       rules.GameStateToJson ("initial"),
       "does not match the game's initial block");

--- a/xayagame/sqlitestorage.hpp
+++ b/xayagame/sqlitestorage.hpp
@@ -48,6 +48,13 @@ private:
   mutable std::map<std::string, sqlite3_stmt*> preparedStatements;
 
   /**
+   * Set to true when we have a currently open transaction.  This is used to
+   * verify that BeginTransaction is not called in a nested way.  (Savepoints
+   * would in theory support that, but we exclude it nevertheless.)
+   */
+  bool startedTransaction = false;
+
+  /**
    * Opens the database at filename into the handle.  It is an error if the
    * handle is already opened.
    */
@@ -124,6 +131,10 @@ public:
                     unsigned height, const UndoData& data) override;
   void ReleaseUndoData (const uint256& hash) override;
   void PruneUndoData (unsigned height) override;
+
+  void BeginTransaction () override;
+  void CommitTransaction () override;
+  void RollbackTransaction () override;
 
 };
 

--- a/xayagame/sqlitestorage_tests.cpp
+++ b/xayagame/sqlitestorage_tests.cpp
@@ -35,6 +35,8 @@ INSTANTIATE_TYPED_TEST_CASE_P (SQLite, BasicStorageTests,
                                InMemorySQLiteStorage);
 INSTANTIATE_TYPED_TEST_CASE_P (SQLite, PruningStorageTests,
                                InMemorySQLiteStorage);
+INSTANTIATE_TYPED_TEST_CASE_P (SQLite, TransactingStorageTests,
+                               InMemorySQLiteStorage);
 
 /**
  * Tests for SQLiteStorage with a temporary on-disk database file (instead of
@@ -80,8 +82,10 @@ TEST_F (PersistentSQLiteStorageTests, PersistsData)
     SQLiteStorage storage(filename);
     storage.Initialise ();
 
+    storage.BeginTransaction ();
     storage.SetCurrentGameState (hash, state);
     storage.AddUndoData (hash, 42, undo);
+    storage.CommitTransaction ();
   }
 
   {
@@ -104,8 +108,10 @@ TEST_F (PersistentSQLiteStorageTests, ClearWithOnDiskFile)
   SQLiteStorage storage(filename);
   storage.Initialise ();
 
+  storage.BeginTransaction ();
   storage.SetCurrentGameState (hash, state);
   storage.AddUndoData (hash, 42, undo);
+  storage.CommitTransaction ();
 
   uint256 h;
   UndoData val;

--- a/xayagame/storage.cpp
+++ b/xayagame/storage.cpp
@@ -16,6 +16,24 @@ StorageInterface::Initialise ()
 }
 
 void
+StorageInterface::BeginTransaction ()
+{
+  /* Nothing is done in the default implementation.  */
+}
+
+void
+StorageInterface::CommitTransaction ()
+{
+  /* Nothing is done in the default implementation.  */
+}
+
+void
+StorageInterface::RollbackTransaction ()
+{
+  /* Nothing is done in the default implementation.  */
+}
+
+void
 MemoryStorage::Clear ()
 {
   hasState = false;

--- a/xayagame/storage.hpp
+++ b/xayagame/storage.hpp
@@ -111,6 +111,32 @@ public:
        future (because the blocks involved have many confirmations).  */
   }
 
+  /**
+   * Tells the storage that a change to the state is about to be made
+   * (because a new block is being attached or detached).
+   *
+   * Transactions will not be nested, i.e. this function is only called when
+   * the last transaction has either been committed or rolled back.
+   *
+   * By default, this function does nothing.  If the storage implementation
+   * supports a transaction mechanism to keep multiple changes consistent,
+   * it can override the method to start such a transaction.
+   */
+  virtual void BeginTransaction ();
+
+  /**
+   * Tells the storage that all state changes related to the previously started
+   * transaction have been completed successfully.
+   */
+  virtual void CommitTransaction ();
+
+  /**
+   * Tells the storage that there was an error during the state changes for the
+   * previously started transaction, and all changes made since then should
+   * be reverted if possible.
+   */
+  virtual void RollbackTransaction ();
+
 };
 
 /**

--- a/xayagame/transactionmanager.cpp
+++ b/xayagame/transactionmanager.cpp
@@ -1,0 +1,119 @@
+// Copyright (C) 2018 The Xaya developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "transactionmanager.hpp"
+
+#include <glog/logging.h>
+
+namespace xaya
+{
+namespace internal
+{
+
+TransactionManager::~TransactionManager ()
+{
+  /* The code in Game should be written to make sure that all transactions
+     are either committed or aborted using RAII, so that it should never
+     happen that a transaction stays "in progress" until the manager instance
+     itself is destroyed (together with Game).  */
+  CHECK (!inTransaction);
+
+  Flush ();
+}
+
+void
+TransactionManager::Flush ()
+{
+  CHECK (!inTransaction);
+
+  LOG (INFO)
+      << "Committing " << batchedCommits
+      << " batched transactions to the underlying storage instance";
+
+  if (batchedCommits > 0)
+    {
+      if (storage != nullptr)
+        storage->CommitTransaction ();
+      batchedCommits = 0;
+    }
+}
+
+void
+TransactionManager::SetStorage (StorageInterface& s)
+{
+  Flush ();
+  storage = &s;
+}
+
+void
+TransactionManager::SetBatchSize (const unsigned sz)
+{
+  CHECK (sz >= 1);
+  batchSize = sz;
+  LOG (INFO) << "Set batch size for TransactionManager to " << batchSize;
+
+  if (batchedCommits >= batchSize)
+    {
+      LOG (INFO)
+          << "We have " << batchedCommits
+          << " batched transactions, trying to commit the batch now";
+      if (inTransaction)
+        LOG (INFO) << "There is a pending transaction, not committing";
+      else
+        Flush ();
+    }
+}
+
+void
+TransactionManager::BeginTransaction ()
+{
+  CHECK (storage != nullptr);
+
+  CHECK (!inTransaction);
+  inTransaction = true;
+
+  VLOG (1) << "Starting new transaction on the TransactionManager";
+
+  if (batchedCommits == 0)
+    {
+      LOG (INFO) << "No pending commits, starting new underlying transaction";
+      storage->BeginTransaction ();
+    }
+}
+
+void
+TransactionManager::CommitTransaction ()
+{
+  CHECK (storage != nullptr);
+
+  CHECK (inTransaction);
+  inTransaction = false;
+
+  ++batchedCommits;
+  VLOG (1)
+      << "Committing current transaction on TransactionManager, now we have "
+      << batchedCommits << " batched transactions";
+
+  if (batchedCommits >= batchSize)
+    Flush ();
+}
+
+void
+TransactionManager::RollbackTransaction ()
+{
+  CHECK (storage != nullptr);
+
+  CHECK (inTransaction);
+  inTransaction = false;
+
+  LOG (INFO)
+      << "Rolling back current and " << batchedCommits
+      << " batched transactions";
+
+  storage->RollbackTransaction ();
+  batchedCommits = 0;
+}
+
+} // namespace internal
+} // namespace xaya

--- a/xayagame/transactionmanager.hpp
+++ b/xayagame/transactionmanager.hpp
@@ -1,0 +1,107 @@
+// Copyright (C) 2018 The Xaya developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef XAYAGAME_TRANSACTIONMANAGER_HPP
+#define XAYAGAME_TRANSACTIONMANAGER_HPP
+
+/* This file is an implementation detail of Game and should not be
+   used directly by external code!  */
+
+#include "storage.hpp"
+
+namespace xaya
+{
+namespace internal
+{
+
+/**
+ * Utility class that takes care of (potentially) batching together
+ * atomic transactions while the game is catching up.  It has an underlying
+ * storage interface, on which transaction handling is done.  But it also
+ * allows to enable batching, in which case a started transaction will not
+ * immediately be committed, but only after the manager has been requested
+ * to do a certain number of transactions itself.
+ */
+class TransactionManager
+{
+
+private:
+
+  /** The underlying storage instance.  */
+  StorageInterface* storage = nullptr;
+
+  /** The desired batch size.  <= 1 means batching is disabled.  */
+  unsigned batchSize = 1;
+
+  /**
+   * Number of already "committed" but batched transactions.  If this is
+   * nonzero, then a transaction on the underlying storage instance has
+   * been started but not yet finished.
+   */
+  unsigned batchedCommits = 0;
+
+  /**
+   * Whether or not a transaction has currently been started *on the manager*.
+   * This is independent of batching.
+   */
+  bool inTransaction = false;
+
+  /**
+   * Flushes the current batch of transactions to the underlying storage.
+   * This must not be called if a transaction is in progress.
+   */
+  void Flush ();
+
+public:
+
+  TransactionManager () = default;
+  ~TransactionManager ();
+
+  TransactionManager (const TransactionManager&) = delete;
+  void operator= (const TransactionManager&) = delete;
+
+  /**
+   * Sets the underlying storage instance.  This must not be called while
+   * a transaction on the manager is ongoing.  Committed but batched
+   * transactions will be committed on the current instance before updating
+   * the instance reference.
+   */
+  void SetStorage (StorageInterface& s);
+
+  /**
+   * Changes the desired batch size.  The value must be at least one.  Setting
+   * it to one disables batching, a larger number enables batching.  If the
+   * number is set to something lower than the number of currently batched
+   * transactions, then the batch may be committed right away.
+   */
+  void SetBatchSize (unsigned sz);
+
+  /**
+   * Starts a new transaction on the manager.  Depending on batching
+   * behaviour, this may or may not start a transaction on the underlying
+   * storage itself.
+   */
+  void BeginTransaction ();
+
+  /**
+   * Commits the currently ongoing transaction on the manager.  This may
+   * commit a transaction on the underlying storage, or may just mark the
+   * current one as "committed" in the batch and wait for more transactions
+   * before committing the entire batch.
+   */
+  void CommitTransaction ();
+
+  /**
+   * Aborts and rolls back the current transaction in the manager.  This has the
+   * effect of rolling back the entire current batch in case more transactions
+   * have been batched.
+   */
+  void RollbackTransaction ();
+
+};
+
+} // namespace internal
+} // namespace xaya
+
+#endif // XAYAGAME_TRANSACTIONMANAGER_HPP

--- a/xayagame/transactionmanager_tests.cpp
+++ b/xayagame/transactionmanager_tests.cpp
@@ -1,0 +1,227 @@
+// Copyright (C) 2018 The Xaya developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "transactionmanager.hpp"
+
+#include "storage.hpp"
+
+#include "testutils.hpp"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <glog/logging.h>
+
+namespace xaya
+{
+namespace internal
+{
+namespace
+{
+
+using testing::InSequence;
+
+/**
+ * Simple subclass of MemoryStorage that mocks the transaction methods
+ * so we can verify calls to them using gmock.
+ */
+class MockedStorage : public MemoryStorage
+{
+
+public:
+
+  MockedStorage ()
+  {
+    /* By default, expect no calls to be made.  The calls that we expect
+       should explicitly be specified in the individual tests.  */
+    EXPECT_CALL (*this, BeginTransaction ()).Times (0);
+    EXPECT_CALL (*this, CommitTransaction ()).Times (0);
+    EXPECT_CALL (*this, RollbackTransaction ()).Times (0);
+  }
+
+  MOCK_METHOD0 (BeginTransaction, void ());
+  MOCK_METHOD0 (CommitTransaction, void ());
+  MOCK_METHOD0 (RollbackTransaction, void ());
+
+};
+
+class TransactionManagerTests : public testing::Test
+{
+
+protected:
+
+  TransactionManager tm;
+  MockedStorage storage;
+
+  TransactionManagerTests ()
+  {
+    /* For ease-of-use in most tests, we already set up the transaction manager
+       and storage.  Some tests (e.g. for the destructor) will need a
+       different setting, but they can just customly instantiate another
+       TransactionManager.  */
+    tm.SetStorage (storage);
+  }
+
+};
+
+TEST_F (TransactionManagerTests, NoBatching)
+{
+  {
+    InSequence dummy;
+
+    EXPECT_CALL (storage, BeginTransaction ());
+    EXPECT_CALL (storage, CommitTransaction ());
+
+    EXPECT_CALL (storage, BeginTransaction ());
+    EXPECT_CALL (storage, RollbackTransaction ());
+
+    EXPECT_CALL (storage, BeginTransaction ());
+    EXPECT_CALL (storage, CommitTransaction ());
+  }
+
+  tm.SetBatchSize (1);
+
+  tm.BeginTransaction ();
+  tm.CommitTransaction ();
+
+  tm.BeginTransaction ();
+  tm.RollbackTransaction ();
+
+  tm.BeginTransaction ();
+  tm.CommitTransaction ();
+}
+
+TEST_F (TransactionManagerTests, BasicBatching)
+{
+  {
+    InSequence dummy;
+    EXPECT_CALL (storage, BeginTransaction ());
+    EXPECT_CALL (storage, CommitTransaction ());
+  }
+
+  tm.SetBatchSize (2);
+
+  tm.BeginTransaction ();
+  tm.CommitTransaction ();
+
+  tm.BeginTransaction ();
+  tm.CommitTransaction ();
+}
+
+TEST_F (TransactionManagerTests, Rollback)
+{
+  {
+    InSequence dummy;
+    EXPECT_CALL (storage, BeginTransaction ());
+    EXPECT_CALL (storage, RollbackTransaction ());
+  }
+
+  tm.SetBatchSize (10);
+
+  tm.BeginTransaction ();
+  tm.CommitTransaction ();
+
+  tm.BeginTransaction ();
+  tm.RollbackTransaction ();
+}
+
+TEST_F (TransactionManagerTests, DestructorTriggersFlush)
+{
+  {
+    InSequence dummy;
+    EXPECT_CALL (storage, BeginTransaction ());
+    EXPECT_CALL (storage, CommitTransaction ());
+  }
+
+  /* We need to use a custom instance, so that it gets destructed right
+     during this test case (not only later as part of the fixture).  */
+  TransactionManager m;
+  m.SetStorage (storage);
+
+  m.SetBatchSize (10);
+
+  m.BeginTransaction ();
+  m.CommitTransaction ();
+}
+
+TEST_F (TransactionManagerTests, SetStorageFlushes)
+{
+  MockedStorage secondStorage;
+
+  {
+    InSequence dummy;
+
+    EXPECT_CALL (storage, BeginTransaction ());
+    EXPECT_CALL (storage, CommitTransaction ());
+
+    EXPECT_CALL (secondStorage, BeginTransaction ());
+    EXPECT_CALL (secondStorage, RollbackTransaction ());
+  }
+
+  tm.SetBatchSize (10);
+  tm.BeginTransaction ();
+  tm.CommitTransaction ();
+
+  /* Changing the storage should flush the previous one.  The next
+     transaction (aborted) will be on secondStorage.  */
+  tm.SetStorage (secondStorage);
+  tm.BeginTransaction ();
+  tm.RollbackTransaction ();
+}
+
+using SetBatchSizeTests = TransactionManagerTests;
+
+TEST_F (SetBatchSizeTests, TriggersFlush)
+{
+  {
+    InSequence dummy;
+
+    EXPECT_CALL (storage, BeginTransaction ());
+    EXPECT_CALL (storage, CommitTransaction ());
+
+    EXPECT_CALL (storage, BeginTransaction ());
+    EXPECT_CALL (storage, RollbackTransaction ());
+  }
+
+  tm.SetBatchSize (10);
+
+  tm.BeginTransaction ();
+  tm.CommitTransaction ();
+
+  /* Setting the batch size to one triggers a flush.  */
+  tm.SetBatchSize (1);
+
+  /* Create a rollback now, which would "cancel" the previous commit in
+     case the flush wouldn't have been performed.  */
+  tm.BeginTransaction ();
+  tm.RollbackTransaction ();
+}
+
+TEST_F (SetBatchSizeTests, NoFlushWhenTransactionInProgress)
+{
+  {
+    InSequence dummy;
+
+    EXPECT_CALL (storage, BeginTransaction ());
+    EXPECT_CALL (storage, RollbackTransaction ());
+  }
+
+  tm.SetBatchSize (10);
+
+  tm.BeginTransaction ();
+  tm.CommitTransaction ();
+  tm.BeginTransaction ();
+
+  /* Setting the batch size to one will not trigger a flush, since
+     we have a started transaction as well.  */
+  tm.SetBatchSize (1);
+
+  /* This rollback will cancel also the (not-yet-flushed) previous commit,
+     so that no CommitTransaction() should be called at all.  */
+  tm.RollbackTransaction ();
+}
+
+} // anonymous namespace
+} // namespace internal
+} // namespace xaya


### PR DESCRIPTION
While the game is catching up, batch the "atomic transactions" done with the storage (i.e. not one every block but one every 1,000 blocks).  This solves the issue described in #16, and makes Mover sync almost as fast with an on-disk SQLite file as with a database in memory.

The change also includes a refactoring commit that moves the transaction mechanism from `GameLogic` to `StorageInterface`, where it belongs logically.  This allows us to take advantage of atomic transactions and the speed-up for SQLite databases directly in `SQLiteStorage`, rather than only for `SQLiteGame`'s.  Games with special external state can still use it as well, by having their own storage subclass that keeps both the `libxayagame`-related data and the game's external state data.