### PR TITLE
Add DefaultMain for SQLite-based games

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2018 The Xaya developers
+Copyright (c) 2018-2019 The Xaya developers
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/xayagame/defaultmain.hpp
+++ b/xayagame/defaultmain.hpp
@@ -5,11 +5,15 @@
 #ifndef XAYAGAME_DEFAULTMAIN_HPP
 #define XAYAGAME_DEFAULTMAIN_HPP
 
+#include "game.hpp"
 #include "gamelogic.hpp"
 #include "storage.hpp"
 
+#include <jsonrpccpp/server/connectors/httpserver.h>
+
 #include <json/json.h>
 
+#include <memory>
 #include <string>
 
 namespace xaya
@@ -25,6 +29,96 @@ enum class RpcServerType
   NONE = 0,
   /** Start a JSON-RPC server listening through HTTP.  */
   HTTP = 1,
+};
+
+/**
+ * Interace for a class that runs the game's RPC server.  We need this mainly
+ * since the server classes from jsonrpccpp do not inherit from a single
+ * super class which we could use instead.
+ */
+class RpcServerInterface
+{
+
+protected:
+
+  RpcServerInterface () = default;
+
+public:
+
+  virtual ~RpcServerInterface () = default;
+
+  RpcServerInterface (const RpcServerInterface&) = delete;
+  void operator=  (const RpcServerInterface&) = delete;
+
+  /**
+   * Starts listening on the server.
+   */
+  virtual void StartListening () = 0;
+
+  /**
+   * Stops listening in the server.
+   */
+  virtual void StopListening () = 0;
+
+};
+
+/**
+ * Simple implementation of RpcServerInterface, that simply wraps a templated
+ * actual server class.
+ */
+template <typename T>
+  class WrappedRpcServer : public RpcServerInterface
+{
+
+private:
+
+  T server;
+
+public:
+
+  template <typename... Args>
+    WrappedRpcServer (Args&... args)
+    : server(args...)
+  {}
+
+  void
+  StartListening () override
+  {
+    server.StartListening ();
+  }
+
+  void
+  StopListening () override
+  {
+    server.StopListening ();
+  }
+
+};
+
+/**
+ * Factory interface for constructing instances of classes that are not
+ * required to be provided (like the GameLogic), but can optionally be
+ * customised by games.  An example of such a class is the RPC server.
+ */
+class CustomisedInstanceFactory
+{
+
+public:
+
+  CustomisedInstanceFactory () = default;
+  virtual ~CustomisedInstanceFactory () = default;
+
+  CustomisedInstanceFactory (const CustomisedInstanceFactory&) = delete;
+  void operator= (const CustomisedInstanceFactory&) = delete;
+
+  /**
+   * Returns an instance of the RPC server that should be used for the game.
+   * By default, this method builds a standard GameRpcServer.
+   */
+  std::unique_ptr<RpcServerInterface> BuildRpcServer (
+      Game& game,
+      jsonrpc::AbstractServerConnector& conn);
+
 };
 
 /**
@@ -75,6 +169,15 @@ struct GameDaemonConfiguration
    * data directory.
    */
   std::string DataDirectory;
+
+  /**
+   * Factory class for customed instances of certain optional classes
+   * like the RPC server.  If not set, default classes are used instead.
+   *
+   * The pointer here is just a pointer and not owned by the struct.  It must
+   * be managed outside of the DefaultMain call.
+   */
+  CustomisedInstanceFactory* InstanceFactory = nullptr;
 
 };
 

--- a/xayagame/defaultmain.hpp
+++ b/xayagame/defaultmain.hpp
@@ -7,6 +7,7 @@
 
 #include "game.hpp"
 #include "gamelogic.hpp"
+#include "sqlitegame.hpp"
 #include "storage.hpp"
 
 #include <jsonrpccpp/server/connectors/httpserver.h>
@@ -115,7 +116,7 @@ public:
    * Returns an instance of the RPC server that should be used for the game.
    * By default, this method builds a standard GameRpcServer.
    */
-  std::unique_ptr<RpcServerInterface> BuildRpcServer (
+  virtual std::unique_ptr<RpcServerInterface> BuildRpcServer (
       Game& game,
       jsonrpc::AbstractServerConnector& conn);
 
@@ -195,6 +196,18 @@ struct GameDaemonConfiguration
 int DefaultMain (const GameDaemonConfiguration& config,
                  const std::string& gameId,
                  GameLogic& rules);
+
+/**
+ * Runs a default main function for SQLite-based Xaya game daemons.  The
+ * details of the started game daemon can be configured through the config
+ * struct's values.
+ *
+ * Note that this function always ignores config.StorageType and instead
+ * uses "sqlite".
+ */
+int SQLiteMain (const GameDaemonConfiguration& config,
+                const std::string& gameId,
+                SQLiteGame& rules);
 
 /**
  * Struct that holds function pointers for implementations of the

--- a/xayagame/sqlitegame.hpp
+++ b/xayagame/sqlitegame.hpp
@@ -160,12 +160,21 @@ public:
   /** Value for a "missing" ID.  */
   static constexpr IdT EMPTY_ID = 0;
 
-  explicit SQLiteGame (const std::string& f);
+  /**
+   * Constructs an instance which is not yet connected to an actual database.
+   * It has to be Initialise()'ed before it can be used.
+   */
+  SQLiteGame ();
+
   virtual ~SQLiteGame ();
 
-  SQLiteGame () = delete;
   SQLiteGame (const SQLiteGame&) = delete;
   void operator= (const SQLiteGame&) = delete;
+
+  /**
+   * Initialises the game by opening the given database file.
+   */
+  void Initialise (const std::string& dbFile);
 
   /**
    * Returns the storage implementation used internally, which should be set

--- a/xayagame/sqlitegame_tests.cpp
+++ b/xayagame/sqlitegame_tests.cpp
@@ -104,13 +104,10 @@ protected:
     hashHex = GenesisHash ().ToHex ();
   }
 
-  explicit TestGame (const std::string& f)
-    : SQLiteGame (f)
-  {}
+  TestGame () = default;
 
 public:
 
-  TestGame () = delete;
   TestGame (const TestGame&) = delete;
   void operator= (const TestGame&) = delete;
 
@@ -233,9 +230,7 @@ public:
    */
   using MoveSet = std::vector<std::pair<std::string, std::string>>;
 
-  explicit ChatGame (const std::string& f)
-    : TestGame (f)
-  {}
+  ChatGame () = default;
 
   /**
    * Expects that the current game state (corresponding to the given
@@ -315,8 +310,10 @@ protected:
 
   SQLiteGameTests ()
     : GameTestWithBlockchain(GAME_ID),
-      game(GAME_ID), rules(":memory:")
+      game(GAME_ID)
   {
+    rules.Initialise (":memory:");
+
     SetStartingBlock (GenesisHash ());
 
     game.SetStorage (rules.GetStorage ());
@@ -540,7 +537,9 @@ protected:
   void
   CreateChatGame ()
   {
-    rules = std::make_unique<ChatGame> (filename);
+    rules = std::make_unique<ChatGame> ();
+    rules->Initialise (filename);
+
     game.SetStorage (rules->GetStorage ());
     game.SetGameLogic (rules.get ());
   }
@@ -715,9 +714,7 @@ public:
    */
   using MoveSet = std::vector<std::string>;
 
-  explicit InsertGame (const std::string& f)
-    : TestGame (f)
-  {}
+  InsertGame () = default;
 
   /**
    * Expects that the current game state (corresponding to the given


### PR DESCRIPTION
This set of changes adds a new function `SQLiteMain`, which is similar to `DefaultMain` except for `SQLiteGame`-based games.  They also allow the optional configuration of custom RPC server instances for use with the default main functions.