### PR TITLE
Add "waitforchange" functionality to Game and the default RPC server

### DIFF
--- a/mover/gametest/Makefile.am
+++ b/mover/gametest/Makefile.am
@@ -12,7 +12,8 @@ REGTESTS = \
   persistence-sqlite.py \
   pruning.py \
   reorg.py \
-  stopped_xayad.py
+  stopped_xayad.py \
+  waitforchange.py
 
 # Additional tests which are not run as part of "make check" but can be
 # run manually.  They are resource and time consuming, so that running them

--- a/mover/gametest/waitforchange.py
+++ b/mover/gametest/waitforchange.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python
+# Copyright (C) 2018 The Xaya developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+from mover import MoverTest
+
+"""
+Tests the waitforchange RPC method behaviour.
+"""
+
+import threading
+import time
+
+
+def sleepSome ():
+  """
+  Sleeps a small amount of time to make it probable that some work in another
+  thread has been done.
+  """
+
+  time.sleep (0.1)
+
+
+class ForChangeWaiter (threading.Thread):
+  """
+  Thread subclass that calls the waitforchange RPC method and just blocks
+  until it receives the result.
+  """
+
+  def __init__ (self, node):
+    super (ForChangeWaiter, self).__init__ ()
+    self.node = node
+    self.result = None
+    self.start ()
+
+  def run (self):
+    rpc = self.node.createRpc ()
+    self.result = rpc.waitforchange ()
+
+  def shouldBeRunning (self):
+    sleepSome ()
+    assert self.is_alive ()
+
+  def shouldBeDone (self, expected):
+    sleepSome ()
+    assert not self.is_alive ()
+    self.join ()
+    assert self.result == expected
+
+
+class WaitForChangeTest (MoverTest):
+
+  def run (self):
+    self.test_attach ()
+    self.test_detach ()
+    self.test_stopped ()
+
+    # Since the initial game state on regtest is associated with the genesis
+    # block already, we cannot test situations where either waitforchange is
+    # signaled because of the initial state or where there is not yet a current
+    # best block and null is returned from the RPC.
+
+  def test_attach (self):
+    self.log.info ("Testing block attaches...")
+
+    waiter = ForChangeWaiter (self.gamenode)
+    waiter.shouldBeRunning ()
+
+    self.generate (1)
+    waiter.shouldBeDone (self.rpc.xaya.getbestblockhash ())
+
+  def test_detach (self):
+    self.log.info ("Testing block detaches...")
+
+    self.generate (1)
+    blk = self.rpc.xaya.getbestblockhash ()
+
+    waiter = ForChangeWaiter (self.gamenode)
+    waiter.shouldBeRunning ()
+
+    self.rpc.xaya.invalidateblock (blk)
+    waiter.shouldBeDone (self.rpc.xaya.getbestblockhash ())
+
+  def test_stopped (self):
+    self.log.info ("Testing stopping the daemon while a waiter is active...")
+
+    waiter = ForChangeWaiter (self.gamenode)
+    waiter.shouldBeRunning ()
+
+    self.stopGameDaemon ()
+    waiter.shouldBeDone (self.rpc.xaya.getbestblockhash ())
+    self.startGameDaemon ()
+
+
+if __name__ == "__main__":
+  WaitForChangeTest ().main ()

--- a/xayagame/gamerpcserver.cpp
+++ b/xayagame/gamerpcserver.cpp
@@ -23,4 +23,20 @@ GameRpcServer::getcurrentstate ()
   return game.GetCurrentJsonState ();
 }
 
+Json::Value
+GameRpcServer::waitforchange ()
+{
+  LOG (INFO) << "RPC method called: waitforchange";
+
+  uint256 block;
+  game.WaitForChange (&block);
+
+  /* If there is no best block so far, return JSON null.  */
+  if (block.IsNull ())
+    return Json::Value ();
+
+  /* Otherwise, return the block hash.  */
+  return block.ToHex ();
+}
+
 } // namespace xaya

--- a/xayagame/gamerpcserver.hpp
+++ b/xayagame/gamerpcserver.hpp
@@ -43,6 +43,8 @@ public:
 
   virtual Json::Value getcurrentstate () override;
 
+  virtual Json::Value waitforchange () override;
+
 };
 
 } // namespace xaya

--- a/xayagame/mainloop_tests.cpp
+++ b/xayagame/mainloop_tests.cpp
@@ -4,9 +4,10 @@
 
 #include "mainloop.hpp"
 
+#include "testutils.hpp"
+
 #include <gtest/gtest.h>
 
-#include <chrono>
 #include <memory>
 #include <thread>
 
@@ -39,16 +40,6 @@ protected:
         EXPECT_FALSE (flag);
         flag = true;
       };
-  }
-
-  /**
-   * Sleep for "some time" to give the main loop thread time to run and simulate
-   * some delay in a real application.
-   */
-  static void
-  SleepSome ()
-  {
-    std::this_thread::sleep_for (std::chrono::milliseconds (10));
   }
 
   /**

--- a/xayagame/rpc-stubs/game.json
+++ b/xayagame/rpc-stubs/game.json
@@ -7,5 +7,10 @@
     "name": "getcurrentstate",
     "params": {},
     "returns": {}
+  },
+  {
+    "name": "waitforchange",
+    "params": {},
+    "returns": {}
   }
 ]

--- a/xayagame/testutils.cpp
+++ b/xayagame/testutils.cpp
@@ -6,7 +6,9 @@
 
 #include <glog/logging.h>
 
+#include <chrono>
 #include <cstdio>
+#include <thread>
 
 namespace xaya
 {
@@ -24,6 +26,12 @@ BlockHash (unsigned num)
   uint256 res;
   CHECK (res.FromHex (hex));
   return res;
+}
+
+void
+SleepSome ()
+{
+  std::this_thread::sleep_for (std::chrono::milliseconds (10));
 }
 
 void

--- a/xayagame/testutils.hpp
+++ b/xayagame/testutils.hpp
@@ -30,6 +30,13 @@ namespace xaya
 uint256 BlockHash (unsigned num);
 
 /**
+ * Sleep for "some time" to give other threads time to run and simulate
+ * some delay in a real application.  This is a hack, but it works well for
+ * some test situations we need.
+ */
+void SleepSome ();
+
+/**
  * Memory storage instance that has mocks for verifying the transaction
  * methods that are called.
  */

--- a/xayagame/uint256.cpp
+++ b/xayagame/uint256.cpp
@@ -79,4 +79,17 @@ uint256::FromBlob (const unsigned char* blob)
   std::copy (blob, blob + NUM_BYTES, data.data ());
 }
 
+bool
+uint256::IsNull () const
+{
+  return std::all_of (data.begin (), data.end (),
+                      [] (const Array::value_type val) { return val == 0; });
+}
+
+void
+uint256::SetNull ()
+{
+  std::fill (data.begin (), data.end (), 0);
+}
+
 } // namespace xaya

--- a/xayagame/uint256.hpp
+++ b/xayagame/uint256.hpp
@@ -67,6 +67,17 @@ public:
    */
   void FromBlob (const unsigned char* blob);
 
+  /**
+   * Checks if this number is all-zeros, which is used as "null" value.
+   */
+  bool IsNull () const;
+
+  /**
+   * Sets the value to all-zeros, corresponding to a "null" value (since this
+   * is a hash that will never occur in practice).
+   */
+  void SetNull ();
+
   friend bool
   operator== (const uint256& a, const uint256& b)
   {

--- a/xayagame/uint256_tests.cpp
+++ b/xayagame/uint256_tests.cpp
@@ -80,5 +80,28 @@ TEST (Uint256Tests, FromBlob)
   EXPECT_TRUE (obj == copy);
 }
 
+TEST (Uint256Tests, IsNull)
+{
+  uint256 obj;
+  ASSERT_TRUE (obj.FromHex (std::string (64, '0')));
+  EXPECT_TRUE (obj.IsNull ());
+
+  ASSERT_TRUE (obj.FromHex ("01" + std::string (62, '0')));
+  EXPECT_FALSE (obj.IsNull ());
+  ASSERT_TRUE (obj.FromHex (std::string (62, '0') + "01"));
+  EXPECT_FALSE (obj.IsNull ());
+}
+
+TEST (Uint256Tests, SetNull)
+{
+  uint256 obj;
+  ASSERT_TRUE (obj.FromHex (std::string (64, '8')));
+  EXPECT_FALSE (obj.IsNull ());
+
+  obj.SetNull ();
+  EXPECT_TRUE (obj.IsNull ());
+  EXPECT_EQ (obj.ToHex (), std::string (64, '0'));
+}
+
 } // anonymous namespace
 } // namespace xaya

--- a/xayagametest/game.py
+++ b/xayagametest/game.py
@@ -57,7 +57,7 @@ class Node ():
     envVars["GLOG_log_dir"] = self.datadir
     self.proc = subprocess.Popen (args, env=envVars)
 
-    self.rpc = jsonrpclib.Server ("http://localhost:%d" % self.port)
+    self.rpc = self.createRpc ()
 
     self.log.info ("Waiting for the JSON-RPC server to be up...")
     while True:
@@ -79,6 +79,15 @@ class Node ():
     self.log.info ("Waiting for game process to stop...")
     self.proc.wait ()
     self.proc = None
+
+  def createRpc (self):
+    """
+    Returns a freshly created JSON-RPC connection for this node.  This can
+    be used if multiple threads need to send RPCs in parallel.
+    """
+
+    return jsonrpclib.Server ("http://localhost:%d" % self.port)
+
 
   def logMatches (self, expr):
     """


### PR DESCRIPTION
This adds a new `WaitForChange` method to the `Game` class and an associated `waitforchange` RPC method for the default game RPC server.  The method blocks the caller until the current game state has changed, and then returns the new state's associated block hash.

With this functionality, clients like front-ends can implement long polling to update their state in sync with the backend game state.

This implements #27.