### PR TITLE
Add current height to game-state returning RPCs

### DIFF
--- a/mover/gametest/basic.py
+++ b/mover/gametest/basic.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright (C) 2018 The Xaya developers
+# Copyright (C) 2018-2019 The Xaya developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -13,6 +13,8 @@ Tests basic game operation with some moves and the resulting game state.
 class BasicTest (MoverTest):
 
   def run (self):
+    self.expectGameState ({"players": {}})
+
     self.generate (101)
     self.expectGameState ({"players": {}})
 

--- a/xayagame/Makefile.am
+++ b/xayagame/Makefile.am
@@ -26,6 +26,7 @@ libxayagame_la_SOURCES = \
   game.cpp \
   gamelogic.cpp \
   gamerpcserver.cpp \
+  heightcache.cpp \
   lmdbstorage.cpp \
   mainloop.cpp \
   pruningqueue.cpp \
@@ -40,6 +41,7 @@ xayagame_HEADERS = \
   game.hpp \
   gamelogic.hpp \
   gamerpcserver.hpp \
+  heightcache.hpp \
   lmdbstorage.hpp \
   mainloop.hpp \
   pruningqueue.hpp \
@@ -67,6 +69,7 @@ tests_LDADD = $(builddir)/libxayagame.la \
 tests_SOURCES = testutils.cpp \
   game_tests.cpp \
   gamelogic_tests.cpp \
+  heightcache_tests.cpp \
   lmdbstorage_tests.cpp \
   mainloop_tests.cpp \
   pruningqueue_tests.cpp \

--- a/xayagame/game.hpp
+++ b/xayagame/game.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018 The Xaya developers
+// Copyright (C) 2018-2019 The Xaya developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -6,6 +6,7 @@
 #define XAYAGAME_GAME_HPP
 
 #include "gamelogic.hpp"
+#include "heightcache.hpp"
 #include "mainloop.hpp"
 #include "pruningqueue.hpp"
 #include "storage.hpp"
@@ -125,8 +126,8 @@ private:
   /** The ZMQ subscriber.  */
   internal::ZmqSubscriber zmq;
 
-  /** Storage system in use.  */
-  StorageInterface* storage = nullptr;
+  /** The height-caching storage we use.  */
+  std::unique_ptr<internal::StorageWithCachedHeight> storage;
 
   /** The game rules in use.  */
   GameLogic* rules = nullptr;

--- a/xayagame/heightcache.cpp
+++ b/xayagame/heightcache.cpp
@@ -1,0 +1,66 @@
+// Copyright (C) 2019 The Xaya developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "heightcache.hpp"
+
+#include <glog/logging.h>
+
+namespace xaya
+{
+namespace internal
+{
+
+StorageWithCachedHeight::StorageWithCachedHeight (StorageInterface& s,
+                                                  const HeightCallback& cb)
+  : hashToHeight(cb), storage(&s)
+{
+  CHECK (storage != nullptr);
+}
+
+void
+StorageWithCachedHeight::SetCurrentGameStateWithHeight (
+    const uint256& hash, const unsigned height, const GameStateData& data)
+{
+  storage->SetCurrentGameState (hash, data);
+
+  hasHeight = true;
+  cachedHeight = height;
+
+  VLOG (1) << "Cached height for block " <<  hash.ToHex () << ": " << height;
+}
+
+bool
+StorageWithCachedHeight::GetCurrentBlockHashWithHeight (uint256& hash,
+                                                        unsigned& height) const
+{
+  if (!storage->GetCurrentBlockHash (hash))
+    return false;
+
+  bool retrievedHeight = false;
+  if (!hasHeight)
+    {
+      LOG (INFO) << "No cached block height, retrieving for " << hash.ToHex ();
+      cachedHeight = hashToHeight (hash);
+      hasHeight = true;
+      retrievedHeight = true;
+    }
+
+  CHECK (hasHeight);
+  height = cachedHeight;
+
+  if (crossCheck && !retrievedHeight)
+    CHECK_EQ (cachedHeight, hashToHeight (hash)) << "Cached height is wrong";
+
+  return true;
+}
+
+void
+StorageWithCachedHeight::SetCurrentGameState (const uint256& hash,
+                                              const GameStateData& data)
+{
+  LOG (FATAL) << "SetCurrentGameStateWithHeight has to be used";
+}
+
+} // namespace internal
+} // namespace xaya

--- a/xayagame/heightcache.hpp
+++ b/xayagame/heightcache.hpp
@@ -1,0 +1,188 @@
+// Copyright (C) 2019 The Xaya developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef XAYAGAME_HEIGHTCACHE_HPP
+#define XAYAGAME_HEIGHTCACHE_HPP
+
+/* This file is an implementation detail of Game and should not be
+   used directly by external code!  */
+
+#include "storage.hpp"
+#include "uint256.hpp"
+
+#include <functional>
+
+namespace xaya
+{
+namespace internal
+{
+
+/**
+ * Wrapper around a StorageInterface that adds an in-memory cached height
+ * for the current game state.  The SetCurrentGameState function is replaced
+ * by a variant that gets the height as well, and a new
+ * GetCurrentGameStateWithHeight method is provided to access the associated
+ * height as well.
+ *
+ * When no cached height is available yet or for cross-checking in regtest
+ * mode, a function has to be provided that retrieves the block height for
+ * a block hash (e.g. by calling Xaya Core's RPC interface).  That is used
+ * for cases when the height is requested right after start-up and before
+ * it has been set.
+ */
+class StorageWithCachedHeight : public StorageInterface
+{
+
+private:
+
+  /**
+   * Callback function that retrieves the block height for a given hash.
+   */
+  using HeightCallback = std::function<unsigned (const uint256& hash)>;
+
+  /** The callback function we use to translate hashes to heights.  */
+  const HeightCallback hashToHeight;
+
+  /** The wrapped storage interface.  */
+  StorageInterface* const storage;
+
+  /**
+   * If true, then hashes are always translated to heights via the callback
+   * (even if there is a cached height).  The cached height, if any, is then
+   * cross-checked against the retrieved one.  This can be used for testing
+   * purposes, e.g. in regtest mode.
+   */
+  bool crossCheck = false;
+
+  /**
+   * The cached height corresponding to the current game-state block hash
+   * in storage.
+   */
+  mutable unsigned cachedHeight;
+
+  /** Whether or not we have a cached height.  */
+  mutable bool hasHeight = false;
+
+  friend class StorageWithDummyHeight;
+
+public:
+
+  explicit StorageWithCachedHeight (StorageInterface& s,
+                                    const HeightCallback& cb);
+
+  StorageWithCachedHeight () = delete;
+  StorageWithCachedHeight (const StorageWithCachedHeight&) = delete;
+  void operator= (const StorageWithCachedHeight&) = delete;
+
+  /**
+   * Turns on strict (but expensive) cross checks of the cached height.
+   * Game uses this on the regtest chain only.
+   */
+  void
+  EnableCrossChecks ()
+  {
+    crossCheck = true;
+  }
+
+  /**
+   * Sets the current game state in the underlying storage, including an
+   * associated block height that is cached in memory.
+   */
+  void SetCurrentGameStateWithHeight (const uint256& hash,
+                                      unsigned height,
+                                      const GameStateData& data);
+
+  /**
+   * Retrieves the current block hash (if any) together with the associated
+   * block height.
+   */
+  bool GetCurrentBlockHashWithHeight (uint256& hash, unsigned& height) const;
+
+  /* Methods from StorageInterface.  They simply call through to the wrapped
+     instance, with a few minor extra things.  */
+
+  void
+  Initialise () override
+  {
+    storage->Initialise ();
+  }
+
+  void
+  Clear () override
+  {
+    hasHeight = false;
+    storage->Clear ();
+  }
+
+  bool
+  GetCurrentBlockHash (uint256& hash) const override
+  {
+    return storage->GetCurrentBlockHash (hash);
+  }
+
+  GameStateData
+  GetCurrentGameState () const override
+  {
+    return storage->GetCurrentGameState ();
+  }
+
+  /**
+   * SetCurrentGameState must not be called.  Instead,
+   * SetCurrentGameStateWithHeight has to be used.  This method crashes always.
+   */
+  void SetCurrentGameState (const uint256& hash,
+                            const GameStateData& data) override;
+
+  bool
+  GetUndoData (const uint256& hash, UndoData& data) const override
+  {
+    return storage->GetUndoData (hash, data);
+  }
+
+  void
+  AddUndoData (const uint256& hash, const unsigned height,
+               const UndoData& data) override
+  {
+    storage->AddUndoData (hash, height, data);
+  }
+
+  void
+  ReleaseUndoData (const uint256& hash) override
+  {
+    storage->ReleaseUndoData (hash);
+  }
+
+  void
+  PruneUndoData (const unsigned height) override
+  {
+    storage->PruneUndoData (height);
+  }
+
+  void
+  BeginTransaction () override
+  {
+    storage->BeginTransaction ();
+  }
+
+  void
+  CommitTransaction () override
+  {
+    storage->CommitTransaction ();
+  }
+
+  void
+  RollbackTransaction () override
+  {
+    /* Clear the cached height to make sure it is not wrong afterwards.  */
+    hasHeight = false;
+
+    storage->RollbackTransaction ();
+  }
+
+};
+
+} // namespace internal
+} // namespace xaya
+
+#endif // XAYAGAME_HEIGHTCACHE_HPP

--- a/xayagame/heightcache_tests.cpp
+++ b/xayagame/heightcache_tests.cpp
@@ -1,0 +1,229 @@
+// Copyright (C) 2019 The Xaya developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "heightcache.hpp"
+
+#include "storage.hpp"
+#include "uint256.hpp"
+
+#include "storage_tests.hpp"
+#include "testutils.hpp"
+
+#include <gtest/gtest.h>
+
+#include <glog/logging.h>
+
+#include <memory>
+
+namespace xaya
+{
+namespace internal
+{
+
+/**
+ * Modified instance of StorageWithCachedHeight that uses a dummy height,
+ * so that it can be tested against the standard storage tests.
+ */
+class StorageWithDummyHeight : public StorageWithCachedHeight
+{
+
+private:
+
+  /**
+   * The memory storage that is wrapped by the cached-height storage.
+   * We have to use a pointer here, since we need to construct that object
+   * already before the super-class constructor is called.  The pointer is
+   * then initialised from the reference in the super-class afterwards.
+   * This also means that the storage will be destructed before the super-class
+   * destructor is called, but that is fine since it is not used from there
+   * (and this is only test code).
+   */
+  std::unique_ptr<StorageInterface> memoryStorage;
+
+  /**
+   * Dummy function for the hash-to-height translation.  This should not be
+   * called at all for the standard storage tests.
+   */
+  static unsigned
+  HashToHeight (const uint256& hash)
+  {
+    LOG (FATAL) << "HashToHeight should not be called for the storage tests";
+  }
+
+public:
+
+  StorageWithDummyHeight ()
+    : StorageWithCachedHeight (*new MemoryStorage (), &HashToHeight)
+  {
+    memoryStorage.reset (StorageWithCachedHeight::storage);
+  }
+
+  void
+  SetCurrentGameState (const uint256& hash, const GameStateData& data) override
+  {
+    SetCurrentGameStateWithHeight (hash, 0, data);
+  }
+
+};
+
+namespace
+{
+
+/* Verify that the wrapped storage works as a basic storage, if we just cache
+   a dummy height (and never request the height).  */
+INSTANTIATE_TYPED_TEST_CASE_P (HeightCache, BasicStorageTests,
+                               StorageWithDummyHeight);
+INSTANTIATE_TYPED_TEST_CASE_P (HeightCache, PruningStorageTests,
+                               StorageWithDummyHeight);
+
+/**
+ * Test fixture that sets up a memory storage and a real storage with cached
+ * height (not the dummy one).  This is used for tests of the height cache
+ * itself.
+ */
+class HeightCacheTests : public testing::Test
+{
+
+private:
+
+  /** The underlying memory storage.  */
+  MemoryStorage memoryStorage;
+
+  /**
+   * Hash-to-height function that checks the hash against the first ten
+   * test block hashes (from testutils' BlockHash).  This also increments
+   * the hashToHeightCount value.
+   */
+  unsigned
+  HashToHeight (const uint256& hash)
+  {
+    ++hashToHeightCount;
+    for (unsigned i = 0; i < 10; ++i)
+      if (hash == BlockHash (i))
+        return i;
+    LOG (FATAL) << "Unexpected test block hash: " << hash.ToHex ();
+  }
+
+protected:
+
+  /** The height-caching storage that can be used for tests.  */
+  StorageWithCachedHeight storage;
+
+  /** Counter for how often the hash-to-height function has been called.  */
+  int hashToHeightCount = 0;
+
+  HeightCacheTests ()
+    : memoryStorage(),
+      storage(memoryStorage,
+              [this] (const uint256& hash) {
+                return HashToHeight (hash);
+              })
+  {}
+
+  /**
+   * Utility function to store the given hash and height.
+   */
+  void
+  StoreHashAndHeight (const uint256& hash, const unsigned height)
+  {
+    storage.BeginTransaction ();
+    storage.SetCurrentGameStateWithHeight (hash, height, GameStateData ());
+    storage.CommitTransaction ();
+  }
+
+  /**
+   * Stores the given hash as current game state in the underlying storage,
+   * bypassing the cache.  This can be used to simulate a situation where
+   * the storage has a persisted value but the cache has just been started.
+   */
+  void
+  StoreOnlyHash (const uint256& hash)
+  {
+    memoryStorage.BeginTransaction ();
+    memoryStorage.SetCurrentGameState (hash, GameStateData ());
+    memoryStorage.CommitTransaction ();
+  }
+
+  /**
+   * Expect the given hash and height as current state.
+   */
+  void
+  ExpectHashAndHeight (const uint256& expectedHash,
+                       const unsigned expectedHeight) const
+  {
+    uint256 hash;
+    unsigned height;
+    ASSERT_TRUE (storage.GetCurrentBlockHashWithHeight (hash, height));
+    EXPECT_EQ (hash, expectedHash);
+    EXPECT_EQ (height, expectedHeight);
+  }
+
+};
+
+TEST_F (HeightCacheTests, NoCurrentState)
+{
+  uint256 hash;
+  unsigned height;
+  EXPECT_FALSE (storage.GetCurrentBlockHashWithHeight (hash, height));
+  EXPECT_EQ (hashToHeightCount, 0);
+}
+
+TEST_F (HeightCacheTests, BasicCaching)
+{
+  StoreHashAndHeight (BlockHash (2), 10);
+  ExpectHashAndHeight (BlockHash (2), 10);
+  EXPECT_EQ (hashToHeightCount, 0);
+}
+
+TEST_F (HeightCacheTests, TranslationFunction)
+{
+  StoreOnlyHash (BlockHash (2));
+  ExpectHashAndHeight (BlockHash (2), 2);
+  EXPECT_EQ (hashToHeightCount, 1);
+}
+
+TEST_F (HeightCacheTests, CrossChecks)
+{
+  storage.EnableCrossChecks ();
+  StoreHashAndHeight (BlockHash (2), 10);
+
+  uint256 hash;
+  unsigned height;
+  EXPECT_DEATH (storage.GetCurrentBlockHashWithHeight (hash, height),
+                "Cached height is wrong");
+}
+
+TEST_F (HeightCacheTests, Clear)
+{
+  StoreHashAndHeight (BlockHash (2), 10);
+  storage.Clear ();
+  StoreOnlyHash (BlockHash (2));
+
+  ExpectHashAndHeight (BlockHash (2), 2);
+  EXPECT_EQ (hashToHeightCount, 1);
+}
+
+TEST_F (HeightCacheTests, RollbackTransaction)
+{
+  storage.BeginTransaction ();
+  storage.SetCurrentGameStateWithHeight (BlockHash (2), 10, GameStateData ());
+  storage.RollbackTransaction ();
+
+  StoreOnlyHash (BlockHash (2));
+
+  ExpectHashAndHeight (BlockHash (2), 2);
+  EXPECT_EQ (hashToHeightCount, 1);
+}
+
+TEST_F (HeightCacheTests, NoSettingWithoutHeight)
+{
+  storage.BeginTransaction ();
+  EXPECT_DEATH (storage.SetCurrentGameState (BlockHash (2), GameStateData ()),
+                "SetCurrentGameStateWithHeight");
+  storage.CommitTransaction ();
+}
+
+} // anonymous namespace
+} // namespace internal
+} // namespace xaya

--- a/xayagame/rpc-stubs/xaya.json
+++ b/xayagame/rpc-stubs/xaya.json
@@ -26,6 +26,14 @@
     "returns": "hash"
   },
   {
+    "name": "getblockheader",
+    "params":
+      {
+        "blockhash": "hash"
+      },
+    "returns": {}
+  },
+  {
     "name": "game_sendupdates",
     "params":
       {

--- a/xayagame/testutils.cpp
+++ b/xayagame/testutils.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018 The Xaya developers
+// Copyright (C) 2018-2019 The Xaya developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -38,12 +38,14 @@ void
 GameTestFixture::CallBlockAttach (Game& g, const std::string& reqToken,
                                   const uint256& parentHash,
                                   const uint256& blockHash,
+                                  const unsigned height,
                                   const Json::Value& moves,
                                   const bool seqMismatch) const
 {
   Json::Value block(Json::objectValue);
   block["hash"] = blockHash.ToHex ();
   block["parent"] = parentHash.ToHex ();
+  block["height"] = height;
 
   Json::Value data(Json::objectValue);
   if (!reqToken.empty ())
@@ -58,12 +60,14 @@ void
 GameTestFixture::CallBlockDetach (Game& g, const std::string& reqToken,
                                   const uint256& parentHash,
                                   const uint256& blockHash,
+                                  const unsigned height,
                                   const Json::Value& moves,
                                   const bool seqMismatch) const
 {
   Json::Value block(Json::objectValue);
   block["hash"] = blockHash.ToHex ();
   block["parent"] = parentHash.ToHex ();
+  block["height"] = height;
 
   Json::Value data(Json::objectValue);
   if (!reqToken.empty ())
@@ -86,7 +90,9 @@ GameTestWithBlockchain::AttachBlock (Game& g, const uint256& hash,
                                      const Json::Value& moves)
 {
   CHECK (!blockHashes.empty ()) << "No starting block has been set";
-  CallBlockAttach (g, "", blockHashes.back (), hash, moves, false);
+  CallBlockAttach (g, "",
+                   blockHashes.back (), hash, blockHashes.size () + 1,
+                   moves, false);
   blockHashes.push_back (hash);
   moveStack.push_back (moves);
 }
@@ -99,7 +105,9 @@ GameTestWithBlockchain::DetachBlock (Game& g)
 
   const uint256 hash = blockHashes.back ();
   blockHashes.pop_back ();
-  CallBlockDetach (g, "", blockHashes.back (), hash, moveStack.back (), false);
+  CallBlockDetach (g, "",
+                   blockHashes.back (), hash, blockHashes.size () + 1,
+                   moveStack.back (), false);
   moveStack.pop_back ();
 }
 

--- a/xayagame/testutils.hpp
+++ b/xayagame/testutils.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018 The Xaya developers
+// Copyright (C) 2018-2019 The Xaya developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -150,6 +150,7 @@ protected:
    */
   void CallBlockAttach (Game& g, const std::string& reqToken,
                         const uint256& parentHash, const uint256& blockHash,
+                        unsigned height,
                         const Json::Value& moves, const bool seqMismatch) const;
 
   /**
@@ -158,6 +159,7 @@ protected:
    */
   void CallBlockDetach (Game& g, const std::string& reqToken,
                         const uint256& parentHash, const uint256& blockHash,
+                        unsigned height,
                         const Json::Value& moves, const bool seqMismatch) const;
 
 };

--- a/xayagametest/testcase.py
+++ b/xayagametest/testcase.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2018 The Xaya developers
+# Copyright (C) 2018-2019 The Xaya developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -180,12 +180,12 @@ class XayaGameTest (object):
     """
 
     bestblk = self.rpc.xaya.getbestblockhash ()
+    bestheight = self.rpc.xaya.getblockcount ()
     while True:
       state = self.rpc.game.getcurrentstate ()
-      if state["gameid"] != self.gameId:
-        self.log.error ("Game state does not have expected game ID: %s vs %s"
-            % (state["gameid"], self.gameId))
+      assert state["gameid"] == self.gameId
       if state["state"] == "up-to-date" and state["blockhash"] == bestblk:
+        assert state["height"] == bestheight
         return state["gamestate"]
       self.log.warning (("Game state (%s, %s) does not match"
                             +" the best block (%s), waiting")


### PR DESCRIPTION
With this, a new `height` field is returned from the `getcurrentstate` RPC as well as other RPCs based on `GetCustomStateData`, as suggested in #30.  This is implemented by keeping a cache of the height in memory, but not the persistent storage.  When needed, the height is requested through Xaya Core's `getblockheader` RPC.

In regtest mode, the height is requested always and cross-checked against the cached height to ensure that the caching works fine (in addition to the unit tests that are there).