### PR TITLE
Game channels: Signature-verification utility

### DIFF
--- a/gamechannel/Makefile.am
+++ b/gamechannel/Makefile.am
@@ -24,11 +24,13 @@ libgamechannel_la_SOURCES = \
   channelgame.cpp \
   database.cpp \
   schema.cpp \
+  signatures.cpp \
   $(PROTOSOURCES)
 gamechannel_HEADERS = \
   channelgame.hpp \
   database.hpp \
   schema.hpp \
+  signatures.hpp \
   $(PROTOHEADERS)
 
 check_PROGRAMS = tests
@@ -42,11 +44,13 @@ tests_LDADD = \
   $(builddir)/libgamechannel.la \
   $(top_builddir)/xayautil/libxayautil.la \
   $(top_builddir)/xayagame/libxayagame.la \
+  $(top_builddir)/xayagame/libtestutils.la \
   $(JSONCPP_LIBS) $(JSONRPCCLIENT_LIBS) $(JSONRPCSERVER_LIBS) \
   $(GLOG_LIBS) $(GTEST_LIBS) $(SQLITE3_LIBS) $(PROTOBUF_LIBS)
 tests_SOURCES = \
   database_tests.cpp \
   schema_tests.cpp \
+  signatures_tests.cpp \
   \
   testgame.cpp
 check_HEADERS = \

--- a/gamechannel/Makefile.am
+++ b/gamechannel/Makefile.am
@@ -1,7 +1,7 @@
 lib_LTLIBRARIES = libgamechannel.la
 gamechanneldir = $(includedir)/gamechannel
 
-PROTOS = metadata.proto
+PROTOS = metadata.proto signatures.proto
 PROTOHEADERS = $(PROTOS:.proto=.pb.h)
 PROTOSOURCES = $(PROTOS:.proto=.pb.cc)
 

--- a/gamechannel/signatures.cpp
+++ b/gamechannel/signatures.cpp
@@ -1,0 +1,38 @@
+// Copyright (C) 2019 The Xaya developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "signatures.hpp"
+
+#include <xayagame/signatures.hpp>
+#include <xayautil/base64.hpp>
+#include <xayautil/hash.hpp>
+
+#include <string>
+
+namespace xaya
+{
+
+std::set<int>
+VerifyParticipantSignatures (XayaRpcClient& rpc,
+                             const ChannelMetadata& meta,
+                             const SignedData& data)
+{
+  const std::string msg = SHA256::Hash (data.data ()).ToHex ();
+
+  std::set<std::string> addresses;
+  for (const auto& sgn : data.signatures ())
+    {
+      const std::string& sgnStr = EncodeBase64 (sgn);
+      addresses.emplace (VerifyMessage (rpc, msg, sgnStr));
+    }
+
+  std::set<int> res;
+  for (int i = 0; i < meta.participants_size (); ++i)
+    if (addresses.count (meta.participants (i).address ()) > 0)
+      res.emplace (i);
+
+  return res;
+}
+
+} // namespace xaya

--- a/gamechannel/signatures.hpp
+++ b/gamechannel/signatures.hpp
@@ -1,0 +1,30 @@
+// Copyright (C) 2019 The Xaya developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef GAMECHANNEL_SIGNATURES_HPP
+#define GAMECHANNEL_SIGNATURES_HPP
+
+#include "metadata.pb.h"
+#include "signatures.pb.h"
+
+#include <xayagame/rpc-stubs/xayarpcclient.h>
+
+#include <set>
+
+namespace xaya
+{
+
+/**
+ * Verifies the signatures on a SignedData instance in relation to the
+ * participants and their signing keys of the given channel metadata.
+ * This function returns a set of the participant indices for which a valid
+ * signature was found on the data.
+ */
+std::set<int> VerifyParticipantSignatures (XayaRpcClient& rpc,
+                                           const ChannelMetadata& meta,
+                                           const SignedData& data);
+
+} // namespace xaya
+
+#endif // GAMECHANNEL_SIGNATURES_HPP

--- a/gamechannel/signatures.proto
+++ b/gamechannel/signatures.proto
@@ -1,0 +1,26 @@
+// Copyright (C) 2019 The Xaya developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+syntax = "proto2";
+
+package xaya;
+
+/** A piece of data with signatures of channel participants.  */
+message SignedData
+{
+
+  /**
+   * The data itself.  This can encode different entities, like board states,
+   * moves or changes made to a channel in agreement.
+   */
+  optional bytes data = 1;
+
+  /**
+   * The signatures made on the data by channel participants.  Each signature
+   * is the "signmessage" output of Xaya Core, but base64-decoded to binary.
+   * The message is the SHA256-hash of "data", encoded into lower-case hex.
+   */
+  repeated bytes signatures = 2;
+
+}

--- a/gamechannel/signatures_tests.cpp
+++ b/gamechannel/signatures_tests.cpp
@@ -1,0 +1,91 @@
+// Copyright (C) 2019 The Xaya developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "signatures.hpp"
+
+#include "xayagame/testutils.hpp"
+
+#include <xayagame/rpc-stubs/xayarpcclient.h>
+#include <xayautil/base64.hpp>
+#include <xayautil/hash.hpp>
+
+#include <jsonrpccpp/client/connectors/httpclient.h>
+#include <jsonrpccpp/server/connectors/httpserver.h>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+namespace xaya
+{
+namespace
+{
+
+using testing::Return;
+
+class SignaturesTests : public testing::Test
+{
+
+private:
+
+  jsonrpc::HttpServer httpServer;
+  jsonrpc::HttpClient httpClient;
+
+protected:
+
+  MockXayaRpcServer mockXayaServer;
+  XayaRpcClient rpcClient;
+
+  SignaturesTests ()
+    : httpServer(MockXayaRpcServer::HTTP_PORT),
+      httpClient(MockXayaRpcServer::HTTP_URL),
+      mockXayaServer(httpServer),
+      rpcClient(httpClient)
+  {
+    mockXayaServer.StartListening ();
+  }
+
+  ~SignaturesTests ()
+  {
+    mockXayaServer.StopListening ();
+  }
+
+};
+
+TEST_F (SignaturesTests, VerifyParticipantSignatures)
+{
+  ChannelMetadata meta;
+  meta.add_participants ()->set_address ("address 1");
+  meta.add_participants ()->set_address ("address 2");
+
+  SignedData data;
+  data.set_data ("foobar");
+  const std::string msg = SHA256::Hash ("foobar").ToHex ();
+  data.add_signatures ("signature 1");
+  data.add_signatures ("signature 2");
+  data.add_signatures ("signature 3");
+
+  EXPECT_CALL (mockXayaServer,
+               verifymessage ("", msg, EncodeBase64 ("signature 1")))
+      .WillOnce (Return (ParseJson (R"({
+        "valid": true,
+        "address": "some other address"
+      })")));
+  EXPECT_CALL (mockXayaServer,
+               verifymessage ("", msg, EncodeBase64 ("signature 2")))
+      .WillOnce (Return (ParseJson (R"({
+        "valid": true,
+        "address": "address 2"
+      })")));
+  EXPECT_CALL (mockXayaServer,
+               verifymessage ("", msg, EncodeBase64 ("signature 3")))
+      .WillOnce (Return (ParseJson (R"({
+        "valid": false
+      })")));
+
+  EXPECT_EQ (VerifyParticipantSignatures (rpcClient, meta, data),
+             std::set<int> ({1}));
+}
+
+} // anonymous namespace
+} // namespace xaya

--- a/xayagame/Makefile.am
+++ b/xayagame/Makefile.am
@@ -61,19 +61,34 @@ rpcstub_HEADERS = \
   rpc-stubs/xayarpcclient.h \
   rpc-stubs/xayarpcserverstub.h
 
+check_LTLIBRARIES = libtestutils.la
 check_PROGRAMS = tests
 TESTS = tests
+
+libtestutils_la_CXXFLAGS = \
+  -I$(top_srcdir) \
+  $(JSONCPP_CFLAGS) $(JSONRPCCLIENT_CFLAGS) $(JSONRPCSERVER_CFLAGS) \
+  $(GLOG_CFLAGS) $(GTEST_CFLAGS)
+libtestutils_la_LIBADD = \
+  $(builddir)/libxayagame.la \
+  $(top_builddir)/xayautil/libxayautil.la \
+  $(JSONCPP_LIBS) $(JSONRPCCLIENT_LIBS) $(JSONRPCSERVER_LIBS) \
+  $(GLOG_LIBS) $(GTEST_LIBS)
+libtestutils_la_SOURCES = \
+  testutils.cpp
+TESTUTILHEADERS = testutils.hpp
 
 tests_CXXFLAGS = \
   -I$(top_srcdir) \
   $(JSONCPP_CFLAGS) $(JSONRPCCLIENT_CFLAGS) $(JSONRPCSERVER_CFLAGS) \
   $(GLOG_CFLAGS) $(GTEST_CFLAGS) $(SQLITE3_CFLAGS) $(LMDB_CFLAGS) $(ZMQ_CFLAGS)
 tests_LDADD = \
+  $(builddir)/libtestutils.la \
   $(builddir)/libxayagame.la \
   $(top_builddir)/xayautil/libxayautil.la \
   $(JSONCPP_LIBS) $(JSONRPCCLIENT_LIBS) $(JSONRPCSERVER_LIBS) \
   $(GLOG_LIBS) $(GTEST_LIBS) $(SQLITE3_LIBS) $(LMDB_LIBS) $(ZMQ_LIBS)
-tests_SOURCES = testutils.cpp \
+tests_SOURCES = \
   game_tests.cpp \
   gamelogic_tests.cpp \
   heightcache_tests.cpp \
@@ -86,7 +101,9 @@ tests_SOURCES = testutils.cpp \
   storage_tests.cpp \
   transactionmanager_tests.cpp \
   zmqsubscriber_tests.cpp
-check_HEADERS = testutils.hpp storage_tests.hpp
+TESTHEADERS = storage_tests.hpp
+
+check_HEADERS = $(TESTUTILHEADERS) $(TESTHEADERS)
 
 rpc-stubs/gamerpcclient.h: $(srcdir)/rpc-stubs/game.json
 	jsonrpcstub "$<" --cpp-client=GameRpcClient --cpp-client-file="$@"


### PR DESCRIPTION
This defines a data format (as protocol buffer) for messages signed by channel participants, and provides a function that verifies those signatures against the signing addresses of a given channel's metadata.

With this, GSPs of channel games can verify modifications made in agreement (e.g. closing a channel after the game is finished), and also state proofs will be based on that.