### PR TITLE
Expose and verify the connected Xaya Core version

### DIFF
--- a/xayagame/defaultmain.cpp
+++ b/xayagame/defaultmain.cpp
@@ -116,6 +116,19 @@ CreateRpcServerConnector (const GameDaemonConfiguration& config)
       << static_cast<int> (config.GameRpcServer);
 }
 
+/**
+ * Checks the Xaya Core version against the minimum and maximum versions
+ * defined in the configuration.
+ */
+void
+VerifyXayaVersion (const GameDaemonConfiguration& config, const unsigned v)
+{
+  LOG (INFO) << "Connected to Xaya Core version " << v;
+  CHECK_GE (v, config.MinXayaVersion) << "Xaya Core is too old";
+  if (config.MaxXayaVersion > 0)
+    CHECK_LE (v, config.MaxXayaVersion) << "Xaya Core is too new";
+}
+
 } // anonymous namespace
 
 int
@@ -138,6 +151,7 @@ DefaultMain (const GameDaemonConfiguration& config, const std::string& gameId,
 
       auto game = std::make_unique<Game> (gameId);
       game->ConnectRpcClient (httpConnector);
+      VerifyXayaVersion (config, game->GetXayaVersion ());
       CHECK (game->DetectZmqEndpoint ());
 
       std::unique_ptr<StorageInterface> storage
@@ -202,6 +216,7 @@ SQLiteMain (const GameDaemonConfiguration& config, const std::string& gameId,
 
       auto game = std::make_unique<Game> (gameId);
       game->ConnectRpcClient (httpConnector);
+      VerifyXayaVersion (config, game->GetXayaVersion ());
       CHECK (game->DetectZmqEndpoint ());
 
       const fs::path gameDir = GetGameDirectory (config, gameId,

--- a/xayagame/defaultmain.hpp
+++ b/xayagame/defaultmain.hpp
@@ -139,6 +139,20 @@ struct GameDaemonConfiguration
   std::string XayaRpcUrl;
 
   /**
+   * The minimum required Xaya Core version.  By default, this is Xaya Core 1.1,
+   * where the ZMQ interface for games was introduced.
+   */
+  unsigned MinXayaVersion = 1010000;
+
+  /**
+   * The maximum possible Xaya Core version.  If zero (the default), then
+   * no maximum version is imposed.  This can be set for instance if
+   * incompatible changes to the ZMQ interface are made in the future, and
+   * the old game daemon needs to be updated to work with newer Xaya Core.
+   */
+  unsigned MaxXayaVersion = 0;
+
+  /**
    * The type of JSON-RPC server that should be started for the game
    * (if any).
    */

--- a/xayagame/game.cpp
+++ b/xayagame/game.cpp
@@ -345,6 +345,20 @@ Game::ConnectRpcClient (jsonrpc::IClientConnector& conn)
     rules->SetChain (chain);
 }
 
+unsigned
+Game::GetXayaVersion () const
+{
+  std::lock_guard<std::mutex> lock(mut);
+  CHECK (rpcClient != nullptr);
+
+  const auto info = rpcClient->getnetworkinfo ();
+  CHECK (info.isObject ());
+  const auto& version = info["version"];
+  CHECK (version.isUInt ());
+
+  return version.asUInt ();
+}
+
 Chain
 Game::GetChain () const
 {

--- a/xayagame/game.hpp
+++ b/xayagame/game.hpp
@@ -243,6 +243,16 @@ public:
   void ConnectRpcClient (jsonrpc::IClientConnector& conn);
 
   /**
+   * Returns the version of the connected Xaya Core daemon in the form
+   * AABBCCDD, where AA is the major version, BB the minor version, CC the
+   * revision and DD the build.  For instance, 1020300 would be Xaya Core
+   * 1.2.3.
+   *
+   * This method CHECK fails if the RPC connection has not yet been set up.
+   */
+  unsigned GetXayaVersion () const;
+
+  /**
    * Returns the chain (network) type as enum of the
    * connected Xaya daemon.  This can be used to set up the storage database
    * correctly, for instance.  Must not be called before ConnectRpcClient.

--- a/xayagame/game_tests.cpp
+++ b/xayagame/game_tests.cpp
@@ -99,6 +99,7 @@ public:
        should explicitly be specified in the individual tests.  */
     EXPECT_CALL (*this, getzmqnotifications ()).Times (0);
     EXPECT_CALL (*this, trackedgames (_, _)).Times (0);
+    EXPECT_CALL (*this, getnetworkinfo ()).Times (0);
     EXPECT_CALL (*this, getblockhash (_)).Times (0);
     EXPECT_CALL (*this, getblockheader (_)).Times (0);
     EXPECT_CALL (*this, game_sendupdates (_, _)).Times (0);
@@ -107,6 +108,7 @@ public:
   MOCK_METHOD0 (getzmqnotifications, Json::Value ());
   MOCK_METHOD2 (trackedgames, void (const std::string& command,
                                     const std::string& gameid));
+  MOCK_METHOD0 (getnetworkinfo, Json::Value ());
   MOCK_METHOD1 (getblockhash, std::string (int height));
   MOCK_METHOD1 (getblockheader, Json::Value (const std::string& hash));
   MOCK_METHOD2 (game_sendupdates, Json::Value (const std::string& fromblock,
@@ -374,6 +376,22 @@ protected:
   }
 
 };
+
+/* ************************************************************************** */
+
+using XayaVersionTests = GameTests;
+
+TEST_F (XayaVersionTests, Works)
+{
+  Json::Value networkInfo(Json::objectValue);
+  networkInfo["version"] = 1020300;
+  EXPECT_CALL (mockXayaServer, getnetworkinfo ())
+      .WillOnce (Return (networkInfo));
+
+  Game g(GAME_ID);
+  g.ConnectRpcClient (httpClient);
+  EXPECT_EQ (g.GetXayaVersion (), 1020300);
+}
 
 /* ************************************************************************** */
 

--- a/xayagame/rpc-stubs/xaya.json
+++ b/xayagame/rpc-stubs/xaya.json
@@ -13,6 +13,11 @@
       }
   },
   {
+    "name": "getnetworkinfo",
+    "params": {},
+    "returns": {}
+  },
+  {
     "name": "getblockchaininfo",
     "params": {},
     "returns": {}


### PR DESCRIPTION
This adds a new method `Game::GetXayaVersion`, which exposes the version of the connected Xaya Core daemon.  The default mains (`DefaultMain` and `SQLiteMain`) use that to verify that the version is within a configured range of admissible Xaya versions for the game.

This makes it possible to gracefully handle situations where the Xaya ZMQ interface or other features are changed in the future and games may depend on newer features.