### PR TITLE
Game channels: Refactor BoardRules to allow "parsing"

### DIFF
--- a/gamechannel/boardrules.cpp
+++ b/gamechannel/boardrules.cpp
@@ -7,6 +7,6 @@
 namespace xaya
 {
 
-constexpr int BoardRules::NO_TURN;
+constexpr int ParsedBoardState::NO_TURN;
 
 } // namespace xaya

--- a/gamechannel/boardrules.hpp
+++ b/gamechannel/boardrules.hpp
@@ -52,6 +52,9 @@ public:
    * Compares two given board states in the context of the given metadata.
    * Returns true if they are equivalent (i.e. possibly different encodings
    * of the same state).
+   *
+   * If one or both of the passed states is invalid (e.g. malformed data),
+   * then the function should return false.
    */
   virtual bool CompareStates (const proto::ChannelMetadata& meta,
                               const BoardState& a,
@@ -61,6 +64,10 @@ public:
    * Returns which player's turn it is in the given state.  The return value
    * is the player index into the channel's participants array.  This may return
    * NO_TURN to indicate that it is noone's turn at the moment.
+   *
+   * It is guaranteed that this function is never called on an invalid state.
+   * In other words, it is only called on results of successful calls
+   * to ApplyMove.
    */
   virtual int WhoseTurn (const proto::ChannelMetadata& meta,
                          const BoardState& state) const = 0;
@@ -71,6 +78,10 @@ public:
    * to determine whether a given state is "after" another.  It can also be
    * seen as the "block height" in the "private chain" formed during a game
    * on a channel.
+   *
+   * It is guaranteed that this function is never called on an invalid state.
+   * In other words, it is only called on results of successful calls
+   * to ApplyMove.
    */
   virtual unsigned TurnCount (const proto::ChannelMetadata& meta,
                               const BoardState& state) const = 0;
@@ -78,7 +89,12 @@ public:
   /**
    * Applies a move (assumed to be made by the player whose turn it is)
    * onto the given state, yielding a new board state.  Returns false
-   * if the move is invalid instead.
+   * if the move is invalid instead (either because the data itself does
+   * not represent a move at all, or because the move is invalid in the
+   * context of the given old state).
+   *
+   * If the old state is invalid (e.g. malformed data), then this function
+   * should also return false.
    */
   virtual bool ApplyMove (const proto::ChannelMetadata& meta,
                           const BoardState& oldState, const BoardMove& mv,

--- a/gamechannel/boardrules.hpp
+++ b/gamechannel/boardrules.hpp
@@ -7,6 +7,9 @@
 
 #include "proto/metadata.pb.h"
 
+#include <xayagame/rpc-stubs/xayarpcclient.h>
+
+#include <memory>
 #include <string>
 
 namespace xaya
@@ -22,20 +25,21 @@ using BoardState = std::string;
 using BoardMove = std::string;
 
 /**
- * Abstract base class for the game-specific processor of board states and
- * moves on a channel.  This is the main class defining the rules of the
- * on-chain game.
+ * Interface for a game-specific "parsed" representation of a board state.
+ * Instances of subclasses are obtained by parsing an (encoded) BoardState
+ * through the game's BoardRules instance, and then those instances can be
+ * used to further work with a game state.
  *
- * The implemented methods of this class should be pure and thread-safe.
- * They may be called in parallel and from various different threads from
- * the game-channel framework.
+ * A typical usage pattern here is that the BoardState could be a serialised
+ * protocol buffer, while the ParsedBoardState is a wrapper class around
+ * the actual protocol buffer.
  */
-class BoardRules
+class ParsedBoardState
 {
 
 protected:
 
-  BoardRules () = default;
+  ParsedBoardState () = default;
 
 public:
 
@@ -46,59 +50,76 @@ public:
    */
   static constexpr int NO_TURN = -1;
 
-  virtual ~BoardRules () = default;
+  virtual ~ParsedBoardState () = default;
 
   /**
-   * Compares two given board states in the context of the given metadata.
-   * Returns true if they are equivalent (i.e. possibly different encodings
-   * of the same state).
+   * Compares the current state to the given other board state.  Returns true
+   * if they are equivalent (i.e. possibly different encodings of the same
+   * state).
    *
-   * If one or both of the passed states is invalid (e.g. malformed data),
-   * then the function should return false.
+   * The passed in BoardState may be invalid (even malformed encoded data),
+   * in which case this function should return false.
    */
-  virtual bool CompareStates (const proto::ChannelMetadata& meta,
-                              const BoardState& a,
-                              const BoardState& b) const = 0;
+  virtual bool Equals (const BoardState& other) const = 0;
 
   /**
-   * Returns which player's turn it is in the given state.  The return value
-   * is the player index into the channel's participants array.  This may return
-   * NO_TURN to indicate that it is noone's turn at the moment.
-   *
-   * It is guaranteed that this function is never called on an invalid state.
-   * In other words, it is only called on results of successful calls
-   * to ApplyMove.
+   * Returns which player's turn it is in the current state.  The return value
+   * is the player index into the associated channel's participants array.
+   * This may return NO_TURN to indicate that it is noone's turn at the moment.
    */
-  virtual int WhoseTurn (const proto::ChannelMetadata& meta,
-                         const BoardState& state) const = 0;
+  virtual int WhoseTurn () const = 0;
 
   /**
-   * Returns the "turn count" for the given game state.  This is a number
+   * Returns the "turn count" for the current game state.  This is a number
    * that should increase with turns made in the game, so that it is possible
    * to determine whether a given state is "after" another.  It can also be
    * seen as the "block height" in the "private chain" formed during a game
    * on a channel.
-   *
-   * It is guaranteed that this function is never called on an invalid state.
-   * In other words, it is only called on results of successful calls
-   * to ApplyMove.
    */
-  virtual unsigned TurnCount (const proto::ChannelMetadata& meta,
-                              const BoardState& state) const = 0;
+  virtual unsigned TurnCount () const = 0;
 
   /**
    * Applies a move (assumed to be made by the player whose turn it is)
-   * onto the given state, yielding a new board state.  Returns false
+   * onto the current state, yielding a new board state.  Returns false
    * if the move is invalid instead (either because the data itself does
    * not represent a move at all, or because the move is invalid in the
    * context of the given old state).
-   *
-   * If the old state is invalid (e.g. malformed data), then this function
-   * should also return false.
    */
-  virtual bool ApplyMove (const proto::ChannelMetadata& meta,
-                          const BoardState& oldState, const BoardMove& mv,
+  virtual bool ApplyMove (XayaRpcClient& rpc, const BoardMove& mv,
                           BoardState& newState) const = 0;
+
+};
+
+/**
+ * Abstract base class for the game-specific processor of board states and
+ * moves on a channel.  This is the main class defining the rules of the
+ * on-chain game, by means of constructing proper subclasses of
+ * ParsedBoardState (which then do the real processing).
+ */
+class BoardRules
+{
+
+protected:
+
+  BoardRules () = default;
+
+public:
+
+  virtual ~BoardRules () = default;
+
+  /**
+   * Parses an encoded BoardState into a ParsedBoardState instance, which
+   * implements the abstract methods suitably for the game at hand.
+   *
+   * If the state is invalid (e.g. malformed data), this function should return
+   * nullptr instead.
+   *
+   * The passed-in ChannelMetadata can be used to put the board state into
+   * context.  It is guaranteed that the reference stays valid at least as
+   * long as the returned ParsedBoardState instance will be alive.
+   */
+  virtual std::unique_ptr<ParsedBoardState> ParseState (
+      const proto::ChannelMetadata& meta, const BoardState& s) const = 0;
 
 };
 

--- a/gamechannel/channelgame.cpp
+++ b/gamechannel/channelgame.cpp
@@ -78,6 +78,14 @@ ChannelGame::ProcessDispute (ChannelData& ch, const unsigned height,
   if (!CheckStateProofIsLater (GetXayaRpc (), rules, ch, proof, provenState))
     return false;
 
+  const auto provenParsed = rules.ParseState (meta, provenState);
+  CHECK (provenParsed != nullptr);
+  if (provenParsed->WhoseTurn () == ParsedBoardState::NO_TURN)
+    {
+      LOG (WARNING) << "Cannot file dispute for 'no turn' situation";
+      return false;
+    }
+
   VLOG (1) << "Dispute is valid, updating state...";
 
   ch.SetState (provenState);

--- a/gamechannel/channelgame.cpp
+++ b/gamechannel/channelgame.cpp
@@ -40,8 +40,13 @@ CheckStateProofIsLater (XayaRpcClient& rpc, const BoardRules& rules,
       return false;
     }
 
-  const unsigned onChainCnt = rules.TurnCount (meta, onChainState);
-  const unsigned provenCnt = rules.TurnCount (meta, provenState);
+  const auto onChainParsed = rules.ParseState (meta, onChainState);
+  CHECK (onChainParsed != nullptr);
+  const auto provenParsed = rules.ParseState (meta, provenState);
+  CHECK (provenParsed != nullptr);
+
+  const unsigned onChainCnt = onChainParsed->TurnCount ();
+  const unsigned provenCnt = provenParsed->TurnCount ();
   if (onChainCnt >= provenCnt)
     {
       LOG (WARNING)
@@ -60,16 +65,18 @@ bool
 ChannelGame::ProcessDispute (ChannelData& ch, const unsigned height,
                              const proto::StateProof& proof)
 {
-  BoardState provenState;
-  if (!CheckStateProofIsLater (GetXayaRpc (), GetBoardRules (), ch, proof,
-                               provenState))
-    return false;
-
   /* If there is already a dispute in the on-chain game state, then it can only
      have been placed there by an earlier block (or perhaps the same block
      in edge cases).  */
   if (ch.HasDispute ())
     CHECK_GE (height, ch.GetDisputeHeight ());
+
+  const auto& meta = ch.GetMetadata ();
+  const auto& rules = GetBoardRules ();
+
+  BoardState provenState;
+  if (!CheckStateProofIsLater (GetXayaRpc (), rules, ch, proof, provenState))
+    return false;
 
   VLOG (1) << "Dispute is valid, updating state...";
 

--- a/gamechannel/channelgame_tests.cpp
+++ b/gamechannel/channelgame_tests.cpp
@@ -97,6 +97,24 @@ TEST_F (DisputeTests, InvalidStateProof)
   EXPECT_FALSE (ch->HasDispute ());
 }
 
+TEST_F (DisputeTests, InvalidStateClaimed)
+{
+  auto ch = GetChannel ("test");
+  ch->SetState ("0 1");
+
+  ASSERT_FALSE (game.ProcessDispute (*ch, 100, ParseStateProof (R"(
+    initial_state:
+      {
+        data: "invalid"
+        signatures: "sgn0"
+        signatures: "sgn1"
+      }
+  )")));
+
+  EXPECT_EQ (ch->GetState (), "0 1");
+  EXPECT_FALSE (ch->HasDispute ());
+}
+
 TEST_F (DisputeTests, NoLaterTurn)
 {
   auto ch = GetChannel ("test");
@@ -170,6 +188,26 @@ TEST_F (ResolutionTests, InvalidStateProof)
     initial_state:
       {
         data: "42 5"
+      }
+  )")));
+
+  EXPECT_EQ (ch->GetState (), "0 1");
+  ASSERT_TRUE (ch->HasDispute ());
+  EXPECT_EQ (ch->GetDisputeHeight (), 100);
+}
+
+TEST_F (ResolutionTests, InvalidStateClaimed)
+{
+  auto ch = GetChannel ("test");
+  ch->SetDisputeHeight (100);
+  ch->SetState ("0 1");
+
+  ASSERT_FALSE (game.ProcessResolution (*ch, ParseStateProof (R"(
+    initial_state:
+      {
+        data: "invalid"
+        signatures: "sgn0"
+        signatures: "sgn1"
       }
   )")));
 

--- a/gamechannel/channelgame_tests.cpp
+++ b/gamechannel/channelgame_tests.cpp
@@ -135,6 +135,24 @@ TEST_F (DisputeTests, NoLaterTurn)
   EXPECT_EQ (ch->GetDisputeHeight (), 50);
 }
 
+TEST_F (DisputeTests, NoTurnState)
+{
+  auto ch = GetChannel ("test");
+  ch->SetState ("100 5");
+
+  ASSERT_FALSE (game.ProcessDispute (*ch, 100, ParseStateProof (R"(
+    initial_state:
+      {
+        data: "101 6"
+        signatures: "sgn0"
+        signatures: "sgn1"
+      }
+  )")));
+
+  EXPECT_EQ (ch->GetState (), "100 5");
+  EXPECT_FALSE (ch->HasDispute ());
+}
+
 TEST_F (DisputeTests, SettingValidDispute)
 {
   auto ch = GetChannel ("test");
@@ -252,6 +270,25 @@ TEST_F (ResolutionTests, Valid)
   )")));
 
   EXPECT_EQ (ch->GetState (), "20 6");
+  EXPECT_FALSE (ch->HasDispute ());
+}
+
+TEST_F (ResolutionTests, ResolvesToNoTurnState)
+{
+  auto ch = GetChannel ("test");
+  ch->SetDisputeHeight (100);
+  ch->SetState ("10 5");
+
+  ASSERT_TRUE (game.ProcessResolution (*ch, ParseStateProof (R"(
+    initial_state:
+      {
+        data: "100 6"
+        signatures: "sgn0"
+        signatures: "sgn1"
+      }
+  )")));
+
+  EXPECT_EQ (ch->GetState (), "100 6");
   EXPECT_FALSE (ch->HasDispute ());
 }
 

--- a/gamechannel/stateproof.cpp
+++ b/gamechannel/stateproof.cpp
@@ -24,27 +24,34 @@ namespace
 bool
 ExtraVerifyStateTransition (XayaRpcClient& rpc, const BoardRules& rules,
                             const proto::ChannelMetadata& meta,
-                            const BoardState& oldState,
+                            const ParsedBoardState& oldState,
                             const proto::StateTransition& transition,
-                            std::set<int>& signatures)
+                            std::set<int>& signatures,
+                            std::unique_ptr<ParsedBoardState>& parsedNew)
 {
+
+  const int turn = oldState.WhoseTurn ();
+  if (turn == ParsedBoardState::NO_TURN)
+    {
+      LOG (WARNING) << "State transition applied to 'no turn' state";
+      return false;
+    }
+
   BoardState newState;
-  if (!rules.ApplyMove (meta, oldState, transition.move (), newState))
+  if (!oldState.ApplyMove (rpc, transition.move (), newState))
     {
       LOG (WARNING) << "Failed to apply move of state transition";
       return false;
     }
 
-  if (!rules.CompareStates (meta, transition.new_state ().data (), newState))
+  parsedNew = rules.ParseState (meta, newState);
+  /* newState is not user-provided but the output of a successful ApplyMove,
+     so it should be guaranteed to be valid.  */
+  CHECK (parsedNew != nullptr);
+
+  if (!parsedNew->Equals (transition.new_state ().data ()))
     {
       LOG (WARNING) << "Wrong new state claimed in state transition";
-      return false;
-    }
-
-  const int turn = rules.WhoseTurn (meta, oldState);
-  if (turn == BoardRules::NO_TURN)
-    {
-      LOG (WARNING) << "State transition applied to 'no turn' state";
       return false;
     }
 
@@ -67,9 +74,17 @@ VerifyStateTransition (XayaRpcClient& rpc, const BoardRules& rules,
                        const BoardState& oldState,
                        const proto::StateTransition& transition)
 {
+  const auto parsedOld = rules.ParseState (meta, oldState);
+  if (parsedOld == nullptr)
+    {
+      LOG (WARNING) << "Invalid old state in state transition";
+      return false;
+    }
+
+  std::unique_ptr<ParsedBoardState> parsedNew;
   std::set<int> signatures;
-  return ExtraVerifyStateTransition (rpc, rules, meta, oldState, transition,
-                                     signatures);
+  return ExtraVerifyStateTransition (rpc, rules, meta, *parsedOld, transition,
+                                     signatures, parsedNew);
 }
 
 bool
@@ -81,30 +96,30 @@ VerifyStateProof (XayaRpcClient& rpc, const BoardRules& rules,
 {
   std::set<int> signatures
       = VerifyParticipantSignatures (rpc, meta, proof.initial_state ());
+
+  auto parsed = rules.ParseState (meta, proof.initial_state ().data ());
+  if (parsed == nullptr)
+    {
+      LOG (WARNING) << "Invalid initial state for state proof";
+      return false;
+    }
+
   endState = proof.initial_state ().data ();
-  bool foundOnChain = rules.CompareStates (meta, onChainState, endState);
+  bool foundOnChain = parsed->Equals (onChainState);
 
   for (const auto& t : proof.transitions ())
     {
+      std::unique_ptr<ParsedBoardState> parsedNew;
       std::set<int> newSignatures;
-      if (!ExtraVerifyStateTransition (rpc, rules, meta, endState, t,
-                                       newSignatures))
+      if (!ExtraVerifyStateTransition (rpc, rules, meta, *parsed, t,
+                                       newSignatures, parsedNew))
         return false;
 
       signatures.insert (newSignatures.begin (), newSignatures.end ());
+      parsed = std::move (parsedNew);
       endState = t.new_state ().data ();
       if (!foundOnChain)
-        foundOnChain = rules.CompareStates (meta, onChainState, endState);
-    }
-
-  /* Make sure that the end state (which may be just the claimed initial
-     state) is valid.  Otherwise we might end up with invalid data put
-     onto the global game state.  (For instance, if the state proof consists
-     just of an invalid initial state that is signed by all players.)  */
-  if (!rules.CompareStates (meta, endState, endState))
-    {
-      LOG (WARNING) << "Proven endstate is invalid";
-      return false;
+        foundOnChain = parsed->Equals (onChainState);
     }
 
   if (foundOnChain)

--- a/gamechannel/stateproof_tests.cpp
+++ b/gamechannel/stateproof_tests.cpp
@@ -72,6 +72,18 @@ TEST_F (StateTransitionTests, NoTurnState)
   )"));
 }
 
+TEST_F (StateTransitionTests, InvalidClaimedNewState)
+{
+  EXPECT_FALSE (VerifyTransition ("10 1", R"(
+    move: "0",
+    new_state:
+      {
+        data: "invalid"
+        signatures: "sgn0"
+      }
+  )"));
+}
+
 TEST_F (StateTransitionTests, InvalidMove)
 {
   EXPECT_FALSE (VerifyTransition ("10 1", R"(
@@ -148,6 +160,52 @@ protected:
   }
 
 };
+
+TEST_F (StateProofTests, InvalidStates)
+{
+  EXPECT_FALSE (VerifyProof (" 42 5 ", R"(
+    initial_state:
+      {
+        data: "invalid"
+        signatures: "sgn0"
+        signatures: "sgn1"
+      }
+  )"));
+
+  EXPECT_FALSE (VerifyProof (" 42 5 ", R"(
+    initial_state:
+      {
+        data: "invalid"
+        signatures: "sgn1"
+      }
+    transitions:
+      {
+        move: "2"
+        new_state:
+          {
+            data: "44 6"
+            signatures: "sgn0"
+          }
+      }
+  )"));
+
+  EXPECT_FALSE (VerifyProof (" 42 5 ", R"(
+    initial_state:
+      {
+        data: "42 5"
+        signatures: "sgn1"
+      }
+    transitions:
+      {
+        move: "2"
+        new_state:
+          {
+            data: "invalid"
+            signatures: "sgn0"
+          }
+      }
+  )"));
+}
 
 TEST_F (StateProofTests, OnlyInitialOnChain)
 {

--- a/gamechannel/stateproof_tests.cpp
+++ b/gamechannel/stateproof_tests.cpp
@@ -72,6 +72,18 @@ TEST_F (StateTransitionTests, NoTurnState)
   )"));
 }
 
+TEST_F (StateTransitionTests, InvalidOldState)
+{
+  EXPECT_FALSE (VerifyTransition ("invalid", R"(
+    move: "0",
+    new_state:
+      {
+        data: "0 2"
+        signatures: "sgn0"
+      }
+  )"));
+}
+
 TEST_F (StateTransitionTests, InvalidClaimedNewState)
 {
   EXPECT_FALSE (VerifyTransition ("10 1", R"(

--- a/gamechannel/testgame.hpp
+++ b/gamechannel/testgame.hpp
@@ -21,6 +21,7 @@
 
 #include <json/json.h>
 
+#include <memory>
 #include <string>
 
 namespace xaya
@@ -44,18 +45,8 @@ class AdditionRules : public BoardRules
 
 public:
 
-  bool CompareStates (const proto::ChannelMetadata& meta,
-                      const BoardState& a, const BoardState& b) const override;
-
-  int WhoseTurn (const proto::ChannelMetadata& meta,
-                 const BoardState& state) const override;
-
-  unsigned TurnCount (const proto::ChannelMetadata& meta,
-                      const BoardState& state) const override;
-
-  bool ApplyMove (const proto::ChannelMetadata& meta,
-                  const BoardState& oldState, const BoardMove& mv,
-                  BoardState& newState) const override;
+  std::unique_ptr<ParsedBoardState> ParseState (
+      const proto::ChannelMetadata& meta, const BoardState& s) const override;
 
 };
 

--- a/gamechannel/testgame_tests.cpp
+++ b/gamechannel/testgame_tests.cpp
@@ -8,77 +8,102 @@
 
 #include <gtest/gtest.h>
 
+#include <glog/logging.h>
+
 namespace xaya
 {
 namespace
 {
 
-class AdditionRulesTests : public testing::Test
+class AdditionRulesTests : public TestGameFixture
 {
 
 protected:
 
   proto::ChannelMetadata meta;
-  AdditionRules rules;
+
+  bool
+  CompareStates (const BoardState& a, const BoardState& b)
+  {
+    const auto pa = game.rules.ParseState (meta, a);
+    CHECK (pa != nullptr);
+
+    return pa->Equals (b);
+  }
+
+  int
+  WhoseTurn (const BoardState& s)
+  {
+    const auto p = game.rules.ParseState (meta, s);
+    CHECK (p != nullptr);
+
+    return p->WhoseTurn ();
+  }
+
+  unsigned
+  TurnCount (const BoardState& s)
+  {
+    const auto p = game.rules.ParseState (meta, s);
+    CHECK (p != nullptr);
+
+    return p->TurnCount ();
+  }
+
+  bool
+  ApplyMove (const BoardState& old, const BoardMove& mv, BoardState& newState)
+  {
+    const auto po = game.rules.ParseState (meta, old);
+    CHECK (po != nullptr);
+
+    return po->ApplyMove (rpcClient, mv, newState);
+  }
 
 };
 
-TEST_F (AdditionRulesTests, CompareStates)
+TEST_F (AdditionRulesTests, ParseInvalid)
 {
-  EXPECT_TRUE (rules.CompareStates (meta, "1 2", " 1 2 "));
-  EXPECT_TRUE (rules.CompareStates (meta, "105 10", "105 10"));
-  EXPECT_FALSE (rules.CompareStates (meta, "2 1", "3 1"));
-  EXPECT_FALSE (rules.CompareStates (meta, "105 1", "106 1"));
-  EXPECT_FALSE (rules.CompareStates (meta, "5 1", "5 2"));
+  EXPECT_EQ (game.rules.ParseState (meta, "invalid"), nullptr);
 }
 
-TEST_F (AdditionRulesTests, CompareStatesInvalid)
+TEST_F (AdditionRulesTests, CompareStates)
 {
-  EXPECT_FALSE (rules.CompareStates (meta, "5 1", "invalid"));
-  EXPECT_FALSE (rules.CompareStates (meta, "invalid", "5 1"));
-  EXPECT_FALSE (rules.CompareStates (meta, "invalid", "invalid"));
+  EXPECT_TRUE (CompareStates ("1 2", " 1 2 "));
+  EXPECT_TRUE (CompareStates ("105 10", "105 10"));
+  EXPECT_FALSE (CompareStates ("2 1", "3 1"));
+  EXPECT_FALSE (CompareStates ("105 1", "106 1"));
+  EXPECT_FALSE (CompareStates ("5 1", "5 2"));
+  EXPECT_FALSE (CompareStates ("5 1", "invalid"));
 }
 
 TEST_F (AdditionRulesTests, WhoseTurn)
 {
-  EXPECT_EQ (rules.WhoseTurn (meta, "13 1"), 1);
-  EXPECT_EQ (rules.WhoseTurn (meta, "42 1"), 0);
-  EXPECT_EQ (rules.WhoseTurn (meta, "99 2"), 1);
-  EXPECT_EQ (rules.WhoseTurn (meta, "100 10"), BoardRules::NO_TURN);
-  EXPECT_EQ (rules.WhoseTurn (meta, "105 10"), BoardRules::NO_TURN);
-}
-
-TEST_F (AdditionRulesTests, WhoseTurnInvalid)
-{
-  EXPECT_DEATH (rules.WhoseTurn (meta, "invalid"), "invalid game state");
+  EXPECT_EQ (WhoseTurn ("13 1"), 1);
+  EXPECT_EQ (WhoseTurn ("42 1"), 0);
+  EXPECT_EQ (WhoseTurn ("99 2"), 1);
+  EXPECT_EQ (WhoseTurn ("100 10"), ParsedBoardState::NO_TURN);
+  EXPECT_EQ (WhoseTurn ("105 10"), ParsedBoardState::NO_TURN);
 }
 
 TEST_F (AdditionRulesTests, TurnCount)
 {
-  EXPECT_EQ (rules.TurnCount (meta, "10 12"), 12);
-  EXPECT_EQ (rules.TurnCount (meta, "105 1"), 1);
-}
-
-TEST_F (AdditionRulesTests, TurnCountInvalid)
-{
-  EXPECT_DEATH (rules.TurnCount (meta, "invalid"), "invalid game state");
+  EXPECT_EQ (TurnCount ("10 12"), 12);
+  EXPECT_EQ (TurnCount ("105 1"), 1);
 }
 
 TEST_F (AdditionRulesTests, ApplyMove)
 {
   BoardState newState;
-  ASSERT_TRUE (rules.ApplyMove (meta, "42 5", "13", newState));
+  ASSERT_TRUE (ApplyMove ("42 5", "13", newState));
   EXPECT_EQ (newState, "55 6");
-  ASSERT_TRUE (rules.ApplyMove (meta, "99 10", "2", newState));
+  ASSERT_TRUE (ApplyMove ("99 10", "2", newState));
   EXPECT_EQ (newState, "101 11");
 }
 
 TEST_F (AdditionRulesTests, ApplyMoveInvalid)
 {
   BoardState newState;
-  EXPECT_FALSE (rules.ApplyMove (meta, "42 1", "0", newState));
-  EXPECT_FALSE (rules.ApplyMove (meta, "42 1", "-1", newState));
-  EXPECT_FALSE (rules.ApplyMove (meta, "invalid", "1", newState));
+  EXPECT_FALSE (ApplyMove ("42 1", "0", newState));
+  EXPECT_FALSE (ApplyMove ("42 1", "-1", newState));
 }
 
 } // anonymous namespace

--- a/gamechannel/testgame_tests.cpp
+++ b/gamechannel/testgame_tests.cpp
@@ -32,6 +32,13 @@ TEST_F (AdditionRulesTests, CompareStates)
   EXPECT_FALSE (rules.CompareStates (meta, "5 1", "5 2"));
 }
 
+TEST_F (AdditionRulesTests, CompareStatesInvalid)
+{
+  EXPECT_FALSE (rules.CompareStates (meta, "5 1", "invalid"));
+  EXPECT_FALSE (rules.CompareStates (meta, "invalid", "5 1"));
+  EXPECT_FALSE (rules.CompareStates (meta, "invalid", "invalid"));
+}
+
 TEST_F (AdditionRulesTests, WhoseTurn)
 {
   EXPECT_EQ (rules.WhoseTurn (meta, "13 1"), 1);
@@ -41,10 +48,20 @@ TEST_F (AdditionRulesTests, WhoseTurn)
   EXPECT_EQ (rules.WhoseTurn (meta, "105 10"), BoardRules::NO_TURN);
 }
 
+TEST_F (AdditionRulesTests, WhoseTurnInvalid)
+{
+  EXPECT_DEATH (rules.WhoseTurn (meta, "invalid"), "invalid game state");
+}
+
 TEST_F (AdditionRulesTests, TurnCount)
 {
   EXPECT_EQ (rules.TurnCount (meta, "10 12"), 12);
   EXPECT_EQ (rules.TurnCount (meta, "105 1"), 1);
+}
+
+TEST_F (AdditionRulesTests, TurnCountInvalid)
+{
+  EXPECT_DEATH (rules.TurnCount (meta, "invalid"), "invalid game state");
 }
 
 TEST_F (AdditionRulesTests, ApplyMove)
@@ -54,11 +71,14 @@ TEST_F (AdditionRulesTests, ApplyMove)
   EXPECT_EQ (newState, "55 6");
   ASSERT_TRUE (rules.ApplyMove (meta, "99 10", "2", newState));
   EXPECT_EQ (newState, "101 11");
+}
 
+TEST_F (AdditionRulesTests, ApplyMoveInvalid)
+{
+  BoardState newState;
   EXPECT_FALSE (rules.ApplyMove (meta, "42 1", "0", newState));
   EXPECT_FALSE (rules.ApplyMove (meta, "42 1", "-1", newState));
-
-  EXPECT_DEATH (rules.ApplyMove (meta, "100 1", "1", newState), "no turn");
+  EXPECT_FALSE (rules.ApplyMove (meta, "invalid", "1", newState));
 }
 
 } // anonymous namespace


### PR DESCRIPTION
This refactors the `BoardRules` interface so that interpretation of states is moved to a new interface, `ParsedBoardState`.  The `BoardRules` themselves now only need to parse a given encoded `BoardState` and return a proper `ParsedBoardState` instance for it.

This allows us to avoid (some) unnecessary protocol buffer deserialisations when calling e.g. `WhoseTurn`, `TurnCount` and `ApplyMove` all on the same old state.  It also gives us better control over handling invalid states (e.g. malformed protocol buffer data).

Finally, this adds another rule for dispute processing:  Disputes are not allowed to be filed in "no turn" situations.  This makes sense, since there is no player who could be stalling the game in such a situation.