### PR TITLE
Compile flags needed for cross-compilation

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -14,6 +14,13 @@ AX_CXX_COMPILE_STDCXX([14], [noext])
 AX_CHECK_COMPILE_FLAG([-Wall], [CXXFLAGS+=" -Wall"])
 AX_CHECK_COMPILE_FLAG([-Werror], [CXXFLAGS+=" -Werror"])
 AX_CHECK_COMPILE_FLAG([-pedantic], [CXXFLAGS+=" -pedantic"])
+AX_CHECK_COMPILE_FLAG([-Wno-deprecated], [CXXFLAGS+=" -Wno-deprecated"])
+
+# Windows defines ERROR, which requires us to tell glog to not define
+# it as abbreviated log severity (LOG(ERROR) still works, though, and
+# that is all that we actually use in the code).
+# See https://hpc.nih.gov/development/glog.html.
+CXXFLAGS+=" -DGLOG_NO_ABBREVIATED_SEVERITIES"
 
 PKG_CHECK_MODULES([JSONCPP], [jsoncpp])
 PKG_CHECK_MODULES([JSONRPCCLIENT], [libjsonrpccpp-client])


### PR DESCRIPTION
This adds some flags to `CXXFLAGS` that are needed for cross-compilation on Windows.  In particular, `-DGLOG_NO_ABBREVIATED_SEVERITIES` is [needed on Windows](https://hpc.nih.gov/development/glog.html) and `-Wno-deprecated` is needed since the Windows cross-compile warns (and thus fails with `-Werror`) about deprecation in the protocol buffer source file for mover.