### PR TITLE
Game channels: State proofs

### DIFF
--- a/gamechannel/Makefile.am
+++ b/gamechannel/Makefile.am
@@ -21,12 +21,14 @@ libgamechannel_la_LIBADD = \
   $(JSONCPP_LIBS) $(JSONRPCCLIENT_LIBS) $(JSONRPCSERVER_LIBS) \
   $(GLOG_LIBS) $(SQLITE3_LIBS) $(PROTOBUF_LIBS)
 libgamechannel_la_SOURCES = \
+  boardrules.cpp \
   channelgame.cpp \
   database.cpp \
   schema.cpp \
   signatures.cpp \
   $(PROTOSOURCES)
 gamechannel_HEADERS = \
+  boardrules.hpp \
   channelgame.hpp \
   database.hpp \
   schema.hpp \
@@ -51,6 +53,7 @@ tests_SOURCES = \
   database_tests.cpp \
   schema_tests.cpp \
   signatures_tests.cpp \
+  testgame_tests.cpp \
   \
   testgame.cpp
 check_HEADERS = \

--- a/gamechannel/Makefile.am
+++ b/gamechannel/Makefile.am
@@ -1,7 +1,7 @@
 lib_LTLIBRARIES = libgamechannel.la
 gamechanneldir = $(includedir)/gamechannel
 
-PROTOS = metadata.proto signatures.proto
+PROTOS = metadata.proto signatures.proto stateproof.proto
 PROTOHEADERS = $(PROTOS:.proto=.pb.h)
 PROTOSOURCES = $(PROTOS:.proto=.pb.cc)
 
@@ -26,6 +26,7 @@ libgamechannel_la_SOURCES = \
   database.cpp \
   schema.cpp \
   signatures.cpp \
+  stateproof.cpp \
   $(PROTOSOURCES)
 gamechannel_HEADERS = \
   boardrules.hpp \
@@ -33,6 +34,7 @@ gamechannel_HEADERS = \
   database.hpp \
   schema.hpp \
   signatures.hpp \
+  stateproof.hpp \
   $(PROTOHEADERS)
 
 check_PROGRAMS = tests
@@ -53,6 +55,7 @@ tests_SOURCES = \
   database_tests.cpp \
   schema_tests.cpp \
   signatures_tests.cpp \
+  stateproof_tests.cpp \
   testgame_tests.cpp \
   \
   testgame.cpp

--- a/gamechannel/boardrules.cpp
+++ b/gamechannel/boardrules.cpp
@@ -1,0 +1,12 @@
+// Copyright (C) 2019 The Xaya developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "boardrules.hpp"
+
+namespace xaya
+{
+
+constexpr int BoardRules::NO_TURN;
+
+} // namespace xaya

--- a/gamechannel/boardrules.hpp
+++ b/gamechannel/boardrules.hpp
@@ -1,0 +1,81 @@
+// Copyright (C) 2019 The Xaya developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef GAMECHANNEL_BOARDRULES_HPP
+#define GAMECHANNEL_BOARDRULES_HPP
+
+#include "metadata.pb.h"
+
+#include <string>
+
+namespace xaya
+{
+
+/**
+ * The state of the current game board, encoded in a game-specific format.
+ * We use std::string simply as convenient wrapper for arbitrary data.
+ */
+using BoardState = std::string;
+
+/** The game-specific encoded data of a move in a game channel.  */
+using BoardMove = std::string;
+
+/**
+ * Abstract base class for the game-specific processor of board states and
+ * moves on a channel.  This is the main class defining the rules of the
+ * on-chain game.
+ *
+ * The implemented methods of this class should be pure and thread-safe.
+ * They may be called in parallel and from various different threads from
+ * the game-channel framework.
+ */
+class BoardRules
+{
+
+protected:
+
+  BoardRules () = default;
+
+public:
+
+  /**
+   * Participant index value that indicates that it is currently no
+   * player's turn in a game.  This is the case e.g. when the channel is
+   * still waiting for players to join, or when the game has ended.
+   */
+  static constexpr int NO_TURN = -1;
+
+  virtual ~BoardRules () = default;
+
+  /**
+   * Compares two given board states in the context of the given metadata.
+   * Returns true if they are equivalent (i.e. possibly different encodings
+   * of the same state).
+   */
+  virtual bool CompareStates (const ChannelMetadata& meta,
+                              const BoardState& a,
+                              const BoardState& b) const = 0;
+
+  /**
+   * Returns which player's turn it is in the given state.  The return value
+   * is the player index into the channel's participants array.  This may return
+   * NO_TURN to indicate that it is noone's turn at the moment.
+   */
+  virtual int WhoseTurn (const ChannelMetadata& meta,
+                         const BoardState& a) const = 0;
+
+  /**
+   * Applies a move (assumed to be made by the player whose turn it is)
+   * onto the given state, yielding a new board state.  Returns false
+   * if the move is invalid instead.
+   */
+  virtual bool ApplyMove (const ChannelMetadata& meta,
+                          const BoardState& oldState, const BoardMove& mv,
+                          BoardState& newState) const = 0;
+
+};
+
+} // namespace xaya
+
+#endif // GAMECHANNEL_BOARDRULES_HPP

--- a/gamechannel/channelgame.hpp
+++ b/gamechannel/channelgame.hpp
@@ -5,6 +5,8 @@
 #ifndef GAMECHANNEL_CHANNELGAME_HPP
 #define GAMECHANNEL_CHANNELGAME_HPP
 
+#include "boardrules.hpp"
+
 #include <xayagame/sqlitegame.hpp>
 
 namespace xaya
@@ -27,6 +29,12 @@ protected:
    * called from the overridden SetupSchema method.
    */
   void SetupGameChannelsSchema (sqlite3* db);
+
+  /**
+   * This method needs to be overridden to provide an instance of BoardRules
+   * to the game channels framework.
+   */
+  virtual const BoardRules& GetBoardRules () const = 0;
 
   friend class ChannelData;
   friend class ChannelsTable;

--- a/gamechannel/database.hpp
+++ b/gamechannel/database.hpp
@@ -5,6 +5,7 @@
 #ifndef GAMECHANNEL_DATABASE_HPP
 #define GAMECHANNEL_DATABASE_HPP
 
+#include "boardrules.hpp"
 #include "channelgame.hpp"
 
 #include "metadata.pb.h"
@@ -14,13 +15,9 @@
 #include <sqlite3.h>
 
 #include <memory>
-#include <string>
 
 namespace xaya
 {
-
-/** We use std::string as container for encoded state data.  */
-using BoardState = std::string;
 
 /**
  * Wrapper class around the state of one channel in the database.  This

--- a/gamechannel/signatures_tests.cpp
+++ b/gamechannel/signatures_tests.cpp
@@ -4,14 +4,10 @@
 
 #include "signatures.hpp"
 
-#include "xayagame/testutils.hpp"
+#include "testgame.hpp"
 
-#include <xayagame/rpc-stubs/xayarpcclient.h>
 #include <xayautil/base64.hpp>
 #include <xayautil/hash.hpp>
-
-#include <jsonrpccpp/client/connectors/httpclient.h>
-#include <jsonrpccpp/server/connectors/httpserver.h>
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
@@ -23,34 +19,7 @@ namespace
 
 using testing::Return;
 
-class SignaturesTests : public testing::Test
-{
-
-private:
-
-  jsonrpc::HttpServer httpServer;
-  jsonrpc::HttpClient httpClient;
-
-protected:
-
-  MockXayaRpcServer mockXayaServer;
-  XayaRpcClient rpcClient;
-
-  SignaturesTests ()
-    : httpServer(MockXayaRpcServer::HTTP_PORT),
-      httpClient(MockXayaRpcServer::HTTP_URL),
-      mockXayaServer(httpServer),
-      rpcClient(httpClient)
-  {
-    mockXayaServer.StartListening ();
-  }
-
-  ~SignaturesTests ()
-  {
-    mockXayaServer.StopListening ();
-  }
-
-};
+using SignaturesTests = TestGameFixture;
 
 TEST_F (SignaturesTests, VerifyParticipantSignatures)
 {

--- a/gamechannel/stateproof.cpp
+++ b/gamechannel/stateproof.cpp
@@ -1,0 +1,117 @@
+// Copyright (C) 2019 The Xaya developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "stateproof.hpp"
+
+#include "signatures.hpp"
+
+#include <glog/logging.h>
+
+#include <set>
+
+namespace xaya
+{
+
+namespace
+{
+
+/**
+ * Internal version of VerifyStateTransition, which also returns all valid
+ * signatures made on the new state.  This is useful when validating a state
+ * proof, so that we do not need to duplicate that check.
+ */
+bool
+ExtraVerifyStateTransition (XayaRpcClient& rpc, const BoardRules& rules,
+                            const ChannelMetadata& meta,
+                            const BoardState& oldState,
+                            const StateTransition& transition,
+                            std::set<int>& signatures)
+{
+  const int turn = rules.WhoseTurn (meta, oldState);
+  if (turn == BoardRules::NO_TURN)
+    {
+      LOG (WARNING) << "State transition applied to 'no turn' state";
+      return false;
+    }
+
+  BoardState newState;
+  if (!rules.ApplyMove (meta, oldState, transition.move (), newState))
+    {
+      LOG (WARNING) << "Failed to apply move of state transition";
+      return false;
+    }
+
+  if (!rules.CompareStates (meta, transition.new_state ().data (), newState))
+    {
+      LOG (WARNING) << "Wrong new state claimed in state transition";
+      return false;
+    }
+
+  signatures = VerifyParticipantSignatures (rpc, meta, transition.new_state ());
+  if (signatures.count (turn) == 0)
+    {
+      LOG (WARNING)
+          << "No valid signature of player " << turn << " on state transition";
+      return false;
+    }
+
+  return true;
+}
+
+} // anonymous namespace
+
+bool
+VerifyStateTransition (XayaRpcClient& rpc, const BoardRules& rules,
+                       const ChannelMetadata& meta, const BoardState& oldState,
+                       const StateTransition& transition)
+{
+  std::set<int> signatures;
+  return ExtraVerifyStateTransition (rpc, rules, meta, oldState, transition,
+                                     signatures);
+}
+
+bool
+VerifyStateProof (XayaRpcClient& rpc, const BoardRules& rules,
+                  const ChannelData& channel, const StateProof& proof,
+                  BoardState& endState)
+{
+  const auto& meta = channel.GetMetadata ();
+  const auto& onChainState = channel.GetState ();
+
+  std::set<int> signatures
+      = VerifyParticipantSignatures (rpc, meta, proof.initial_state ());
+  endState = proof.initial_state ().data ();
+  bool foundOnChain = rules.CompareStates (meta, onChainState, endState);
+
+  for (const auto& t : proof.transitions ())
+    {
+      std::set<int> newSignatures;
+      if (!ExtraVerifyStateTransition (rpc, rules, meta, endState, t,
+                                       newSignatures))
+        return false;
+
+      signatures.insert (newSignatures.begin (), newSignatures.end ());
+      endState = t.new_state ().data ();
+      if (!foundOnChain)
+        foundOnChain = rules.CompareStates (meta, onChainState, endState);
+    }
+
+  if (foundOnChain)
+    {
+      VLOG (1) << "StateProof has on-chain state and is valid";
+      return true;
+    }
+
+  for (int i = 0; i < meta.participants_size (); ++i)
+    if (signatures.count (i) == 0)
+      {
+        LOG (WARNING) << "StateProof has no signature of player " << i;
+        return false;
+      }
+
+  VLOG (1) << "StateProof has signatures by all players and is valid";
+  return true;
+}
+
+} // namespace xaya

--- a/gamechannel/stateproof.hpp
+++ b/gamechannel/stateproof.hpp
@@ -1,0 +1,42 @@
+// Copyright (C) 2019 The Xaya developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef GAMECHANNEL_STATEPROOF_HPP
+#define GAMECHANNEL_STATEPROOF_HPP
+
+#include "boardrules.hpp"
+#include "database.hpp"
+
+#include "metadata.pb.h"
+#include "stateproof.pb.h"
+
+#include <xayagame/rpc-stubs/xayarpcclient.h>
+
+namespace xaya
+{
+
+/**
+ * Checks if a given state transition is valid from the current state.
+ * Returns true if it is.
+ *
+ * A state transition is valid if the move is valid from old state -> new state
+ * and the player who was supposed to make that move signed the new state.
+ */
+bool VerifyStateTransition (XayaRpcClient& rpc, const BoardRules& rules,
+                            const ChannelMetadata& meta,
+                            const BoardState& oldState,
+                            const StateTransition& transition);
+
+/**
+ * Verifies a state proof for the given channel.  If the proof is complete
+ * and valid, then true is returned and the resulting board state is returned
+ * in endState.
+ */
+bool VerifyStateProof (XayaRpcClient& rpc, const BoardRules& rules,
+                       const ChannelData& channel, const StateProof& proof,
+                       BoardState& endState);
+
+} // namespace xaya
+
+#endif // GAMECHANNEL_STATEPROOF_HPP

--- a/gamechannel/stateproof.proto
+++ b/gamechannel/stateproof.proto
@@ -1,0 +1,56 @@
+// Copyright (C) 2019 The Xaya developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+syntax = "proto2";
+
+import "signatures.proto";
+
+package xaya;
+
+/**
+ * A state transition:  This is a move made by the current player together
+ * with the resulting state signed by that player.  If we have a known current
+ * state, then this is the information we need to verify that this is the
+ * current player's move.  Furthermore, by having a state signed by that
+ * player afterwards, we get a basis to build upon and proving that that
+ * player agreed at this point.
+ */
+message StateTransition
+{
+
+  /** The player's move encoded in a game-specific format.  */
+  optional bytes move = 1;
+
+  /** The resulting state and the player's signature.  */
+  optional SignedData new_state = 2;
+
+}
+
+/**
+ * A full proof of some state of the game channel and that every participant
+ * agrees to it.  This starts off some base state and then applies state
+ * transitions ending at the target state.  As long as the base or any later
+ * state was known to be good (i.e. already put on-chain) or every participant
+ * signed a state during the steps, this is ensured.  It is also fine
+ * if someone signed only a state even if they were not the one who did a move,
+ * although that is unlikely to occur in practice.
+ *
+ * Note that there are possible efficiency-improvements to the format
+ * and rules of such a state proof.  For instance, it would be enough if for
+ * each player, the *last* state resulting from a move of them is signed.
+ * If, for example, some player makes three moves after each other for some
+ * reason, then only the last state actually needs a signature and the
+ * signatures for "intermediate" states can be left out.  For now, this is
+ * not implemented, though.
+ */
+message StateProof
+{
+
+  /** The initial state and potentially signatures on it.  */
+  optional SignedData initial_state = 1;
+
+  /** A series of ordered state transitions on top of the initial state.  */
+  repeated StateTransition transitions = 2;
+
+}

--- a/gamechannel/stateproof_tests.cpp
+++ b/gamechannel/stateproof_tests.cpp
@@ -1,0 +1,347 @@
+// Copyright (C) 2019 The Xaya developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "stateproof.hpp"
+
+#include "testgame.hpp"
+
+#include <xayautil/hash.hpp>
+
+#include <google/protobuf/text_format.h>
+
+#include <gtest/gtest.h>
+
+#include <glog/logging.h>
+
+namespace xaya
+{
+namespace
+{
+
+using google::protobuf::TextFormat;
+
+class GeneralStateProofTests : public TestGameFixture
+{
+
+protected:
+
+  ChannelMetadata meta;
+
+  GeneralStateProofTests ()
+  {
+    meta.add_participants ()->set_address ("addr0");
+    meta.add_participants ()->set_address ("addr1");
+
+    ValidSignature ("sgn0", "addr0");
+    ValidSignature ("sgn1", "addr1");
+    ValidSignature ("sgn42", "addr42");
+  }
+
+};
+
+/* ************************************************************************** */
+
+class StateTransitionTests : public GeneralStateProofTests
+{
+
+protected:
+
+  /**
+   * Calls VerifyStateTransition based on the given state and the
+   * transition proto loaded from text format.
+   */
+  bool
+  VerifyTransition (const BoardState& oldState, const std::string& transition)
+  {
+    StateTransition proto;
+    CHECK (TextFormat::ParseFromString (transition, &proto));
+
+    return VerifyStateTransition (rpcClient, game.rules, meta, oldState, proto);
+  }
+
+};
+
+TEST_F (StateTransitionTests, NoTurnState)
+{
+  EXPECT_FALSE (VerifyTransition ("100", R"(
+    move: "1",
+    new_state:
+      {
+        data: "101"
+        signatures: "sgn0"
+      }
+  )"));
+}
+
+TEST_F (StateTransitionTests, InvalidMove)
+{
+  EXPECT_FALSE (VerifyTransition ("10", R"(
+    move: "0",
+    new_state:
+      {
+        data: "10"
+        signatures: "sgn0"
+      }
+  )"));
+}
+
+TEST_F (StateTransitionTests, NewStateMismatch)
+{
+  EXPECT_FALSE (VerifyTransition ("10", R"(
+    move: "1",
+    new_state:
+      {
+        data: "12"
+        signatures: "sgn0"
+      }
+  )"));
+}
+
+TEST_F (StateTransitionTests, InvalidSignature)
+{
+  EXPECT_FALSE (VerifyTransition ("10", R"(
+    move: "1",
+    new_state:
+      {
+        data: "11"
+        signatures: "sgn1"
+        signatures: "sgn42"
+      }
+  )"));
+}
+
+TEST_F (StateTransitionTests, Valid)
+{
+  ExpectSignature (" 11 ", "signed by zero", "addr0");
+
+  EXPECT_TRUE (VerifyTransition ("10", R"(
+    move: "1",
+    new_state:
+      {
+        data: " 11 "
+        signatures: "signed by zero"
+        signatures: "sgn42"
+      }
+  )"));
+}
+
+/* ************************************************************************** */
+
+class StateProofTests : public GeneralStateProofTests
+{
+
+private:
+
+  ChannelsTable tbl;
+  const uint256 id;
+
+protected:
+
+  BoardState endState;
+
+  StateProofTests ()
+    : tbl(game), id(SHA256::Hash ("id"))
+  {
+    /* Set up a ChannelData instance in the database.  This allows us to
+       always use the same one later for VerifyProof, so that we do not need
+       to generate distinct IDs or otherwise hack around.  */
+    tbl.CreateNew (id);
+  }
+
+  /**
+   * Calls VerifyStateProof based on the given on-chain state and the
+   * proof proto loaded from text format.
+   */
+  bool
+  VerifyProof (const BoardState& chainState, const std::string& proof)
+  {
+    StateProof proto;
+    CHECK (TextFormat::ParseFromString (proof, &proto));
+
+    auto ch = tbl.GetById (id);
+    ch->MutableMetadata () = meta;
+    ch->SetState (chainState);
+
+    return VerifyStateProof (rpcClient, game.rules, *ch, proto, endState);
+  }
+
+};
+
+TEST_F (StateProofTests, OnlyInitialOnChain)
+{
+  ASSERT_TRUE (VerifyProof (" 42 ", R"(
+    initial_state:
+      {
+        data: "42"
+        signatures: "sgn42"
+      }
+  )"));
+  EXPECT_EQ (endState, "42");
+}
+
+TEST_F (StateProofTests, OnlyInitialSigned)
+{
+  ExpectSignature ("42", "signature 0", "addr0");
+  ExpectSignature ("42", "signature 1", "addr1");
+
+  ASSERT_TRUE (VerifyProof ("0", R"(
+    initial_state:
+      {
+        data: "42"
+        signatures: "signature 0"
+        signatures: "signature 1"
+      }
+  )"));
+  EXPECT_EQ (endState, "42");
+}
+
+TEST_F (StateProofTests, OnlyInitialNotSigned)
+{
+  EXPECT_FALSE (VerifyProof ("0", R"(
+    initial_state:
+      {
+        data: "42"
+        signatures: "sgn0"
+        signatures: "sgn42"
+      }
+  )"));
+}
+
+TEST_F (StateProofTests, InvalidTransition)
+{
+  EXPECT_FALSE (VerifyProof ("42", R"(
+    initial_state:
+      {
+        data: "42"
+      }
+    transitions:
+      {
+        move: "0"
+        new_state:
+          {
+            data: "42"
+          }
+      }
+  )"));
+
+  EXPECT_FALSE (VerifyProof ("42", R"(
+    initial_state:
+      {
+        data: "42"
+      }
+    transitions:
+      {
+        move: "1"
+        new_state:
+          {
+            data: "43"
+            signatures: "sgn1"
+          }
+      }
+  )"));
+}
+
+TEST_F (StateProofTests, MissingSignature)
+{
+  EXPECT_FALSE (VerifyProof ("0", R"(
+    initial_state:
+      {
+        data: "42"
+      }
+    transitions:
+      {
+        move: "2"
+        new_state:
+          {
+            data: "44"
+            signatures: "sgn0"
+          }
+      }
+    transitions:
+      {
+        move: "2"
+        new_state:
+          {
+            data: "46"
+            signatures: "sgn0"
+          }
+      }
+  )"));
+}
+
+TEST_F (StateProofTests, IntermediateStateOnChain)
+{
+  ASSERT_TRUE (VerifyProof (" 44 ", R"(
+    initial_state:
+      {
+        data: "42"
+      }
+    transitions:
+      {
+        move: "2"
+        new_state:
+          {
+            data: "44"
+            signatures: "sgn0"
+          }
+      }
+    transitions:
+      {
+        move: "2"
+        new_state:
+          {
+            data: "46"
+            signatures: "sgn0"
+          }
+      }
+  )"));
+  EXPECT_EQ (endState, "46");
+}
+
+TEST_F (StateProofTests, SignedInitialState)
+{
+  ASSERT_TRUE (VerifyProof ("0", R"(
+    initial_state:
+      {
+        data: "42"
+        signatures: "sgn1"
+      }
+    transitions:
+      {
+        move: "1"
+        new_state:
+          {
+            data: "43"
+            signatures: "sgn0"
+          }
+      }
+  )"));
+  EXPECT_EQ (endState, "43");
+}
+
+TEST_F (StateProofTests, MultiSignedLaterState)
+{
+  ASSERT_TRUE (VerifyProof ("0", R"(
+    initial_state:
+      {
+        data: "42"
+      }
+    transitions:
+      {
+        move: "1"
+        new_state:
+          {
+            data: "43"
+            signatures: "sgn0"
+            signatures: "sgn1"
+          }
+      }
+  )"));
+  EXPECT_EQ (endState, "43");
+}
+
+/* ************************************************************************** */
+
+} // anonymous namespace
+} // namespace xaya

--- a/gamechannel/testgame.hpp
+++ b/gamechannel/testgame.hpp
@@ -61,10 +61,6 @@ public:
 class TestGame : public ChannelGame
 {
 
-private:
-
-  AdditionRules rules;
-
 protected:
 
   void SetupSchema (sqlite3* db) override;
@@ -77,6 +73,10 @@ protected:
   const BoardRules& GetBoardRules () const override;
 
   friend class TestGameFixture;
+
+public:
+
+  AdditionRules rules;
 
 };
 

--- a/gamechannel/testgame.hpp
+++ b/gamechannel/testgame.hpp
@@ -8,6 +8,13 @@
 #include "boardrules.hpp"
 #include "channelgame.hpp"
 
+#include "xayagame/testutils.hpp"
+
+#include <xayagame/rpc-stubs/xayarpcclient.h>
+
+#include <jsonrpccpp/client/connectors/httpclient.h>
+#include <jsonrpccpp/server/connectors/httpserver.h>
+
 #include <gtest/gtest.h>
 
 #include <sqlite3.h>
@@ -75,14 +82,22 @@ protected:
 
 /**
  * Test fixture that constructs a TestGame instance with an in-memory database
- * and exposes that to the test itself.
+ * and exposes that to the test itself.  It also runs a mock Xaya Core server
+ * for use together with signature verification.
  */
 class TestGameFixture : public testing::Test
 {
 
+private:
+
+  jsonrpc::HttpServer httpServer;
+  jsonrpc::HttpClient httpClient;
+
 protected:
 
-  /** TestGame instance that is used in the test.  */
+  MockXayaRpcServer mockXayaServer;
+  XayaRpcClient rpcClient;
+
   TestGame game;
 
   /**
@@ -92,9 +107,29 @@ protected:
   TestGameFixture ();
 
   /**
+   * The destructor shuts down the mock Xaya server.
+   */
+  ~TestGameFixture ();
+
+  /**
    * Returns the raw database handle of the test game.
    */
   sqlite3* GetDb ();
+
+  /**
+   * Sets up the mock server to validate *any* message with the given
+   * signature as belonging to the given address.  sgn is in raw binary
+   * (will be base64-encoded for the RPC).
+   */
+  void ValidSignature (const std::string& sgn, const std::string& addr);
+
+  /**
+   * Expects exactly one call to verifymessage with the given message
+   * and signature (both as binary, they will be hashed / base64-encoded).
+   * Returns a valid response for the given address.
+   */
+  void ExpectSignature (const std::string& msg, const std::string& sgn,
+                        const std::string& addr);
 
 };
 

--- a/gamechannel/testgame.hpp
+++ b/gamechannel/testgame.hpp
@@ -5,6 +5,7 @@
 #ifndef GAMECHANNEL_TESTGAME_HPP
 #define GAMECHANNEL_TESTGAME_HPP
 
+#include "boardrules.hpp"
 #include "channelgame.hpp"
 
 #include <gtest/gtest.h>
@@ -21,11 +22,41 @@ namespace xaya
 class TestGameFixture;
 
 /**
+ * Board rules for a trivial example game used in unit tests.  The game goes
+ * like this:
+ *
+ * The current state is a number, encoded simply in a string.  The current
+ * turn is for player (number % 2).  When the number is 100 or above, then
+ * the game is finished.  A move is simply another, strictly positive number
+ * encoded as a string, which gets added to the current "state number".
+ */
+class AdditionRules : public BoardRules
+{
+
+public:
+
+  bool CompareStates (const ChannelMetadata& meta,
+                      const BoardState& a, const BoardState& b) const override;
+
+  int WhoseTurn (const ChannelMetadata& meta,
+                 const BoardState& a) const override;
+
+  bool ApplyMove (const ChannelMetadata& meta,
+                  const BoardState& oldState, const BoardMove& mv,
+                  BoardState& newState) const override;
+
+};
+
+/**
  * Subclass of ChannelGame that implements a trivial game only as much as
  * necessary for unit tests of the game-channel framework.
  */
 class TestGame : public ChannelGame
 {
+
+private:
+
+  AdditionRules rules;
 
 protected:
 
@@ -35,6 +66,8 @@ protected:
   void InitialiseState (sqlite3* db) override;
   void UpdateState (sqlite3* db, const Json::Value& blockData) override;
   Json::Value GetStateAsJson (sqlite3* db) override;
+
+  const BoardRules& GetBoardRules () const override;
 
   friend class TestGameFixture;
 

--- a/gamechannel/testgame_tests.cpp
+++ b/gamechannel/testgame_tests.cpp
@@ -1,0 +1,58 @@
+// Copyright (C) 2019 The Xaya developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "testgame.hpp"
+
+#include "metadata.pb.h"
+
+#include <gtest/gtest.h>
+
+namespace xaya
+{
+namespace
+{
+
+class AdditionRulesTests : public testing::Test
+{
+
+protected:
+
+  ChannelMetadata meta;
+  AdditionRules rules;
+
+};
+
+TEST_F (AdditionRulesTests, CompareStates)
+{
+  EXPECT_TRUE (rules.CompareStates (meta, "1", " 1 "));
+  EXPECT_TRUE (rules.CompareStates (meta, "105", "105"));
+  EXPECT_FALSE (rules.CompareStates (meta, "2", "3"));
+  EXPECT_FALSE (rules.CompareStates (meta, "105", "106"));
+}
+
+TEST_F (AdditionRulesTests, WhoseTurn)
+{
+  EXPECT_EQ (rules.WhoseTurn (meta, "13"), 1);
+  EXPECT_EQ (rules.WhoseTurn (meta, "42"), 0);
+  EXPECT_EQ (rules.WhoseTurn (meta, "99"), 1);
+  EXPECT_EQ (rules.WhoseTurn (meta, "100"), BoardRules::NO_TURN);
+  EXPECT_EQ (rules.WhoseTurn (meta, "105"), BoardRules::NO_TURN);
+}
+
+TEST_F (AdditionRulesTests, ApplyMove)
+{
+  BoardState newState;
+  ASSERT_TRUE (rules.ApplyMove (meta, "42", "13", newState));
+  EXPECT_EQ (newState, "55");
+  ASSERT_TRUE (rules.ApplyMove (meta, "99", "2", newState));
+  EXPECT_EQ (newState, "101");
+
+  EXPECT_FALSE (rules.ApplyMove (meta, "42", "0", newState));
+  EXPECT_FALSE (rules.ApplyMove (meta, "42", "-1", newState));
+
+  EXPECT_DEATH (rules.ApplyMove (meta, "100", "1", newState), "no turn");
+}
+
+} // anonymous namespace
+} // namespace xaya


### PR DESCRIPTION
This implements *state proofs*.  They are data structures (by means of protocol buffers) that contain board states, moves and player signatures in such a way that they prove that every channel participant agrees to a certain state.  Disputes and resolutions make use of them to "put the current state on-chain".

As a preparation, the first commit of this change set introduces the general interface that specific games need to implement in order to actually define the rules of in-channel games.