### PR TITLE
Game channels: Generic dispute and resolution processing

### DIFF
--- a/gamechannel/Makefile.am
+++ b/gamechannel/Makefile.am
@@ -56,6 +56,7 @@ tests_LDADD = \
   $(JSONCPP_LIBS) $(JSONRPCCLIENT_LIBS) $(JSONRPCSERVER_LIBS) \
   $(GLOG_LIBS) $(GTEST_LIBS) $(SQLITE3_LIBS) $(PROTOBUF_LIBS)
 tests_SOURCES = \
+  channelgame_tests.cpp \
   database_tests.cpp \
   schema_tests.cpp \
   signatures_tests.cpp \

--- a/gamechannel/boardrules.hpp
+++ b/gamechannel/boardrules.hpp
@@ -63,7 +63,17 @@ public:
    * NO_TURN to indicate that it is noone's turn at the moment.
    */
   virtual int WhoseTurn (const ChannelMetadata& meta,
-                         const BoardState& a) const = 0;
+                         const BoardState& state) const = 0;
+
+  /**
+   * Returns the "turn count" for the given game state.  This is a number
+   * that should increase with turns made in the game, so that it is possible
+   * to determine whether a given state is "after" another.  It can also be
+   * seen as the "block height" in the "private chain" formed during a game
+   * on a channel.
+   */
+  virtual unsigned TurnCount (const ChannelMetadata& meta,
+                              const BoardState& state) const = 0;
 
   /**
    * Applies a move (assumed to be made by the player whose turn it is)

--- a/gamechannel/channelgame.cpp
+++ b/gamechannel/channelgame.cpp
@@ -5,6 +5,9 @@
 #include "channelgame.hpp"
 
 #include "schema.hpp"
+#include "stateproof.hpp"
+
+#include <glog/logging.h>
 
 namespace xaya
 {
@@ -13,6 +16,47 @@ void
 ChannelGame::SetupGameChannelsSchema (sqlite3* db)
 {
   InternalSetupGameChannelsSchema (db);
+}
+
+bool
+ChannelGame::ProcessDispute (ChannelData& ch, const unsigned height,
+                             const StateProof& proof)
+{
+  const auto& meta = ch.GetMetadata ();
+  const auto& onChainState = ch.GetState ();
+  const auto& rules = GetBoardRules ();
+
+  BoardState provenState;
+  if (!VerifyStateProof (GetXayaRpc (), rules, meta, onChainState, proof,
+                         provenState))
+    {
+      LOG (WARNING) << "Dispute has invalid state proof";
+      return false;
+    }
+
+  const unsigned onChainCnt = rules.TurnCount (meta, onChainState);
+  const unsigned provenCnt = rules.TurnCount (meta, provenState);
+  if (onChainCnt >= provenCnt)
+    {
+      LOG (WARNING)
+          << "Dispute has turn count " << provenCnt
+          << ", which is not beyond the on-chain count " << onChainCnt;
+      return false;
+    }
+  CHECK_GT (provenCnt, onChainCnt);
+
+  /* If there is already a dispute in the on-chain game state, then it can only
+     have been placed there by an earlier block (or perhaps the same block
+     in edge cases).  */
+  if (ch.HasDispute ())
+    CHECK_GE (height, ch.GetDisputeHeight ());
+
+  VLOG (1) << "Dispute is valid, updating state...";
+
+  ch.SetState (provenState);
+  ch.SetDisputeHeight (height);
+
+  return true;
 }
 
 } // namespace xaya

--- a/gamechannel/channelgame.hpp
+++ b/gamechannel/channelgame.hpp
@@ -46,6 +46,16 @@ protected:
                        const StateProof& proof);
 
   /**
+   * Processes a request (e.g. sent in a move) for resolving a dispute
+   * in the given channel.  If the provided state proof is valid and at least
+   * one turn further than the current on-chain state, then the new state is
+   * put on-chain and any open disputes are resolved (and true is returned).
+   * Note that this function succeeds also if there is not an open dispute;
+   * in that case, the on-chain state will simply be updated.
+   */
+  bool ProcessResolution (ChannelData& ch, const StateProof& proof);
+
+  /**
    * This method needs to be overridden to provide an instance of BoardRules
    * to the game channels framework.
    */

--- a/gamechannel/channelgame.hpp
+++ b/gamechannel/channelgame.hpp
@@ -6,6 +6,9 @@
 #define GAMECHANNEL_CHANNELGAME_HPP
 
 #include "boardrules.hpp"
+#include "database.hpp"
+
+#include "proto/stateproof.pb.h"
 
 #include <xayagame/sqlitegame.hpp>
 
@@ -29,6 +32,18 @@ protected:
    * called from the overridden SetupSchema method.
    */
   void SetupGameChannelsSchema (sqlite3* db);
+
+  /**
+   * Processes a request (e.g. sent in a move) to open a dispute at the
+   * current block height for the given game channel and based on the
+   * given state proof.  If the request is valid (mainly meaning that the
+   * state proof is valid and for a "later" state than the current on-chain
+   * state), then the dispute is opened on the ChannelData instance and
+   * true is returned.  If it is not valid, then no changes are made and
+   * false is returned.
+   */
+  bool ProcessDispute (ChannelData& ch, unsigned height,
+                       const StateProof& proof);
 
   /**
    * This method needs to be overridden to provide an instance of BoardRules

--- a/gamechannel/channelgame_tests.cpp
+++ b/gamechannel/channelgame_tests.cpp
@@ -1,0 +1,162 @@
+// Copyright (C) 2019 The Xaya developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "channelgame.hpp"
+
+#include "testgame.hpp"
+
+#include <xayautil/hash.hpp>
+
+#include <google/protobuf/text_format.h>
+
+#include <gtest/gtest.h>
+
+#include <glog/logging.h>
+
+namespace xaya
+{
+namespace
+{
+
+using google::protobuf::TextFormat;
+
+/**
+ * Parses a text-format string into a StateProof proto.
+ */
+StateProof
+ParseStateProof (const std::string& str)
+{
+  StateProof res;
+  CHECK (TextFormat::ParseFromString (str, &res));
+
+  return res;
+}
+
+class ChannelGameTests : public TestGameFixture
+{
+
+private:
+
+  ChannelMetadata meta;
+
+  ChannelsTable tbl;
+
+protected:
+
+  ChannelGameTests ()
+    : tbl(game)
+  {
+    meta.add_participants ()->set_address ("addr0");
+    meta.add_participants ()->set_address ("addr1");
+
+    ValidSignature ("sgn0", "addr0");
+    ValidSignature ("sgn1", "addr1");
+    ValidSignature ("sgn42", "addr42");
+  }
+
+  /**
+   * Creates or retrieves a handle for a channel based on a given "name".
+   * The channel's ID is derived from the name, so that multiple channels
+   * can be used in tests as needed.  The channel has its metadata set to
+   * the "meta" default instance, else no changes are made.
+   */
+  ChannelsTable::Handle
+  GetChannel (const std::string& name)
+  {
+    const uint256 id = SHA256::Hash (name);
+
+    auto h = tbl.GetById (id);
+    if (h == nullptr)
+      h = tbl.CreateNew (id);
+
+    h->MutableMetadata () = meta;
+
+    return h;
+  }
+
+};
+
+/* ************************************************************************** */
+
+using DisputeTests = ChannelGameTests;
+
+TEST_F (DisputeTests, InvalidStateProof)
+{
+  auto ch = GetChannel ("test");
+  ch->SetState ("0 1");
+
+  ASSERT_FALSE (game.ProcessDispute (*ch, 100, ParseStateProof (R"(
+    initial_state:
+      {
+        data: "42 5"
+      }
+  )")));
+
+  EXPECT_EQ (ch->GetState (), "0 1");
+  EXPECT_FALSE (ch->HasDispute ());
+}
+
+TEST_F (DisputeTests, NoLaterTurn)
+{
+  auto ch = GetChannel ("test");
+  ch->SetDisputeHeight (50);
+  ch->SetState ("10 5");
+
+  ASSERT_FALSE (game.ProcessDispute (*ch, 100, ParseStateProof (R"(
+    initial_state:
+      {
+        data: "20 5"
+        signatures: "sgn0"
+        signatures: "sgn1"
+      }
+  )")));
+
+  EXPECT_EQ (ch->GetState (), "10 5");
+  ASSERT_TRUE (ch->HasDispute ());
+  EXPECT_EQ (ch->GetDisputeHeight (), 50);
+}
+
+TEST_F (DisputeTests, SettingValidDispute)
+{
+  auto ch = GetChannel ("test");
+  ch->SetState ("10 5");
+
+  ASSERT_TRUE (game.ProcessDispute (*ch, 100, ParseStateProof (R"(
+    initial_state:
+      {
+        data: "20 6"
+        signatures: "sgn0"
+        signatures: "sgn1"
+      }
+  )")));
+
+  EXPECT_EQ (ch->GetState (), "20 6");
+  ASSERT_TRUE (ch->HasDispute ());
+  EXPECT_EQ (ch->GetDisputeHeight (), 100);
+}
+
+TEST_F (DisputeTests, UpdateAtSameHeight)
+{
+  auto ch = GetChannel ("test");
+  ch->SetDisputeHeight (100);
+  ch->SetState ("10 5");
+
+  ASSERT_TRUE (game.ProcessDispute (*ch, 100, ParseStateProof (R"(
+    initial_state:
+      {
+        data: "20 6"
+        signatures: "sgn0"
+        signatures: "sgn1"
+      }
+  )")));
+
+  EXPECT_EQ (ch->GetState (), "20 6");
+  ASSERT_TRUE (ch->HasDispute ());
+  EXPECT_EQ (ch->GetDisputeHeight (), 100);
+}
+
+/* ************************************************************************** */
+
+} // anonymous namespace
+} // namespace xaya

--- a/gamechannel/database.cpp
+++ b/gamechannel/database.cpp
@@ -4,6 +4,8 @@
 
 #include "database.hpp"
 
+#include "channelgame.hpp"
+
 #include <glog/logging.h>
 
 #include <set>

--- a/gamechannel/database.hpp
+++ b/gamechannel/database.hpp
@@ -6,7 +6,6 @@
 #define GAMECHANNEL_DATABASE_HPP
 
 #include "boardrules.hpp"
-#include "channelgame.hpp"
 
 #include "proto/metadata.pb.h"
 
@@ -18,6 +17,8 @@
 
 namespace xaya
 {
+
+class ChannelGame;
 
 /**
  * Wrapper class around the state of one channel in the database.  This

--- a/gamechannel/stateproof_tests.cpp
+++ b/gamechannel/stateproof_tests.cpp
@@ -64,11 +64,11 @@ protected:
 
 TEST_F (StateTransitionTests, NoTurnState)
 {
-  EXPECT_FALSE (VerifyTransition ("100", R"(
+  EXPECT_FALSE (VerifyTransition ("100 1", R"(
     move: "1",
     new_state:
       {
-        data: "101"
+        data: "101 2"
         signatures: "sgn0"
       }
   )"));
@@ -76,11 +76,11 @@ TEST_F (StateTransitionTests, NoTurnState)
 
 TEST_F (StateTransitionTests, InvalidMove)
 {
-  EXPECT_FALSE (VerifyTransition ("10", R"(
+  EXPECT_FALSE (VerifyTransition ("10 1", R"(
     move: "0",
     new_state:
       {
-        data: "10"
+        data: "10 2"
         signatures: "sgn0"
       }
   )"));
@@ -88,11 +88,11 @@ TEST_F (StateTransitionTests, InvalidMove)
 
 TEST_F (StateTransitionTests, NewStateMismatch)
 {
-  EXPECT_FALSE (VerifyTransition ("10", R"(
+  EXPECT_FALSE (VerifyTransition ("10 1", R"(
     move: "1",
     new_state:
       {
-        data: "12"
+        data: "11 5"
         signatures: "sgn0"
       }
   )"));
@@ -100,11 +100,11 @@ TEST_F (StateTransitionTests, NewStateMismatch)
 
 TEST_F (StateTransitionTests, InvalidSignature)
 {
-  EXPECT_FALSE (VerifyTransition ("10", R"(
+  EXPECT_FALSE (VerifyTransition ("10 1", R"(
     move: "1",
     new_state:
       {
-        data: "11"
+        data: "11 2"
         signatures: "sgn1"
         signatures: "sgn42"
       }
@@ -113,13 +113,13 @@ TEST_F (StateTransitionTests, InvalidSignature)
 
 TEST_F (StateTransitionTests, Valid)
 {
-  ExpectSignature (" 11 ", "signed by zero", "addr0");
+  ExpectSignature (" 11 2 ", "signed by zero", "addr0");
 
-  EXPECT_TRUE (VerifyTransition ("10", R"(
+  EXPECT_TRUE (VerifyTransition ("10 1", R"(
     move: "1",
     new_state:
       {
-        data: " 11 "
+        data: " 11 2 "
         signatures: "signed by zero"
         signatures: "sgn42"
       }
@@ -153,38 +153,38 @@ protected:
 
 TEST_F (StateProofTests, OnlyInitialOnChain)
 {
-  ASSERT_TRUE (VerifyProof (" 42 ", R"(
+  ASSERT_TRUE (VerifyProof (" 42 5 ", R"(
     initial_state:
       {
-        data: "42"
+        data: "42 5"
         signatures: "sgn42"
       }
   )"));
-  EXPECT_EQ (endState, "42");
+  EXPECT_EQ (endState, "42 5");
 }
 
 TEST_F (StateProofTests, OnlyInitialSigned)
 {
-  ExpectSignature ("42", "signature 0", "addr0");
-  ExpectSignature ("42", "signature 1", "addr1");
+  ExpectSignature ("42 5", "signature 0", "addr0");
+  ExpectSignature ("42 5", "signature 1", "addr1");
 
-  ASSERT_TRUE (VerifyProof ("0", R"(
+  ASSERT_TRUE (VerifyProof ("0 1", R"(
     initial_state:
       {
-        data: "42"
+        data: "42 5"
         signatures: "signature 0"
         signatures: "signature 1"
       }
   )"));
-  EXPECT_EQ (endState, "42");
+  EXPECT_EQ (endState, "42 5");
 }
 
 TEST_F (StateProofTests, OnlyInitialNotSigned)
 {
-  EXPECT_FALSE (VerifyProof ("0", R"(
+  EXPECT_FALSE (VerifyProof ("0 1", R"(
     initial_state:
       {
-        data: "42"
+        data: "42 5"
         signatures: "sgn0"
         signatures: "sgn42"
       }
@@ -193,32 +193,32 @@ TEST_F (StateProofTests, OnlyInitialNotSigned)
 
 TEST_F (StateProofTests, InvalidTransition)
 {
-  EXPECT_FALSE (VerifyProof ("42", R"(
+  EXPECT_FALSE (VerifyProof ("42 1", R"(
     initial_state:
       {
-        data: "42"
+        data: "42 1"
       }
     transitions:
       {
         move: "0"
         new_state:
           {
-            data: "42"
+            data: "42 2"
           }
       }
   )"));
 
-  EXPECT_FALSE (VerifyProof ("42", R"(
+  EXPECT_FALSE (VerifyProof ("42 1", R"(
     initial_state:
       {
-        data: "42"
+        data: "42 1"
       }
     transitions:
       {
         move: "1"
         new_state:
           {
-            data: "43"
+            data: "43 2"
             signatures: "sgn1"
           }
       }
@@ -227,17 +227,17 @@ TEST_F (StateProofTests, InvalidTransition)
 
 TEST_F (StateProofTests, MissingSignature)
 {
-  EXPECT_FALSE (VerifyProof ("0", R"(
+  EXPECT_FALSE (VerifyProof ("0 1", R"(
     initial_state:
       {
-        data: "42"
+        data: "42 5"
       }
     transitions:
       {
         move: "2"
         new_state:
           {
-            data: "44"
+            data: "44 6"
             signatures: "sgn0"
           }
       }
@@ -246,7 +246,7 @@ TEST_F (StateProofTests, MissingSignature)
         move: "2"
         new_state:
           {
-            data: "46"
+            data: "46 7"
             signatures: "sgn0"
           }
       }
@@ -255,17 +255,17 @@ TEST_F (StateProofTests, MissingSignature)
 
 TEST_F (StateProofTests, IntermediateStateOnChain)
 {
-  ASSERT_TRUE (VerifyProof (" 44 ", R"(
+  ASSERT_TRUE (VerifyProof (" 44 11 ", R"(
     initial_state:
       {
-        data: "42"
+        data: "42 10"
       }
     transitions:
       {
         move: "2"
         new_state:
           {
-            data: "44"
+            data: "44 11"
             signatures: "sgn0"
           }
       }
@@ -274,20 +274,20 @@ TEST_F (StateProofTests, IntermediateStateOnChain)
         move: "2"
         new_state:
           {
-            data: "46"
+            data: "46 12"
             signatures: "sgn0"
           }
       }
   )"));
-  EXPECT_EQ (endState, "46");
+  EXPECT_EQ (endState, "46 12");
 }
 
 TEST_F (StateProofTests, SignedInitialState)
 {
-  ASSERT_TRUE (VerifyProof ("0", R"(
+  ASSERT_TRUE (VerifyProof ("0 1", R"(
     initial_state:
       {
-        data: "42"
+        data: "42 5"
         signatures: "sgn1"
       }
     transitions:
@@ -295,33 +295,33 @@ TEST_F (StateProofTests, SignedInitialState)
         move: "1"
         new_state:
           {
-            data: "43"
+            data: "43 6"
             signatures: "sgn0"
           }
       }
   )"));
-  EXPECT_EQ (endState, "43");
+  EXPECT_EQ (endState, "43 6");
 }
 
 TEST_F (StateProofTests, MultiSignedLaterState)
 {
-  ASSERT_TRUE (VerifyProof ("0", R"(
+  ASSERT_TRUE (VerifyProof ("0 1", R"(
     initial_state:
       {
-        data: "42"
+        data: "42 5"
       }
     transitions:
       {
         move: "1"
         new_state:
           {
-            data: "43"
+            data: "43 6"
             signatures: "sgn0"
             signatures: "sgn1"
           }
       }
   )"));
-  EXPECT_EQ (endState, "43");
+  EXPECT_EQ (endState, "43 6");
 }
 
 /* ************************************************************************** */

--- a/gamechannel/stateproof_tests.cpp
+++ b/gamechannel/stateproof_tests.cpp
@@ -6,8 +6,6 @@
 
 #include "testgame.hpp"
 
-#include <xayautil/hash.hpp>
-
 #include <google/protobuf/text_format.h>
 
 #include <gtest/gtest.h>

--- a/gamechannel/testgame.cpp
+++ b/gamechannel/testgame.cpp
@@ -131,6 +131,7 @@ TestGameFixture::TestGameFixture ()
     rpcClient(httpClient)
 {
   game.Initialise (":memory:");
+  game.InitialiseGameContext (Chain::MAIN, "add", &rpcClient);
   game.GetStorage ()->Initialise ();
   /* The initialisation above already sets up the database schema.  */
 

--- a/gamechannel/testgame.hpp
+++ b/gamechannel/testgame.hpp
@@ -32,10 +32,12 @@ class TestGameFixture;
  * Board rules for a trivial example game used in unit tests.  The game goes
  * like this:
  *
- * The current state is a number, encoded simply in a string.  The current
+ * The current state is a pair of numbers, encoded simply in a string.  Those
+ * numbers are a "current number" and the turn count.  The current
  * turn is for player (number % 2).  When the number is 100 or above, then
  * the game is finished.  A move is simply another, strictly positive number
  * encoded as a string, which gets added to the current "state number".
+ * The turn count is simply incremented on each turn made.
  */
 class AdditionRules : public BoardRules
 {
@@ -46,7 +48,10 @@ public:
                       const BoardState& a, const BoardState& b) const override;
 
   int WhoseTurn (const ChannelMetadata& meta,
-                 const BoardState& a) const override;
+                 const BoardState& state) const override;
+
+  unsigned TurnCount (const ChannelMetadata& meta,
+                      const BoardState& state) const override;
 
   bool ApplyMove (const ChannelMetadata& meta,
                   const BoardState& oldState, const BoardMove& mv,

--- a/gamechannel/testgame.hpp
+++ b/gamechannel/testgame.hpp
@@ -84,6 +84,7 @@ public:
   AdditionRules rules;
 
   using ChannelGame::ProcessDispute;
+  using ChannelGame::ProcessResolution;
 
 };
 

--- a/gamechannel/testgame.hpp
+++ b/gamechannel/testgame.hpp
@@ -83,6 +83,8 @@ public:
 
   AdditionRules rules;
 
+  using ChannelGame::ProcessDispute;
+
 };
 
 /**

--- a/gamechannel/testgame_tests.cpp
+++ b/gamechannel/testgame_tests.cpp
@@ -25,33 +25,40 @@ protected:
 
 TEST_F (AdditionRulesTests, CompareStates)
 {
-  EXPECT_TRUE (rules.CompareStates (meta, "1", " 1 "));
-  EXPECT_TRUE (rules.CompareStates (meta, "105", "105"));
-  EXPECT_FALSE (rules.CompareStates (meta, "2", "3"));
-  EXPECT_FALSE (rules.CompareStates (meta, "105", "106"));
+  EXPECT_TRUE (rules.CompareStates (meta, "1 2", " 1 2 "));
+  EXPECT_TRUE (rules.CompareStates (meta, "105 10", "105 10"));
+  EXPECT_FALSE (rules.CompareStates (meta, "2 1", "3 1"));
+  EXPECT_FALSE (rules.CompareStates (meta, "105 1", "106 1"));
+  EXPECT_FALSE (rules.CompareStates (meta, "5 1", "5 2"));
 }
 
 TEST_F (AdditionRulesTests, WhoseTurn)
 {
-  EXPECT_EQ (rules.WhoseTurn (meta, "13"), 1);
-  EXPECT_EQ (rules.WhoseTurn (meta, "42"), 0);
-  EXPECT_EQ (rules.WhoseTurn (meta, "99"), 1);
-  EXPECT_EQ (rules.WhoseTurn (meta, "100"), BoardRules::NO_TURN);
-  EXPECT_EQ (rules.WhoseTurn (meta, "105"), BoardRules::NO_TURN);
+  EXPECT_EQ (rules.WhoseTurn (meta, "13 1"), 1);
+  EXPECT_EQ (rules.WhoseTurn (meta, "42 1"), 0);
+  EXPECT_EQ (rules.WhoseTurn (meta, "99 2"), 1);
+  EXPECT_EQ (rules.WhoseTurn (meta, "100 10"), BoardRules::NO_TURN);
+  EXPECT_EQ (rules.WhoseTurn (meta, "105 10"), BoardRules::NO_TURN);
+}
+
+TEST_F (AdditionRulesTests, TurnCount)
+{
+  EXPECT_EQ (rules.TurnCount (meta, "10 12"), 12);
+  EXPECT_EQ (rules.TurnCount (meta, "105 1"), 1);
 }
 
 TEST_F (AdditionRulesTests, ApplyMove)
 {
   BoardState newState;
-  ASSERT_TRUE (rules.ApplyMove (meta, "42", "13", newState));
-  EXPECT_EQ (newState, "55");
-  ASSERT_TRUE (rules.ApplyMove (meta, "99", "2", newState));
-  EXPECT_EQ (newState, "101");
+  ASSERT_TRUE (rules.ApplyMove (meta, "42 5", "13", newState));
+  EXPECT_EQ (newState, "55 6");
+  ASSERT_TRUE (rules.ApplyMove (meta, "99 10", "2", newState));
+  EXPECT_EQ (newState, "101 11");
 
-  EXPECT_FALSE (rules.ApplyMove (meta, "42", "0", newState));
-  EXPECT_FALSE (rules.ApplyMove (meta, "42", "-1", newState));
+  EXPECT_FALSE (rules.ApplyMove (meta, "42 1", "0", newState));
+  EXPECT_FALSE (rules.ApplyMove (meta, "42 1", "-1", newState));
 
-  EXPECT_DEATH (rules.ApplyMove (meta, "100", "1", newState), "no turn");
+  EXPECT_DEATH (rules.ApplyMove (meta, "100 1", "1", newState), "no turn");
 }
 
 } // anonymous namespace


### PR DESCRIPTION
This set of changes implements generic functions in the game-channels framework for processing disputes and resolutions.  These functions (part of `ChannelGame`) can be called from the move processor of a concrete game to help it process disputes/resolutions in open channels.