### PR TITLE
Implement automatic ID generation for SQLiteGame's

### DIFF
--- a/xayagame/sqlitegame.hpp
+++ b/xayagame/sqlitegame.hpp
@@ -52,6 +52,10 @@ private:
      implementation detail and part of sqlitegame.cpp.  */
   class Storage;
 
+  /* Internal helper class (defined and implemented in sqlitegame.cpp) that
+     holds a set of currently activate AutoId values.  */
+  class ActiveAutoIds;
+
   /**
    * The storage instance that is used.  std::unique_ptr is used so that we
    * can use the forward-declared type and do not need to define Storage right
@@ -59,7 +63,16 @@ private:
    */
   std::unique_ptr<Storage> database;
 
+  /**
+   * Currently active AutoIds (if any).  This pointer is set for use by
+   * the Ids() member function while a set is managed (e.g. during a call
+   * to UpdateState).  It is set to null when no set is active.
+   */
+  ActiveAutoIds* activeIds = nullptr;
+
 protected:
+
+  class AutoId;
 
   /**
    * This method is called on every open of the SQLite database, and should
@@ -111,6 +124,12 @@ protected:
   sqlite3_stmt* PrepareStatement (const std::string& sql) const;
 
   /**
+   * Returns a handle to an AutoId instance for a given named key.  That can
+   * be used to generate a consistent sequence of integer IDs.
+   */
+  AutoId& Ids (const std::string& key);
+
+  /**
    * Extracts custom state data from the database (as done by a callback
    * that queries the data).  This calls GetCustomStateData on the Game
    * instance and provides a callback that handles the "game state" string
@@ -148,6 +167,80 @@ public:
                                   const UndoData& undo) override;
 
   Json::Value GameStateToJson (const GameStateData& state) override;
+
+};
+
+/**
+ * Helper class to manage a series of automatically generated IDs that can
+ * be used e.g. as primary keys for database tables.  (But other than
+ * letting SQLite generate them, they are guaranteed to be consistent
+ * across instances and reorgs.)
+ *
+ * This instance provides the user-visible interface.  It caches the currently
+ * next ID in memory, only reading it from the database and syncing it back
+ * when constructed/destructed.  One such instance is kept active while the
+ * user-supplied game logic is executing, e.g. while processing one block.
+ * This ensures that we do not have to do many SQL operations for managing IDs;
+ * at most two per block (and per instance).
+ */
+class SQLiteGame::AutoId
+{
+
+private:
+
+  /** The next ID value to give out.  */
+  unsigned nextValue;
+
+  /**
+   * The last value that has been read from or synced to the database.
+   * (Or 0 if no sync has been made yet.)
+   */
+  unsigned dbValue = 0;
+
+  /**
+   * Constructs the AutoId, initialised from the database.
+   */
+  explicit AutoId (SQLiteGame& game, const std::string& key);
+
+  /**
+   * Syncs the current value back to the database if it has been modified.
+   */
+  void Sync (SQLiteGame& game, const std::string& key);
+
+  friend class SQLiteGame::ActiveAutoIds;
+
+public:
+
+  /**
+   * Destructs the AutoId instance.  This crashes if the current value is
+   * different from the one synced to the database.  Sync() has to be called
+   * before destructing the object to ensure this.
+   */
+  ~AutoId ();
+
+  AutoId () = delete;
+  AutoId (const AutoId&) = delete;
+  void operator= (const AutoId&) = delete;
+
+  /**
+   * Retrieves the next value.
+   */
+  unsigned
+  GetNext ()
+  {
+    return nextValue++;
+  }
+
+  /**
+   * Pre-reserves all IDs up to the given value.  That can be used to mark
+   * them unavailable when they have been created or used otherwise, for
+   * instance through initial static data.
+   */
+  void
+  ReserveUpTo (const unsigned end)
+  {
+    nextValue = std::max (nextValue, end + 1);
+  }
 
 };
 


### PR DESCRIPTION
This adds new functionality to `SQLiteGame`, namely an API to generate unique IDs (to be used as e.g. `PRIMARY KEY` values).  Generating IDs this way (rather than relying on SQLite `rowid`'s) ensures that we have full control over it, and that the IDs are consistent across instances as well as work fine with reorgs and the like.

This implements the first part of #33.