### PR TITLE
Allow specifying bind address for the game RPC server

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,10 @@ your system, respectively.
 for the configuration and/or build to be successful:
 
 - [`libjsoncpp`](https://github.com/open-source-parsers/jsoncpp):
-  Available for Debian-based operating systems in the `libjsoncpp-dev`
-  package.
+  The Debian package `libjsoncpp-dev` is not fresh enough, so it needs
+  to be built from source.  In particular, it must be a version that
+  includes the commit
+  [`f013753b122d43e364f6d6039a38e5c54e65306e`](https://github.com/cinemast/libjson-rpc-cpp/pull/259).
 - [`jsonrpccpp`](https://github.com/cinemast/libjson-rpc-cpp/):
   For Debian, the packages `libjsonrpccpp-dev` and `libjsonrpccpp-tools`
   can be installed.

--- a/mover/gametest/Makefile.am
+++ b/mover/gametest/Makefile.am
@@ -7,6 +7,7 @@ TEST_LIBRARY = \
 
 REGTESTS = \
   basic.py \
+  bind_address.py \
   catching_up.py \
   persistence-lmdb.py \
   persistence-sqlite.py \

--- a/mover/gametest/bind_address.py
+++ b/mover/gametest/bind_address.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python
+# Copyright (C) 2019 The Xaya developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+from mover import MoverTest
+
+import errno
+import jsonrpclib
+import socket
+
+"""
+Tests that the game daemon listens only locally by default, but can be
+changed to listen on all interfaces as well.
+"""
+
+
+class BindAddressTest (MoverTest):
+
+  def run (self):
+    port = self.gamenode.port
+    rpc = jsonrpclib.Server ("http://127.0.0.1:%d" % port)
+    alternateRpc = jsonrpclib.Server ("http://127.0.0.2:%d" % port)
+
+    # By default, the normal RPC connection to 127.0.0.1 should work.  But the
+    # connection to the alternate IP 127.0.0.2 should fail.
+    assert rpc.getcurrentstate ()["chain"] == "regtest"
+    try:
+      alternateRpc.getcurrentstate ()
+      raise AssertionError ("Expected connection failure, got none")
+    except socket.error as exc:
+      assert exc.errno == errno.ECONNREFUSED
+
+    # Restart and listen on all interfaces.
+    self.stopGameDaemon ()
+    self.startGameDaemon (extraArgs=["--game_rpc_host="])
+
+    # Now both connections should work.
+    assert rpc.getcurrentstate ()["chain"] == "regtest"
+    assert alternateRpc.getcurrentstate ()["chain"] == "regtest"
+
+
+if __name__ == "__main__":
+  BindAddressTest ().main ()

--- a/mover/main.cpp
+++ b/mover/main.cpp
@@ -20,6 +20,9 @@ DEFINE_string (xaya_rpc_url, "",
 DEFINE_int32 (game_rpc_port, 0,
               "the port at which the game daemon's JSON-RPC server will be"
               " start (if non-zero)");
+DEFINE_string (game_rpc_host, "127.0.0.1",
+               "the address where the game daemon's JSON-RPC server should"
+               " bind; set to \"\" for listening on all interfaces");
 
 DEFINE_int32 (enable_pruning, -1,
               "if non-negative (including zero), enable pruning of old undo"
@@ -61,6 +64,7 @@ main (int argc, char** argv)
     {
       config.GameRpcServer = xaya::RpcServerType::HTTP;
       config.GameRpcPort = FLAGS_game_rpc_port;
+      config.GameRpcHost = FLAGS_game_rpc_host;
     }
   config.EnablePruning = FLAGS_enable_pruning;
   config.StorageType = FLAGS_storage_type;

--- a/xayagame/defaultmain.cpp
+++ b/xayagame/defaultmain.cpp
@@ -104,11 +104,15 @@ CreateRpcServerConnector (const GameDaemonConfiguration& config)
       return nullptr;
 
     case RpcServerType::HTTP:
-      CHECK (config.GameRpcPort != 0)
-          << "GameRpcPort must be specified for HTTP server type";
-      LOG (INFO)
-          << "Starting JSON-RPC HTTP server at port " << config.GameRpcPort;
-      return std::make_unique<jsonrpc::HttpServer> (config.GameRpcPort);
+      {
+        CHECK (config.GameRpcPort != 0)
+            << "GameRpcPort must be specified for HTTP server type";
+        LOG (INFO)
+            << "Starting JSON-RPC HTTP server at port " << config.GameRpcPort;
+        auto srv = std::make_unique<jsonrpc::HttpServer> (config.GameRpcPort);
+        srv->SetBindAddress (config.GameRpcHost);
+        return srv;
+      }
     }
 
   LOG (FATAL)

--- a/xayagame/defaultmain.hpp
+++ b/xayagame/defaultmain.hpp
@@ -177,6 +177,13 @@ struct GameDaemonConfiguration
   int GameRpcPort = 0;
 
   /**
+   * The address to which the RPC server should bind.  By default, it binds
+   * to 127.0.0.1, so that it is only accessible locally.  If this is explicitly
+   * set to the empty string "", then the server will listen on all interfaces.
+   */
+  std::string GameRpcHost = "127.0.0.1";
+
+  /**
    * If non-negative (including zero), pruning of old undo data is enabled.
    * The specified value determines how many of the latest blocks are
    * kept to perform reorgs.


### PR DESCRIPTION
With this change, the RPC server started for games by the default main's can be explicitly bound to a specific address.  **Furthermore, by default it now only listens at `127.0.0.1` to increase security.**  With this, we resolve #41.

Note that with this change, we need a very recent version of `libjson-rpc-cpp`.  In particular, https://github.com/cinemast/libjson-rpc-cpp/pull/259 has to be included.