### PR TITLE
Remove support for plain TCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,8 @@ for the configuration and/or build to be successful:
   Available for Debian-based operating systems in the `libjsoncpp-dev`
   package.
 - [`jsonrpccpp`](https://github.com/cinemast/libjson-rpc-cpp/):
-  The packages `libjsonrpccpp-dev` and `libjsonrpccpp-tools` on
-  Debian 9 "Stretch" are not suitable.  Instead, build from source
-  and make sure to configure with `-DTCP_SOCKET_SERVER_SERVER=YES`.
+  For Debian, the packages `libjsonrpccpp-dev` and `libjsonrpccpp-tools`
+  can be installed.
 - [`ZeroMQ C++ bindings`](http://zeromq.org/bindings:cpp):
   Available in the Debian package `libzmq3-dev`.
 - [SQLite3](https://www.sqlite.org/) with the

--- a/xayagame/defaultmain.cpp
+++ b/xayagame/defaultmain.cpp
@@ -10,7 +10,6 @@
 #include "sqlitestorage.hpp"
 
 #include <jsonrpccpp/client/connectors/httpclient.h>
-#include <jsonrpccpp/server/connectors/tcpsocketserver.h>
 #include <jsonrpccpp/server/connectors/httpserver.h>
 
 #include <glog/logging.h>
@@ -92,14 +91,6 @@ CreateRpcServerConnector (const GameDaemonConfiguration& config)
       LOG (INFO)
           << "Starting JSON-RPC HTTP server at port " << config.GameRpcPort;
       return std::make_unique<jsonrpc::HttpServer> (config.GameRpcPort);
-
-    case RpcServerType::TCP:
-      CHECK (config.GameRpcPort != 0)
-          << "GameRpcPort must be specified for TCP server type";
-      LOG (INFO)
-          << "Starting JSON-RPC TCP server at port " << config.GameRpcPort;
-      return std::make_unique<jsonrpc::TcpSocketServer> ("127.0.0.1",
-                                                         config.GameRpcPort);
     }
 
   LOG (FATAL)

--- a/xayagame/defaultmain.hpp
+++ b/xayagame/defaultmain.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018 The Xaya developers
+// Copyright (C) 2018-2019 The Xaya developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -25,8 +25,6 @@ enum class RpcServerType
   NONE = 0,
   /** Start a JSON-RPC server listening through HTTP.  */
   HTTP = 1,
-  /** Start a JSON-RPC server listening through a plain TCP socket.  */
-  TCP = 2,
 };
 
 /**


### PR DESCRIPTION
Remove the support for starting a JSON-RPC server with plain TCP (not HTTP) from the `DefaultMain`.  HTTP is better anyway, and with that, we can use the default Debian packages for `libjsonrpccpp`.

See #31.