### PR TITLE
Introduce Random utility and Context for GameLogic callbacks

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -35,6 +35,7 @@ AX_PKG_CHECK_MODULES([LMDB], [lmdb], [])
 
 # Private dependencies of the library itself.
 AX_PKG_CHECK_MODULES([GLOG], [], [libglog])
+AX_PKG_CHECK_MODULES([OPENSSL], [], [openssl])
 AX_PKG_CHECK_MODULES([ZMQ], [], [libzmq])
 
 # Private dependencies that are not needed for libxayagame, but only for

--- a/mover/logic.cpp
+++ b/mover/logic.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018 The Xaya developers
+// Copyright (C) 2018-2019 The Xaya developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -14,7 +14,7 @@ namespace mover
 {
 
 GameStateData
-MoverLogic::GetInitialState (unsigned& height, std::string& hashHex)
+MoverLogic::GetInitialStateInternal (unsigned& height, std::string& hashHex)
 {
   switch (GetChain ())
     {
@@ -197,8 +197,9 @@ MoverLogic::ParseMove (const Json::Value& obj,
 }
 
 GameStateData
-MoverLogic::ProcessForward (const GameStateData& oldState,
-                            const Json::Value& blockData, UndoData& undoData)
+MoverLogic::ProcessForwardInternal (const GameStateData& oldState,
+                                    const Json::Value& blockData,
+                                    UndoData& undoData)
 {
   proto::GameState state;
   CHECK (state.ParseFromString (oldState));
@@ -278,9 +279,9 @@ MoverLogic::ProcessForward (const GameStateData& oldState,
 }
 
 GameStateData
-MoverLogic::ProcessBackwards (const GameStateData& newState,
-                              const Json::Value& blockData,
-                              const UndoData& undoData)
+MoverLogic::ProcessBackwardsInternal (const GameStateData& newState,
+                                      const Json::Value& blockData,
+                                      const UndoData& undoData)
 {
   proto::GameState state;
   CHECK (state.ParseFromString (newState));

--- a/mover/logic.cpp
+++ b/mover/logic.cpp
@@ -16,7 +16,8 @@ namespace mover
 GameStateData
 MoverLogic::GetInitialStateInternal (unsigned& height, std::string& hashHex)
 {
-  switch (GetChain ())
+  const Chain chain = GetContext ().GetChain ();
+  switch (chain)
     {
     case Chain::MAIN:
       height = 125000;
@@ -37,7 +38,7 @@ MoverLogic::GetInitialStateInternal (unsigned& height, std::string& hashHex)
       break;
 
     default:
-      LOG (FATAL) << "Unexpected chain: " << ChainToString (GetChain ());
+      LOG (FATAL) << "Unexpected chain: " << ChainToString (chain);
     }
 
   /* In all cases, the initial game state is just empty.  */

--- a/mover/logic.hpp
+++ b/mover/logic.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018 The Xaya developers
+// Copyright (C) 2018-2019 The Xaya developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -34,18 +34,20 @@ private:
 
   friend class ParseMoveTests;
 
+protected:
+
+  xaya::GameStateData GetInitialStateInternal (unsigned& height,
+                                               std::string& hashHex) override;
+
+  xaya::GameStateData ProcessForwardInternal (
+      const xaya::GameStateData& oldState, const Json::Value& blockData,
+      xaya::UndoData& undo) override;
+
+  xaya::GameStateData ProcessBackwardsInternal (
+      const xaya::GameStateData& newState, const Json::Value& blockData,
+      const xaya::UndoData& undo) override;
+
 public:
-
-  xaya::GameStateData GetInitialState (unsigned& height,
-                                       std::string& hashHex) override;
-
-  xaya::GameStateData ProcessForward (const xaya::GameStateData& oldState,
-                                      const Json::Value& blockData,
-                                      xaya::UndoData& undo) override;
-
-  xaya::GameStateData ProcessBackwards (const xaya::GameStateData& newState,
-                                        const Json::Value& blockData,
-                                        const xaya::UndoData& undo) override;
 
   Json::Value GameStateToJson (const xaya::GameStateData& state) override;
 

--- a/mover/logic_tests.cpp
+++ b/mover/logic_tests.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018 The Xaya developers
+// Copyright (C) 2018-2019 The Xaya developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -183,6 +183,7 @@ TEST (InitialStateTests, IsEmpty)
   for (const auto chain : {Chain::MAIN, Chain::TEST, Chain::REGTEST})
     {
       MoverLogic rules;
+      rules.SetGameId ("mv");
       rules.SetChain (chain);
 
       unsigned height;
@@ -245,6 +246,7 @@ protected:
 
   StateProcessingTests ()
   {
+    rules.SetGameId ("mv");
     rules.SetChain (Chain::MAIN);
 
     unsigned height;
@@ -295,7 +297,13 @@ protected:
         elem["move"] = moves[nm];
         moveArray.append (elem);
       }
+
+    Json::Value blk(Json::objectValue);
+    blk["rngseed"]
+        = "0000000000000000000000000000000000000000000000000000000000000001";
+
     d.blockData = Json::Value (Json::objectValue);
+    d.blockData["block"] = blk;
     d.blockData["moves"] = moveArray;
 
     proto::GameState expectedStatePb;

--- a/xayagame/Makefile.am
+++ b/xayagame/Makefile.am
@@ -33,6 +33,7 @@ libxayagame_la_SOURCES = \
   lmdbstorage.cpp \
   mainloop.cpp \
   pruningqueue.cpp \
+  random.cpp \
   sqlitegame.cpp \
   sqlitestorage.cpp \
   storage.cpp \
@@ -49,6 +50,7 @@ xayagame_HEADERS = \
   lmdbstorage.hpp \
   mainloop.hpp \
   pruningqueue.hpp \
+  random.hpp \
   sqlitegame.hpp \
   sqlitestorage.hpp \
   storage.hpp \
@@ -78,6 +80,7 @@ tests_SOURCES = testutils.cpp \
   lmdbstorage_tests.cpp \
   mainloop_tests.cpp \
   pruningqueue_tests.cpp \
+  random_tests.cpp \
   sqlitegame_tests.cpp \
   sqlitestorage_tests.cpp \
   storage_tests.cpp \

--- a/xayagame/Makefile.am
+++ b/xayagame/Makefile.am
@@ -15,9 +15,11 @@ BUILT_SOURCES = $(RPC_STUBS)
 CLEANFILES = $(RPC_STUBS)
 
 libxayagame_la_CXXFLAGS = \
+  $(OPENSSL_CFLAGS) \
   $(JSONCPP_CFLAGS) $(JSONRPCCLIENT_CFLAGS) $(JSONRPCSERVER_CFLAGS) \
   $(GLOG_CFLAGS) $(SQLITE3_CFLAGS) $(LMDB_CFLAGS) $(ZMQ_CFLAGS)
 libxayagame_la_LIBADD = \
+  $(OPENSSL_LIBS) \
   $(JSONCPP_LIBS) $(JSONRPCCLIENT_LIBS) $(JSONRPCSERVER_LIBS) \
   $(GLOG_LIBS) $(SQLITE3_LIBS) $(LMDB_LIBS) $(ZMQ_LIBS) \
   -lstdc++fs
@@ -26,6 +28,7 @@ libxayagame_la_SOURCES = \
   game.cpp \
   gamelogic.cpp \
   gamerpcserver.cpp \
+  hash.cpp \
   heightcache.cpp \
   lmdbstorage.cpp \
   mainloop.cpp \
@@ -41,6 +44,7 @@ xayagame_HEADERS = \
   game.hpp \
   gamelogic.hpp \
   gamerpcserver.hpp \
+  hash.hpp \
   heightcache.hpp \
   lmdbstorage.hpp \
   mainloop.hpp \
@@ -69,6 +73,7 @@ tests_LDADD = $(builddir)/libxayagame.la \
 tests_SOURCES = testutils.cpp \
   game_tests.cpp \
   gamelogic_tests.cpp \
+  hash_tests.cpp \
   heightcache_tests.cpp \
   lmdbstorage_tests.cpp \
   mainloop_tests.cpp \

--- a/xayagame/defaultmain.cpp
+++ b/xayagame/defaultmain.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018 The Xaya developers
+// Copyright (C) 2018-2019 The Xaya developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -176,22 +176,19 @@ private:
   /** The callback pointers.  */
   const GameLogicCallbacks& callbacks;
 
-public:
-
-  explicit CallbackGameLogic (const GameLogicCallbacks& cb)
-    : callbacks(cb)
-  {}
+protected:
 
   GameStateData
-  GetInitialState (unsigned& height, std::string& hashHex)
+  GetInitialStateInternal (unsigned& height, std::string& hashHex) override
   {
     CHECK (callbacks.GetInitialState != nullptr);
     return callbacks.GetInitialState (GetChain (), height, hashHex);
   }
 
   GameStateData
-  ProcessForward (const GameStateData& oldState, const Json::Value& blockData,
-                  UndoData& undoData) override
+  ProcessForwardInternal (const GameStateData& oldState,
+                          const Json::Value& blockData,
+                          UndoData& undoData) override
   {
     CHECK (callbacks.ProcessForward != nullptr);
     return callbacks.ProcessForward (GetChain (), oldState,
@@ -199,13 +196,20 @@ public:
   }
 
   GameStateData
-  ProcessBackwards (const GameStateData& oldState, const Json::Value& blockData,
-                    const UndoData& undoData) override
+  ProcessBackwardsInternal (const GameStateData& oldState,
+                            const Json::Value& blockData,
+                            const UndoData& undoData) override
   {
     CHECK (callbacks.ProcessBackwards != nullptr);
     return callbacks.ProcessBackwards (GetChain (), oldState,
                                        blockData, undoData);
   }
+
+public:
+
+  explicit CallbackGameLogic (const GameLogicCallbacks& cb)
+    : callbacks(cb)
+  {}
 
   Json::Value
   GameStateToJson (const GameStateData& state) override

--- a/xayagame/defaultmain.cpp
+++ b/xayagame/defaultmain.cpp
@@ -182,7 +182,8 @@ protected:
   GetInitialStateInternal (unsigned& height, std::string& hashHex) override
   {
     CHECK (callbacks.GetInitialState != nullptr);
-    return callbacks.GetInitialState (GetChain (), height, hashHex);
+    return callbacks.GetInitialState (GetContext ().GetChain (),
+                                      height, hashHex);
   }
 
   GameStateData
@@ -191,8 +192,8 @@ protected:
                           UndoData& undoData) override
   {
     CHECK (callbacks.ProcessForward != nullptr);
-    return callbacks.ProcessForward (GetChain (), oldState,
-                                     blockData, undoData);
+    return callbacks.ProcessForward (GetContext ().GetChain (),
+                                     oldState, blockData, undoData);
   }
 
   GameStateData
@@ -201,8 +202,8 @@ protected:
                             const UndoData& undoData) override
   {
     CHECK (callbacks.ProcessBackwards != nullptr);
-    return callbacks.ProcessBackwards (GetChain (), oldState,
-                                       blockData, undoData);
+    return callbacks.ProcessBackwards (GetContext ().GetChain (),
+                                       oldState, blockData, undoData);
   }
 
 public:

--- a/xayagame/game.cpp
+++ b/xayagame/game.cpp
@@ -400,6 +400,7 @@ Game::SetGameLogic (GameLogic* gl)
   std::lock_guard<std::mutex> lock(mut);
   CHECK (!mainLoop.IsRunning ());
   rules = gl;
+  rules->SetGameId (gameId);
   if (chain != Chain::UNKNOWN)
     rules->SetChain (chain);
 }

--- a/xayagame/game_tests.cpp
+++ b/xayagame/game_tests.cpp
@@ -239,7 +239,9 @@ protected:
   GameStateData
   GetInitialStateInternal (unsigned& height, std::string& hashHex) override
   {
-    CHECK (GetChain () == Chain::MAIN);
+    CHECK (GetContext ().GetChain () == Chain::MAIN);
+    CHECK_EQ (GetContext ().GetGameId (), GAME_ID);
+
     height = GAME_GENESIS_HEIGHT;
     hashHex = GAME_GENESIS_HASH;
     return EncodeMap (Map ());
@@ -250,7 +252,8 @@ protected:
                           const Json::Value& blockData,
                           UndoData& undoData) override
   {
-    CHECK (GetChain () == Chain::MAIN);
+    CHECK (GetContext ().GetChain () == Chain::MAIN);
+    CHECK_EQ (GetContext ().GetGameId (), GAME_ID);
 
     Map state = DecodeMap (oldState);
     Map undo;
@@ -283,7 +286,8 @@ protected:
                             const Json::Value& blockData,
                             const UndoData& undoData) override
   {
-    CHECK (GetChain () == Chain::MAIN);
+    CHECK (GetContext ().GetChain () == Chain::MAIN);
+    CHECK_EQ (GetContext ().GetGameId (), GAME_ID);
 
     Map state = DecodeMap (newState);
     const Map undo = DecodeMap (undoData);

--- a/xayagame/game_tests.cpp
+++ b/xayagame/game_tests.cpp
@@ -234,10 +234,10 @@ private:
     return res.str ();
   }
 
-public:
+protected:
 
   GameStateData
-  GetInitialState (unsigned& height, std::string& hashHex) override
+  GetInitialStateInternal (unsigned& height, std::string& hashHex) override
   {
     CHECK (GetChain () == Chain::MAIN);
     height = GAME_GENESIS_HEIGHT;
@@ -246,8 +246,9 @@ public:
   }
 
   GameStateData
-  ProcessForward (const GameStateData& oldState, const Json::Value& blockData,
-                  UndoData& undoData) override
+  ProcessForwardInternal (const GameStateData& oldState,
+                          const Json::Value& blockData,
+                          UndoData& undoData) override
   {
     CHECK (GetChain () == Chain::MAIN);
 
@@ -278,8 +279,9 @@ public:
   }
 
   GameStateData
-  ProcessBackwards (const GameStateData& newState, const Json::Value& blockData,
-                    const UndoData& undoData) override
+  ProcessBackwardsInternal (const GameStateData& newState,
+                            const Json::Value& blockData,
+                            const UndoData& undoData) override
   {
     CHECK (GetChain () == Chain::MAIN);
 
@@ -296,6 +298,8 @@ public:
 
     return EncodeMap (state);
   }
+
+public:
 
   Json::Value
   GameStateToJson (const GameStateData& state) override

--- a/xayagame/gamelogic.cpp
+++ b/xayagame/gamelogic.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018 The Xaya developers
+// Copyright (C) 2018-2019 The Xaya developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -8,6 +8,8 @@
 
 namespace xaya
 {
+
+/* ************************************************************************** */
 
 std::string
 ChainToString (const Chain c)
@@ -27,6 +29,8 @@ ChainToString (const Chain c)
   LOG (FATAL) << "Invalid chain enum value: " << static_cast<int> (c);
 }
 
+/* ************************************************************************** */
+
 Chain
 GameLogic::GetChain () const
 {
@@ -42,16 +46,40 @@ GameLogic::SetChain (const Chain c)
   chain = c;
 }
 
+GameStateData
+GameLogic::GetInitialState (unsigned& height, std::string& hashHex)
+{
+  return GetInitialStateInternal (height, hashHex);
+}
+
+GameStateData
+GameLogic::ProcessForward (const GameStateData& oldState,
+                           const Json::Value& blockData,
+                           UndoData& undoData)
+{
+  return ProcessForwardInternal (oldState, blockData, undoData);
+}
+
+GameStateData
+GameLogic::ProcessBackwards (const GameStateData& newState,
+                             const Json::Value& blockData,
+                             const UndoData& undoData)
+{
+  return ProcessBackwardsInternal (newState, blockData, undoData);
+}
+
 Json::Value
 GameLogic::GameStateToJson (const GameStateData& state)
 {
   return state;
 }
 
+/* ************************************************************************** */
+
 GameStateData
-CachingGame::ProcessForward (const GameStateData& oldState,
-                             const Json::Value& blockData,
-                             UndoData& undoData)
+CachingGame::ProcessForwardInternal (const GameStateData& oldState,
+                                     const Json::Value& blockData,
+                                     UndoData& undoData)
 {
   const GameStateData newState = UpdateState (oldState, blockData);
   undoData = UndoData (oldState);
@@ -59,11 +87,13 @@ CachingGame::ProcessForward (const GameStateData& oldState,
 }
 
 GameStateData
-CachingGame::ProcessBackwards (const GameStateData& newState,
-                               const Json::Value& blockData,
-                               const UndoData& undoData)
+CachingGame::ProcessBackwardsInternal (const GameStateData& newState,
+                                       const Json::Value& blockData,
+                                       const UndoData& undoData)
 {
   return GameStateData (undoData);
 }
+
+/* ************************************************************************** */
 
 } // namespace xaya

--- a/xayagame/gamelogic.cpp
+++ b/xayagame/gamelogic.cpp
@@ -4,6 +4,8 @@
 
 #include "gamelogic.hpp"
 
+#include "hash.hpp"
+
 #include <glog/logging.h>
 
 namespace xaya
@@ -31,6 +33,69 @@ ChainToString (const Chain c)
 
 /* ************************************************************************** */
 
+Context::Context (const GameLogic& l, const uint256& rndSeed)
+  : logic(l)
+{
+  rnd.Seed (rndSeed);
+}
+
+Chain
+Context::GetChain () const
+{
+  CHECK (logic.chain != Chain::UNKNOWN);
+  return logic.chain;
+}
+
+const std::string&
+Context::GetGameId () const
+{
+  CHECK (!logic.gameId.empty ());
+  return logic.gameId;
+}
+
+/* ************************************************************************** */
+
+/**
+ * Helper class that controls setting and unsetting the context pointer
+ * in a GameLogic instance through RAII.
+ */
+class GameLogic::ContextSetter
+{
+
+private:
+
+  /** The underlying GameLogic instance.  */
+  GameLogic& logic;
+
+  /** The Context instance we point to.  */
+  Context& ctx;
+
+public:
+
+  /**
+   * Constructs the instance and sets the context pointer.
+   */
+  explicit ContextSetter (GameLogic& l, Context& c)
+    : logic(l), ctx(c)
+  {
+    CHECK (logic.ctx == nullptr);
+    logic.ctx = &ctx;
+  }
+
+  /**
+   * Destructs the instance, unsetting the pointer.
+   */
+  ~ContextSetter ()
+  {
+    CHECK (logic.ctx == &ctx);
+    logic.ctx = nullptr;
+  }
+
+  ContextSetter (const ContextSetter&) = delete;
+  void operator= (const ContextSetter&) = delete;
+
+};
+
 Chain
 GameLogic::GetChain () const
 {
@@ -46,17 +111,77 @@ GameLogic::SetChain (const Chain c)
   chain = c;
 }
 
+void
+GameLogic::SetGameId (const std::string& id)
+{
+  CHECK (gameId.empty () || gameId == id);
+  CHECK (!id.empty ());
+  gameId = id;
+}
+
+Context&
+GameLogic::GetContext ()
+{
+  CHECK (ctx != nullptr) << "No Internal callback is running at the moment";
+  return *ctx;
+}
+
+const Context&
+GameLogic::GetContext () const
+{
+  CHECK (ctx != nullptr) << "No Internal callback is running at the moment";
+  return *ctx;
+}
+
 GameStateData
 GameLogic::GetInitialState (unsigned& height, std::string& hashHex)
 {
+  CHECK (!gameId.empty ());
+
+  SHA256 rndSeed;
+  rndSeed << "initial state" << gameId;
+
+  Context context(*this, rndSeed.Finalise ());
+  ContextSetter setter(*this, context);
+
   return GetInitialStateInternal (height, hashHex);
 }
+
+namespace
+{
+
+/**
+ * Returns the RNG seed for block attaches / detaches.
+ */
+uint256
+BlockRngSeed (const std::string& gameId, const Json::Value& blockData)
+{
+  CHECK (!gameId.empty ());
+
+  const auto& blk = blockData["block"];
+  CHECK (blk.isObject ());
+  const auto& coreSeedVal = blk["rngseed"];
+  CHECK (coreSeedVal.isString ());
+
+  uint256 coreSeed;
+  CHECK (coreSeed.FromHex (coreSeedVal.asString ()));
+
+  SHA256 rndSeed;
+  rndSeed << "block" << gameId << coreSeed;
+
+  return rndSeed.Finalise ();
+}
+
+} // anonymous namespace
 
 GameStateData
 GameLogic::ProcessForward (const GameStateData& oldState,
                            const Json::Value& blockData,
                            UndoData& undoData)
 {
+  Context context(*this, BlockRngSeed (gameId, blockData));
+  ContextSetter setter(*this, context);
+
   return ProcessForwardInternal (oldState, blockData, undoData);
 }
 
@@ -65,6 +190,9 @@ GameLogic::ProcessBackwards (const GameStateData& newState,
                              const Json::Value& blockData,
                              const UndoData& undoData)
 {
+  Context context(*this, BlockRngSeed (gameId, blockData));
+  ContextSetter setter(*this, context);
+
   return ProcessBackwardsInternal (newState, blockData, undoData);
 }
 

--- a/xayagame/gamelogic.hpp
+++ b/xayagame/gamelogic.hpp
@@ -62,6 +62,12 @@ private:
    */
   Chain chain = Chain::UNKNOWN;
 
+  /**
+   * The game id of the connected game.  This is used to seed the random
+   * number generator.
+   */
+  std::string gameId;
+
 protected:
 
   /**
@@ -114,6 +120,15 @@ public:
    * during the lifetime of the object.
    */
   void SetChain (Chain c);
+
+  /**
+   * Sets the game id.  This is called by the Game instance after connecting
+   * the game rules to it.
+   *
+   * If it was already set, then it must not be changed to some other value
+   * afterwards anymore.
+   */
+  void SetGameId (const std::string& id);
 
   /**
    * Returns the initial state for the game.  This is the function that is

--- a/xayagame/gamelogic.hpp
+++ b/xayagame/gamelogic.hpp
@@ -69,7 +69,10 @@ public:
   void operator= (const Context&) = delete;
 
   /**
-   * Returns the chain that the game is running on.
+   * Returns the chain that the game is running on.  Where possible, this
+   * should be accessed through Context.  But in some situations there
+   * is no context (e.g. SQLiteGame::GetInitialStateBlock), but the chain
+   * might still be important.
    */
   Chain GetChain () const;
 
@@ -119,7 +122,7 @@ private:
 
   /**
    * The chain that the game is running on.  This may influence the rules
-   * and is provided via GetChain.
+   * and is provided via the Context.
    */
   Chain chain = Chain::UNKNOWN;
 

--- a/xayagame/gamelogic_tests.cpp
+++ b/xayagame/gamelogic_tests.cpp
@@ -59,6 +59,11 @@ protected:
   /** The stack of undo data for the simulated blockchain.  */
   std::stack<UndoData> undoStack;
 
+  CachingGameTests ()
+  {
+    game.SetGameId ("replacing game");
+  }
+
   /**
    * Processes the state forward using game and the simulated blockchain.
    */
@@ -90,6 +95,10 @@ protected:
   static Json::Value
   Move (const std::string& value)
   {
+    Json::Value block(Json::objectValue);
+    block["rngseed"]
+        = "0000000000000000000000000000000000000000000000000000000000000001";
+
     Json::Value move(Json::objectValue);
     move["move"] = value;
 
@@ -97,6 +106,7 @@ protected:
     moves.append (move);
 
     Json::Value data(Json::objectValue);
+    data["block"] = block;
     data["moves"] = moves;
 
     return data;
@@ -108,7 +118,12 @@ protected:
   static Json::Value
   NoMove ()
   {
+    Json::Value block(Json::objectValue);
+    block["rngseed"]
+        = "0000000000000000000000000000000000000000000000000000000000000001";
+
     Json::Value data(Json::objectValue);
+    data["block"] = block;
     data["moves"] = Json::Value (Json::arrayValue);
     return data;
   }

--- a/xayagame/gamelogic_tests.cpp
+++ b/xayagame/gamelogic_tests.cpp
@@ -6,6 +6,8 @@
 
 #include "storage.hpp"
 
+#include "testutils.hpp"
+
 #include <json/json.h>
 
 #include <gtest/gtest.h>
@@ -18,6 +20,81 @@ namespace xaya
 {
 namespace
 {
+
+constexpr const char GAME_ID[] = "test game";
+
+/**
+ * Fixture class with a simulated blockchain for verifying basic working
+ * of GameLogic instances without the need to have a real Game instance.
+ */
+template <typename G>
+  class GameLogicFixture : public testing::Test
+{
+
+protected:
+
+  G game;
+
+  /** The current game state in the simulated blockchain.  */
+  GameStateData state;
+  /** The stack of block data that has been attached.  */
+  std::stack<Json::Value> blockStack;
+  /** The stack of undo data for the simulated blockchain.  */
+  std::stack<UndoData> undoStack;
+
+  GameLogicFixture ()
+  {
+    game.SetGameId (GAME_ID);
+
+    unsigned dummyHeight;
+    std::string dummyHashHex;
+    state = game.GetInitialState (dummyHeight, dummyHashHex);
+  }
+
+  /**
+   * Processes the state forward using game and the simulated blockchain.
+   */
+  void
+  AttachBlock (const Json::Value& moves)
+  {
+    Json::Value blk(Json::objectValue);
+    blk["rngseed"] = BlockHash (blockStack.size ()).ToHex ();
+
+    Json::Value blockData(Json::objectValue);
+    blockData["block"] = blk;
+    blockData["moves"] = moves;
+
+    blockStack.push (blockData);
+
+    UndoData undo;
+    state = game.ProcessForward (state, blockData, undo);
+    undoStack.push (undo);
+  }
+
+  /**
+   * Processes the state backwards using game and our simulated blockchain.
+   */
+  void
+  DetachBlock ()
+  {
+    state = game.ProcessBackwards (state, blockStack.top (), undoStack.top ());
+
+    undoStack.pop ();
+    blockStack.pop ();
+  }
+
+  /**
+   * Constructs a moves array that has no actual data.
+   */
+  static Json::Value
+  NoMove ()
+  {
+    return Json::Value (Json::arrayValue);
+  }
+
+};
+
+/* ************************************************************************** */
 
 /**
  * A very simple game implemented using CachingGame:  The state is just a string
@@ -40,92 +117,29 @@ protected:
   GameStateData
   GetInitialStateInternal (unsigned& height, std::string& hashHex) override
   {
-    LOG (FATAL) << "This should not be called by the test";
+    return "";
   }
 
 };
 
-class CachingGameTests : public testing::Test
+class CachingGameTests : public GameLogicFixture<ReplacingGame>
 {
 
 protected:
 
-  ReplacingGame game;
-
-  /** The current game state in the simulated blockchain.  */
-  GameStateData state;
-  /** The stack of block data that has been attached.  */
-  std::stack<Json::Value> blockStack;
-  /** The stack of undo data for the simulated blockchain.  */
-  std::stack<UndoData> undoStack;
-
-  CachingGameTests ()
-  {
-    game.SetGameId ("replacing game");
-  }
-
   /**
-   * Processes the state forward using game and the simulated blockchain.
-   */
-  void
-  AttachBlock (const Json::Value& blockData)
-  {
-    blockStack.push (blockData);
-
-    UndoData undo;
-    state = game.ProcessForward (state, blockData, undo);
-    undoStack.push (undo);
-  }
-
-  /**
-   * Processes the state backwards using game and our simulated blockchain.
-   */
-  void
-  DetachBlock ()
-  {
-    state = game.ProcessBackwards (state, blockStack.top (), undoStack.top ());
-
-    undoStack.pop ();
-    blockStack.pop ();
-  }
-
-  /**
-   * Constructs blockdata that sets the given new string as "move".
+   * Constructs a move array that sets the given value.
    */
   static Json::Value
   Move (const std::string& value)
   {
-    Json::Value block(Json::objectValue);
-    block["rngseed"]
-        = "0000000000000000000000000000000000000000000000000000000000000001";
-
     Json::Value move(Json::objectValue);
     move["move"] = value;
 
     Json::Value moves(Json::arrayValue);
     moves.append (move);
 
-    Json::Value data(Json::objectValue);
-    data["block"] = block;
-    data["moves"] = moves;
-
-    return data;
-  }
-
-  /**
-   * Constructs blockdata that has no move (no change to state).
-   */
-  static Json::Value
-  NoMove ()
-  {
-    Json::Value block(Json::objectValue);
-    block["rngseed"]
-        = "0000000000000000000000000000000000000000000000000000000000000001";
-
-    Json::Value data(Json::objectValue);
-    data["block"] = block;
-    data["moves"] = Json::Value (Json::arrayValue);
-    return data;
+    return moves;
   }
 
 };
@@ -153,6 +167,8 @@ TEST_F (CachingGameTests, Works)
   EXPECT_TRUE (blockStack.empty ());
   EXPECT_EQ (state, "");
 }
+
+/* ************************************************************************** */
 
 } // anonymous namespace
 } // namespace xaya

--- a/xayagame/gamelogic_tests.cpp
+++ b/xayagame/gamelogic_tests.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018 The Xaya developers
+// Copyright (C) 2018-2019 The Xaya developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -37,10 +37,8 @@ protected:
     return blockData["moves"][0]["move"].asString ();
   }
 
-public:
-
   GameStateData
-  GetInitialState (unsigned& height, std::string& hashHex) override
+  GetInitialStateInternal (unsigned& height, std::string& hashHex) override
   {
     LOG (FATAL) << "This should not be called by the test";
   }

--- a/xayagame/hash.cpp
+++ b/xayagame/hash.cpp
@@ -1,0 +1,98 @@
+// Copyright (C) 2019 The Xaya developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "hash.hpp"
+
+#include <glog/logging.h>
+
+#include <openssl/sha.h>
+
+#include <cstddef>
+
+namespace xaya
+{
+
+/**
+ * The actual implementation for the SHA256 state.  This is just a wrapper
+ * around OpenSSL's SHA256_CTX.
+ */
+class SHA256::State
+{
+
+private:
+
+  /** The underlying OpenSSL SHA256 state.  */
+  SHA256_CTX ctx;
+
+public:
+
+  State ();
+
+  State (const State&) = delete;
+  void operator= (const State&) = delete;
+
+  void Update (const unsigned char* data, size_t len);
+  void Finalise (unsigned char* out);
+
+};
+
+SHA256::State::State ()
+{
+  SHA256_Init (&ctx);
+}
+
+void
+SHA256::State::Update (const unsigned char* data, const size_t len)
+{
+  SHA256_Update (&ctx, data, len);
+}
+
+void
+SHA256::State::Finalise (unsigned char* out)
+{
+  SHA256_Final (out, &ctx);
+}
+
+SHA256::SHA256 ()
+{
+  state = std::make_unique<State> ();
+}
+
+SHA256::~SHA256 () = default;
+
+SHA256&
+SHA256::operator<< (const std::string& data)
+{
+  CHECK (state != nullptr);
+  state->Update (reinterpret_cast<const unsigned char*> (&data[0]),
+                 data.size ());
+  return *this;
+}
+
+SHA256&
+SHA256::operator<< (const uint256& data)
+{
+  CHECK (state != nullptr);
+  state->Update (data.GetBlob (), uint256::NUM_BYTES);
+  return *this;
+}
+
+uint256
+SHA256::Finalise ()
+{
+  static_assert (SHA256_DIGEST_LENGTH == uint256::NUM_BYTES,
+                 "uint256 is not a valid output for SHA-256");
+
+  CHECK (state != nullptr);
+
+  unsigned char data[SHA256_DIGEST_LENGTH];
+  state->Finalise (data);
+
+  uint256 res;
+  res.FromBlob (data);
+
+  return res;
+}
+
+} // namespace xaya

--- a/xayagame/hash.hpp
+++ b/xayagame/hash.hpp
@@ -1,0 +1,58 @@
+// Copyright (C) 2019 The Xaya developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef XAYAGAME_HASH_HPP
+#define XAYAGAME_HASH_HPP
+
+#include "uint256.hpp"
+
+#include <memory>
+#include <string>
+
+namespace xaya
+{
+
+/**
+ * Utility class to hash data using SHA-256.  This is used for random numbers
+ * in libxayagame, but may also be used for games directly e.g. to implement
+ * hash commitments.
+ */
+class SHA256
+{
+
+private:
+
+  /**
+   * Holder for the internal state.  This is not exposed here in the header,
+   * so that the dependency on the underlying library (e.g. OpenSSL) is
+   * kept as a pure implementation detail.
+   */
+  class State;
+
+  /** The underlying current state of the hasher.  */
+  std::unique_ptr<State> state;
+
+public:
+
+  SHA256 ();
+  ~SHA256 ();
+
+  SHA256 (const SHA256&) = delete;
+  void operator= (const SHA256&) = delete;
+
+  SHA256& operator<< (const std::string& data);
+  SHA256& operator<< (const uint256& data);
+
+  /**
+   * Finalises the hash and returns the resulting value as uint256.  After
+   * this function has been called, no more operations on the SHA256 instance
+   * are allowed.
+   */
+  uint256 Finalise ();
+
+};
+
+} // namespace xaya
+
+#endif // XAYAGAME_HASH_HPP

--- a/xayagame/hash_tests.cpp
+++ b/xayagame/hash_tests.cpp
@@ -1,0 +1,51 @@
+// Copyright (C) 2019 The Xaya developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "hash.hpp"
+
+#include <gtest/gtest.h>
+
+namespace xaya
+{
+namespace
+{
+
+class SHA256Tests : public testing::Test
+{
+
+protected:
+
+  SHA256 hasher;
+
+};
+
+TEST_F (SHA256Tests, Empty)
+{
+  EXPECT_EQ (hasher.Finalise ().ToHex (),
+     "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
+}
+
+TEST_F (SHA256Tests, NonEmpty)
+{
+  uint256 someData;
+  ASSERT_TRUE (someData.FromHex (
+      "2e773fdbfcb9e80875ce3f2f44a4d17fd9d6a62023cad54bc79f394403e6a6ab"));
+
+  hasher << "foo";
+  hasher << "";
+  hasher << someData;
+  hasher << "";
+  hasher << "bar";
+
+  /* Total data that is being hashed (in hex):
+      666f6f
+      2e773fdbfcb9e80875ce3f2f44a4d17fd9d6a62023cad54bc79f394403e6a6ab
+      626172
+  */
+  EXPECT_EQ (hasher.Finalise ().ToHex (),
+      "bdd7344649494d3f16b5c3bbc9989efe64bba2ce0651d6980aab2f12cef4fb0d");
+}
+
+} // anonymous namespace
+} // namespace xaya

--- a/xayagame/random.cpp
+++ b/xayagame/random.cpp
@@ -1,0 +1,89 @@
+// Copyright (C) 2019 The Xaya developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "random.hpp"
+
+#include "hash.hpp"
+
+#include <glog/logging.h>
+
+#include <cstdint>
+
+namespace xaya
+{
+
+Random::Random ()
+{
+  seed.SetNull ();
+}
+
+void
+Random::Seed (const uint256& s)
+{
+  seed = s;
+  nextIndex = 0;
+}
+
+template <>
+  unsigned char
+  Random::Next<unsigned char> ()
+{
+  CHECK (!seed.IsNull ()) << "Random instance has not been seeded";
+
+  CHECK_LE (nextIndex, uint256::NUM_BYTES);
+  if (nextIndex == uint256::NUM_BYTES)
+    {
+      SHA256 hasher;
+      hasher << seed;
+      seed = hasher.Finalise ();
+      nextIndex = 0;
+    }
+
+  const unsigned char* data = seed.GetBlob ();
+  return data[nextIndex++];
+}
+
+namespace
+{
+
+/**
+ * Requests two "lower bit" integers from the Random instance and combines
+ * them to one integer with double the number of bits.  The two numbers are
+ * combined in a big-endian fashion.
+ */
+template <typename T, typename Half, unsigned HalfBits>
+  T
+  CombineHalfInts (Random& rnd)
+{
+  T res = rnd.Next<Half> ();
+  res <<= HalfBits;
+  res |= rnd.Next<Half> ();
+
+  return res;
+}
+
+} // anonymous namespace
+
+template <>
+  uint16_t
+  Random::Next<uint16_t> ()
+{
+  return CombineHalfInts<uint16_t, unsigned char, 8> (*this);
+}
+
+template <>
+  uint32_t
+  Random::Next<uint32_t> ()
+{
+  return CombineHalfInts<uint32_t, uint16_t, 16> (*this);
+}
+
+template <>
+  uint64_t
+  Random::Next<uint64_t> ()
+{
+  return CombineHalfInts<uint64_t, uint32_t, 32> (*this);
+}
+
+} // namespace xaya

--- a/xayagame/random.hpp
+++ b/xayagame/random.hpp
@@ -1,0 +1,58 @@
+// Copyright (C) 2019 The Xaya developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef XAYAGAME_RANDOM_HPP
+#define XAYAGAME_RANDOM_HPP
+
+#include "uint256.hpp"
+
+namespace xaya
+{
+
+/**
+ * Handle for generating deterministic "random" numbers based off an
+ * initial seed.
+ */
+class Random
+{
+
+private:
+
+  /**
+   * The current state / seed.  The bytes of the seed are given out one by
+   * one as random numbers.  When it runs out, then a next seed is computed
+   * by hashing the previous one.
+   */
+  uint256 seed;
+
+  /** Index of the next byte to give out for the current seed.  */
+  unsigned nextIndex;
+
+public:
+
+  /**
+   * Constructs an empty instance that is not yet seeded.  It must not be
+   * used to extract any random bytes before Seed() has been called.
+   */
+  Random ();
+
+  Random (const Random&) = delete;
+  void operator= (const Random&) = delete;
+
+  /**
+   * Sets / replaces the seed with the given value.
+   */
+  void Seed (const uint256& s);
+
+  /**
+   * Extracts the next byte or perhaps other type (e.g. uint32_t).
+   */
+  template <typename T>
+    T Next ();
+
+};
+
+} // namespace xaya
+
+#endif // XAYAGAME_RANDOM_HPP

--- a/xayagame/random_tests.cpp
+++ b/xayagame/random_tests.cpp
@@ -1,0 +1,68 @@
+// Copyright (C) 2019 The Xaya developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "random.hpp"
+
+#include <gtest/gtest.h>
+
+#include <glog/logging.h>
+
+namespace xaya
+{
+namespace
+{
+
+/** The seed (as hex string) that we use in tests.  */
+constexpr const char SEED[]
+    = "7ca22c1665349f6c2cf40c7f7923e18184bbf3baa2b4096bee511b7a7eaf87e8";
+
+/**
+ * The test fixture class for Random seeds the instance with a predetermined
+ * seed.  We then also expect that the resulting random numbers match exactly
+ * given golden values.  This is so that we notice any changes that affect
+ * the generation of random numbers, as those changes would be consensus
+ * critical for any games relying on Random.
+ */
+class RandomTests : public testing::Test
+{
+
+protected:
+
+  Random rnd;
+
+  RandomTests ()
+  {
+    uint256 seed;
+    CHECK (seed.FromHex (SEED));
+    rnd.Seed (seed);
+  }
+
+};
+
+TEST_F (RandomTests, Bytes)
+{
+  const uint8_t expectedBytes[] = {
+    /* This is the seed itself.  */
+    0x7c, 0xa2, 0x2c, 0x16, 0x65, 0x34, 0x9f, 0x6c,
+    0x2c, 0xf4, 0x0c, 0x7f, 0x79, 0x23, 0xe1, 0x81,
+    0x84, 0xbb, 0xf3, 0xba, 0xa2, 0xb4, 0x09, 0x6b,
+    0xee, 0x51, 0x1b, 0x7a, 0x7e, 0xaf, 0x87, 0xe8,
+
+    /* Some following bytes based on correct "re-seeding".  */
+    0x67, 0xd8, 0x11, 0xd6, 0x7f, 0xfb, 0x76, 0x45,
+  };
+
+  for (const auto b : expectedBytes)
+    ASSERT_EQ (rnd.Next<uint8_t> (), b);
+}
+
+TEST_F (RandomTests, Integers)
+{
+  ASSERT_EQ (rnd.Next<uint16_t> (), 0x7ca2);
+  ASSERT_EQ (rnd.Next<uint32_t> (), 0x2c166534);
+  ASSERT_EQ (rnd.Next<uint64_t> (), 0x9f6c2cf40c7f7923);
+}
+
+} // anonymous namespace
+} // namespace xaya

--- a/xayagame/sqlitegame.cpp
+++ b/xayagame/sqlitegame.cpp
@@ -249,7 +249,7 @@ SQLiteGame::GetStorage ()
 }
 
 GameStateData
-SQLiteGame::GetInitialState (unsigned& height, std::string& hashHex)
+SQLiteGame::GetInitialStateInternal (unsigned& height, std::string& hashHex)
 {
   GetInitialStateBlock (height, hashHex);
   return INITIAL_STATE;
@@ -319,9 +319,9 @@ public:
 } // anonymous namespace
 
 GameStateData
-SQLiteGame::ProcessForward (const GameStateData& oldState,
-                            const Json::Value& blockData,
-                            UndoData& undo)
+SQLiteGame::ProcessForwardInternal (const GameStateData& oldState,
+                                    const Json::Value& blockData,
+                                    UndoData& undo)
 {
   database->EnsureCurrentState (oldState);
 
@@ -402,9 +402,9 @@ public:
 } // anonymous namespace
 
 GameStateData
-SQLiteGame::ProcessBackwards (const GameStateData& newState,
-                              const Json::Value& blockData,
-                              const UndoData& undo)
+SQLiteGame::ProcessBackwardsInternal (const GameStateData& newState,
+                                      const Json::Value& blockData,
+                                      const UndoData& undo)
 {
   database->EnsureCurrentState (newState);
 

--- a/xayagame/sqlitegame.hpp
+++ b/xayagame/sqlitegame.hpp
@@ -141,6 +141,17 @@ protected:
       const Game& game, const std::string& jsonField,
       const std::function<Json::Value (sqlite3*)>& cb);
 
+  GameStateData GetInitialStateInternal (unsigned& height,
+                                         std::string& hashHex) override;
+
+  GameStateData ProcessForwardInternal (const GameStateData& oldState,
+                                        const Json::Value& blockData,
+                                        UndoData& undo) override;
+
+  GameStateData ProcessBackwardsInternal (const GameStateData& newState,
+                                          const Json::Value& blockData,
+                                          const UndoData& undo) override;
+
 public:
 
   /** Type for automatically generated IDs.  */
@@ -161,17 +172,6 @@ public:
    * as main storage in Game.
    */
   StorageInterface* GetStorage ();
-
-  GameStateData GetInitialState (unsigned& height,
-                                 std::string& hashHex) override;
-
-  GameStateData ProcessForward (const GameStateData& oldState,
-                                const Json::Value& blockData,
-                                UndoData& undo) override;
-
-  GameStateData ProcessBackwards (const GameStateData& newState,
-                                  const Json::Value& blockData,
-                                  const UndoData& undo) override;
 
   Json::Value GameStateToJson (const GameStateData& state) override;
 

--- a/xayagame/testutils.cpp
+++ b/xayagame/testutils.cpp
@@ -46,6 +46,7 @@ GameTestFixture::CallBlockAttach (Game& g, const std::string& reqToken,
   block["hash"] = blockHash.ToHex ();
   block["parent"] = parentHash.ToHex ();
   block["height"] = height;
+  block["rngseed"] = blockHash.ToHex ();
 
   Json::Value data(Json::objectValue);
   if (!reqToken.empty ())
@@ -68,6 +69,7 @@ GameTestFixture::CallBlockDetach (Game& g, const std::string& reqToken,
   block["hash"] = blockHash.ToHex ();
   block["parent"] = parentHash.ToHex ();
   block["height"] = height;
+  block["rngseed"] = blockHash.ToHex ();
 
   Json::Value data(Json::objectValue);
   if (!reqToken.empty ())


### PR DESCRIPTION
Introduce a `Context` that provides data while `GameLogic` callbacks are running.  In particular, it gives access to a new utility instance `Random`, which can be used to get random numbers seeded already based on the current block (or specially for the initial state).

This also changes the callbacks themselves to be `protected` and named `GetInitialStateInternal`, `ProcessForwardInternal` and `ProcessBackwardsInternal`.  The non-`Internal` versions are now implemented in `GameLogic` directly and handle management of the context before calling through to the real callbacks.