### PR TITLE
Expose some functionality useful for custom state extraction RPCs

### DIFF
--- a/xayagame/game.cpp
+++ b/xayagame/game.cpp
@@ -415,7 +415,9 @@ Game::DetectZmqEndpoint ()
 }
 
 Json::Value
-Game::GetCurrentJsonState () const
+Game::GetCustomStateData (
+    const std::string& jsonField,
+    const std::function<Json::Value (const GameStateData&)>& cb) const
 {
   std::unique_lock<std::mutex> lock(mut);
 
@@ -430,10 +432,20 @@ Game::GetCurrentJsonState () const
       res["blockhash"] = hash.ToHex ();
 
       const GameStateData gameState = storage->GetCurrentGameState ();
-      res["gamestate"] = rules->GameStateToJson (gameState);
+      res[jsonField] = cb (gameState);
     }
 
   return res;
+}
+
+Json::Value
+Game::GetCurrentJsonState () const
+{
+  return GetCustomStateData ("gamestate",
+      [this] (const GameStateData& state)
+        {
+          return rules->GameStateToJson (state);
+        });
 }
 
 void

--- a/xayagame/game.hpp
+++ b/xayagame/game.hpp
@@ -19,6 +19,7 @@
 #include <jsonrpccpp/client.h>
 
 #include <condition_variable>
+#include <functional>
 #include <memory>
 #include <mutex>
 #include <string>
@@ -297,6 +298,21 @@ public:
   {
     mainLoop.Stop ();
   }
+
+  /**
+   * Returns a JSON object that contains information about the current
+   * syncing state, some meta information (game ID, chain) and custom
+   * information extracted by a callback function from the current
+   * game state.  That data is placed at a custom field in the returned
+   * JSON object.
+   *
+   * This function can be used to implement custom "getter" RPC methods
+   * that do not need to return the full game state but just some part
+   * of it that is interesting at the moment.
+   */
+  Json::Value GetCustomStateData (
+      const std::string& jsonField,
+      const std::function<Json::Value (const GameStateData&)>& cb) const;
 
   /**
    * Returns a JSON object that contains the current game state as well as

--- a/xayagame/sqlitegame.cpp
+++ b/xayagame/sqlitegame.cpp
@@ -161,6 +161,12 @@ SQLiteGame::SetupSchema (sqlite3* db)
      is done in Storage::SetupSchema already before calling here.  */
 }
 
+sqlite3_stmt*
+SQLiteGame::PrepareStatement (const std::string& sql) const
+{
+  return database->PrepareStatement (sql);
+}
+
 StorageInterface*
 SQLiteGame::GetStorage ()
 {

--- a/xayagame/sqlitegame.cpp
+++ b/xayagame/sqlitegame.cpp
@@ -344,4 +344,16 @@ SQLiteGame::GameStateToJson (const GameStateData& state)
   return GetStateAsJson (database->GetDatabase ());
 }
 
+Json::Value
+SQLiteGame::GetCustomStateData (const Game& game, const std::string& jsonField,
+                                const std::function<Json::Value (sqlite3*)>& cb)
+{
+  return game.GetCustomStateData (jsonField,
+      [this, &cb] (const GameStateData& state)
+        {
+          database->EnsureCurrentState (state);
+          return cb (database->GetDatabase ());
+        });
+}
+
 } // namespace xaya

--- a/xayagame/sqlitegame.hpp
+++ b/xayagame/sqlitegame.hpp
@@ -5,6 +5,7 @@
 #ifndef XAYAGAME_SQLITEGAME_HPP
 #define XAYAGAME_SQLITEGAME_HPP
 
+#include "game.hpp"
 #include "gamelogic.hpp"
 #include "storage.hpp"
 
@@ -12,6 +13,7 @@
 
 #include <json/json.h>
 
+#include <functional>
 #include <memory>
 #include <string>
 
@@ -100,6 +102,17 @@ protected:
    * to be returned by the game daemon's JSON-RPC interface.
    */
   virtual Json::Value GetStateAsJson (sqlite3* db) = 0;
+
+  /**
+   * Extracts custom state data from the database (as done by a callback
+   * that queries the data).  This calls GetCustomStateData on the Game
+   * instance and provides a callback that handles the "game state" string
+   * in the same way as GameStateToJson does, before calling the user function
+   * to actually retrieve the data.
+   */
+  Json::Value GetCustomStateData (
+      const Game& game, const std::string& jsonField,
+      const std::function<Json::Value (sqlite3*)>& cb);
 
 public:
 

--- a/xayagame/sqlitegame.hpp
+++ b/xayagame/sqlitegame.hpp
@@ -104,6 +104,13 @@ protected:
   virtual Json::Value GetStateAsJson (sqlite3* db) = 0;
 
   /**
+   * Prepares an SQLite statement in the underlying database and returns
+   * the prepared statement.  The returned statement is owned and managed
+   * by the SQLiteStorage and must not be freed manually!
+   */
+  sqlite3_stmt* PrepareStatement (const std::string& sql) const;
+
+  /**
    * Extracts custom state data from the database (as done by a callback
    * that queries the data).  This calls GetCustomStateData on the Game
    * instance and provides a callback that handles the "game state" string


### PR DESCRIPTION
Some tweaks that are useful for implementing custom RPCs in a game daemon that extract specific parts of the game state.  This can be used when returning the full game state would be inefficient and too large, and only small parts of it are ever needed by a frontend.