### PR TITLE
Xayaships basic board rules

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,3 +1,3 @@
 ACLOCAL_AMFLAGS = ${ACLOCAL_FLAGS} -Im4
 
-SUBDIRS = xayautil xayagame xayagametest mover gamechannel
+SUBDIRS = xayautil xayagame xayagametest mover gamechannel ships

--- a/README.md
+++ b/README.md
@@ -9,6 +9,11 @@ rules of their game.
 can move around an infinite plane.  It is fully functional, although mainly
 meant as example and/or basis for more complex games.
 
+This repository also contains a framework for [**game
+channels**](http://www.ledgerjournal.org/ojs/index.php/ledger/article/view/15)
+as well as [Xayaships](ships/README.md), which is an example game for
+channels.
+
 ## Building
 
 To build `libxayagame` and the example mover game, use the standard routine

--- a/configure.ac
+++ b/configure.ac
@@ -49,6 +49,7 @@ AC_CONFIG_FILES([
   gamechannel/Makefile \
   mover/Makefile \
   mover/gametest/Makefile \
+  ships/Makefile \
   xayagame/Makefile \
   xayagametest/Makefile \
   xayautil/Makefile \

--- a/ships/Makefile.am
+++ b/ships/Makefile.am
@@ -36,13 +36,14 @@ TESTS = tests
 
 tests_CXXFLAGS = \
   -I$(top_srcdir) \
-  $(GLOG_CFLAGS) $(GTEST_CFLAGS) $(PROTOBUF_CFLAGS)
+  $(JSONCPP_CFLAGS) $(GLOG_CFLAGS) $(GTEST_CFLAGS) $(PROTOBUF_CFLAGS)
 tests_LDADD = \
   $(builddir)/libships.la \
   $(top_builddir)/xayautil/libxayautil.la \
+  $(top_builddir)/xayagame/libtestutils.la \
   $(top_builddir)/xayagame/libxayagame.la \
   $(top_builddir)/gamechannel/libgamechannel.la \
-  $(GLOG_LIBS) $(GTEST_LIBS) $(PROTOBUF_LIBS)
+  $(JSONCPP_LIBS) $(GLOG_LIBS) $(GTEST_LIBS) $(PROTOBUF_LIBS)
 tests_SOURCES = \
   board_tests.cpp \
   coord_tests.cpp \

--- a/ships/Makefile.am
+++ b/ships/Makefile.am
@@ -43,7 +43,11 @@ tests_LDADD = \
   $(GLOG_LIBS) $(GTEST_LIBS) $(PROTOBUF_LIBS)
 tests_SOURCES = \
   coord_tests.cpp \
-  grid_tests.cpp
+  grid_tests.cpp \
+  \
+  testutils.cpp
+check_HEADERS = \
+  testutils.hpp
 
 proto/%.pb.h proto/%.pb.cc: $(srcdir)/proto/%.proto
 	protoc -I$(top_srcdir) -I$(srcdir)/proto --cpp_out=proto "$<"

--- a/ships/Makefile.am
+++ b/ships/Makefile.am
@@ -21,10 +21,12 @@ libships_la_LIBADD = \
   $(top_builddir)/gamechannel/libgamechannel.la \
   $(JSONCPP_LIBS) $(GLOG_LIBS) $(PROTOBUF_LIBS)
 libships_la_SOURCES = \
+  board.cpp \
   coord.cpp \
   grid.cpp \
   $(PROTOSOURCES)
 noinst_HEADERS = \
+  board.hpp \
   coord.hpp \
   grid.hpp \
   $(PROTOHEADERS)
@@ -42,6 +44,7 @@ tests_LDADD = \
   $(top_builddir)/gamechannel/libgamechannel.la \
   $(GLOG_LIBS) $(GTEST_LIBS) $(PROTOBUF_LIBS)
 tests_SOURCES = \
+  board_tests.cpp \
   coord_tests.cpp \
   grid_tests.cpp \
   \

--- a/ships/Makefile.am
+++ b/ships/Makefile.am
@@ -22,9 +22,11 @@ libships_la_LIBADD = \
   $(JSONCPP_LIBS) $(GLOG_LIBS) $(PROTOBUF_LIBS)
 libships_la_SOURCES = \
   coord.cpp \
+  grid.cpp \
   $(PROTOSOURCES)
 noinst_HEADERS = \
   coord.hpp \
+  grid.hpp \
   $(PROTOHEADERS)
 
 check_PROGRAMS = tests
@@ -40,7 +42,8 @@ tests_LDADD = \
   $(top_builddir)/gamechannel/libgamechannel.la \
   $(GLOG_LIBS) $(GTEST_LIBS) $(PROTOBUF_LIBS)
 tests_SOURCES = \
-  coord_tests.cpp
+  coord_tests.cpp \
+  grid_tests.cpp
 
 proto/%.pb.h proto/%.pb.cc: $(srcdir)/proto/%.proto
 	protoc -I$(top_srcdir) -I$(srcdir)/proto --cpp_out=proto "$<"

--- a/ships/Makefile.am
+++ b/ships/Makefile.am
@@ -1,0 +1,29 @@
+noinst_LTLIBRARIES = libships.la
+
+PROTOS = \
+  proto/boardmove.proto \
+  proto/boardstate.proto \
+  proto/winnerstatement.proto
+PROTOHEADERS = $(PROTOS:.proto=.pb.h)
+PROTOSOURCES = $(PROTOS:.proto=.pb.cc)
+
+EXTRA_DIST = $(PROTOS)
+
+BUILT_SOURCES = $(PROTOHEADERS)
+CLEANFILES = $(PROTOHEADERS) $(PROTOSOURCES)
+
+libships_la_CXXFLAGS = \
+  -I$(top_srcdir) \
+  $(JSONCPP_CFLAGS) $(GLOG_CFLAGS) $(PROTOBUF_CFLAGS)
+libships_la_LIBADD = \
+  $(top_builddir)/xayautil/libxayautil.la \
+  $(top_builddir)/xayagame/libxayagame.la \
+  $(top_builddir)/gamechannel/libgamechannel.la \
+  $(JSONCPP_LIBS) $(GLOG_LIBS) $(PROTOBUF_LIBS)
+libships_la_SOURCES = \
+  $(PROTOSOURCES)
+noinst_HEADERS = \
+  $(PROTOHEADERS)
+
+proto/%.pb.h proto/%.pb.cc: $(srcdir)/proto/%.proto
+	protoc -I$(top_srcdir) -I$(srcdir)/proto --cpp_out=proto "$<"

--- a/ships/Makefile.am
+++ b/ships/Makefile.am
@@ -21,9 +21,26 @@ libships_la_LIBADD = \
   $(top_builddir)/gamechannel/libgamechannel.la \
   $(JSONCPP_LIBS) $(GLOG_LIBS) $(PROTOBUF_LIBS)
 libships_la_SOURCES = \
+  coord.cpp \
   $(PROTOSOURCES)
 noinst_HEADERS = \
+  coord.hpp \
   $(PROTOHEADERS)
+
+check_PROGRAMS = tests
+TESTS = tests
+
+tests_CXXFLAGS = \
+  -I$(top_srcdir) \
+  $(GLOG_CFLAGS) $(GTEST_CFLAGS) $(PROTOBUF_CFLAGS)
+tests_LDADD = \
+  $(builddir)/libships.la \
+  $(top_builddir)/xayautil/libxayautil.la \
+  $(top_builddir)/xayagame/libxayagame.la \
+  $(top_builddir)/gamechannel/libgamechannel.la \
+  $(GLOG_LIBS) $(GTEST_LIBS) $(PROTOBUF_LIBS)
+tests_SOURCES = \
+  coord_tests.cpp
 
 proto/%.pb.h proto/%.pb.cc: $(srcdir)/proto/%.proto
 	protoc -I$(top_srcdir) -I$(srcdir)/proto --cpp_out=proto "$<"

--- a/ships/README.md
+++ b/ships/README.md
@@ -1,0 +1,69 @@
+# Xayaships
+
+*Xayaships* is an example game on the Xaya platform, demonstrating how
+[**game
+channels**](http://www.ledgerjournal.org/ojs/index.php/ledger/article/view/15)
+can be used for trustless and fully decentralised, scalable off-chain gaming.
+
+This is a simple implementation of the classical game
+[Battleships](https://en.wikipedia.org/wiki/Battleship_%28game%29), where
+players compete against each other and scores are recorded in the
+on-chain game state for eternity.
+
+Note that Xayaships is mainly intended to be an example game for demonstrating
+the capabilities of game channels, testing the implementation and releasing
+code that can be used and extended for other games.  Nevertheless, it provides
+a fully-functional game, that is still fun to play.
+
+The [game ID](https://github.com/xaya/xaya/blob/master/doc/xaya/games.md#games)
+of Xayaships is `g/xs`.
+
+## Game Overview
+
+The on-chain game state of Xayaships keeps track, for each Xaya username,
+of how many games that user has won and lost.  It also stores the
+currently open game channels as needed to process disputes.
+
+Channels can be opened at any time by sending a move requesting to
+open a channel, and anyone can send a move to join an existing channel
+waiting for a second player.  Channels can be closed anytime by the
+player in it as long as no other has joined.  If there are already
+two players in a channel, then it can be closed by any player (typically
+the winner) providing a message stating who won and signed by both participants.
+
+The battleships game itself (on a channel) is played on an **8x8 board**.
+(This allows us conveniently to store a boolean map of the entire board
+in an unsigned 64-bit integer.)
+The following ships are available for placement by each player:
+
+- 1x ship of size 4
+- 2x ship of size 3
+- 4x ship of size 2
+
+Ships can be placed anywhere horizontally or vertically, but are not
+allowed to overlap and also have to have a distance of at least one
+empty grid square (including diagonally) to other ships.
+
+At the beginning of the game, each player places their ships secretly
+and publishes a *hash* of their chosen position (and some salt to make
+brute-force guessing impossible).  Together with that hash, they also publish
+a second hash of some random data.  After that, both reveal the second data,
+and the combination is used to randomly determine who starts the game.
+
+Then the players take turns guessing a location, and the other player
+responds whether or not a ship has been hit; for the moment, this
+report is "trusted".
+When a ship has been hit, the player can make another guess.  Otherwise
+it becomes the opponent's turn.
+
+(Note that in contrast to typical rules, there is no distinction between
+"hit" and "sunk".  This simplifies the game, which helps build a good
+and easy to understand example game.)
+
+At any time, a player can end the game by publishing their full configuration
+and salt.  (This is typically done if all opponent ships have been sunk or
+if the player gets an impossible answer from the opponent.)  In that case,
+the opponent also has to publish their configuration
+and salt, and they are checked against hashes as well as the reported outcomes
+of shots during the game.  If a player lied, he loses the game.  Otherwise,
+the ending player wins if and only if all opponent ships have been sunk.

--- a/ships/board.cpp
+++ b/ships/board.cpp
@@ -608,4 +608,12 @@ ShipsBoardState::ApplyMoveProto (XayaRpcClient& rpc, const proto::BoardMove& mv,
   return false;
 }
 
+proto::BoardState
+InitialBoardState ()
+{
+  proto::BoardState res;
+  res.set_turn (0);
+  return res;
+}
+
 } // namespace ships

--- a/ships/board.cpp
+++ b/ships/board.cpp
@@ -1,0 +1,148 @@
+// Copyright (C) 2019 The Xaya developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "board.hpp"
+
+#include <glog/logging.h>
+
+namespace ships
+{
+
+bool
+ShipsBoardState::IsValid () const
+{
+  CHECK_EQ (GetMetadata ().participants_size (), 2);
+
+  /* If the phase is not well-defined, then the state is invalid.  */
+  const auto phase = GetPhase ();
+  if (phase == Phase::INVALID)
+    return false;
+
+  /* Unless the game is finished, we should have a turn set.  */
+  const auto& pb = GetState ();
+  if (!pb.has_turn () || phase == Phase::FINISHED)
+    return !pb.has_turn () && phase == Phase::FINISHED;
+
+  /* Since we have two players, turn should be zero or one.  */
+  const int turn = pb.turn ();
+  if (turn < 0 || turn > 1)
+    return false;
+
+  /* Verify some phase-dependent rules.  Especially check that turn is set
+     to the correct values for phases where the turn is redundant.  */
+  switch (phase)
+    {
+    case Phase::FIRST_COMMITMENT:
+    case Phase::FIRST_REVEAL_SEED:
+      if (turn != 0)
+        return false;
+      break;
+
+    case Phase::SECOND_COMMITMENT:
+      if (turn != 1)
+        return false;
+      break;
+
+    case Phase::SHOOT:
+    case Phase::ANSWER:
+      /* It can be any player's turn in this case.  This is when we really
+         need the turn field and it is not redundant.  */
+      break;
+
+    case Phase::SECOND_REVEAL_POSITION:
+      {
+        CHECK_EQ (pb.positions_size (), 2);
+        const int otherTurn = 1 - turn;
+        if (pb.positions (turn) != 0 || pb.positions (otherTurn) == 0)
+          return false;
+        break;
+      }
+
+    case Phase::WINNER_DETERMINED:
+      if (turn == static_cast<int> (pb.winner ()))
+        return false;
+      break;
+
+    default:
+      LOG (FATAL) << "Unexpected phase: " << static_cast<int> (phase);
+      return false;
+    }
+
+  return true;
+}
+
+ShipsBoardState::Phase
+ShipsBoardState::GetPhase () const
+{
+  const auto& pb = GetState ();
+
+  if (pb.has_winner_statement ())
+    return Phase::FINISHED;
+  if (pb.has_winner ())
+    return Phase::WINNER_DETERMINED;
+
+  switch (pb.position_hashes_size ())
+    {
+    case 0:
+      return Phase::FIRST_COMMITMENT;
+    case 1:
+      return Phase::SECOND_COMMITMENT;
+    case 2:
+      break;
+    default:
+      return Phase::INVALID;
+    }
+
+  switch (pb.known_ships_size ())
+    {
+    case 0:
+      return Phase::FIRST_REVEAL_SEED;
+    case 2:
+      break;
+    default:
+      return Phase::INVALID;
+    }
+
+  switch (pb.positions_size ())
+    {
+    case 0:
+      break;
+    case 2:
+      return Phase::SECOND_REVEAL_POSITION;
+    default:
+      return Phase::INVALID;
+    }
+
+  if (pb.has_current_shot ())
+    return Phase::ANSWER;
+  return Phase::SHOOT;
+}
+
+int
+ShipsBoardState::WhoseTurn () const
+{
+  if (!GetState ().has_turn ())
+    return xaya::ParsedBoardState::NO_TURN;
+
+  const int res = GetState ().turn ();
+  CHECK_GE (res, 0);
+  CHECK_LE (res, 1);
+
+  return res;
+}
+
+unsigned
+ShipsBoardState::TurnCount () const
+{
+  LOG (FATAL) << "Not implemented";
+}
+
+bool
+ShipsBoardState::ApplyMoveProto (XayaRpcClient& rpc, const proto::BoardMove& mv,
+                                 proto::BoardState& newState) const
+{
+  LOG (FATAL) << "Not implemented";
+}
+
+} // namespace ships

--- a/ships/board.hpp
+++ b/ships/board.hpp
@@ -79,30 +79,20 @@ private:
    */
   Phase GetPhase () const;
 
-  /**
-   * Applies a position commitment move (if valid).
-   */
+  /* Helper routines that apply a given move to the state, modifying it
+     in-place.  If the move is invalid, they return false.  */
   static bool ApplyPositionCommitment (const proto::PositionCommitmentMove& mv,
                                        Phase phase,
                                        proto::BoardState& newState);
-
-  /**
-   * Applies a seed-reveal move (if valid).
-   */
   static bool ApplySeedReveal (const proto::SeedRevealMove& mv, Phase phase,
                                proto::BoardState& newState);
-
-  /**
-   * Applies a shot move (if valid).
-   */
   static bool ApplyShot (const proto::ShotMove& mv, Phase phase,
                          proto::BoardState& newState);
-
-  /**
-   * Applies a reply move (answering a shot), if valid.
-   */
   static bool ApplyReply (const proto::ReplyMove& mv, Phase phase,
                           proto::BoardState& newState);
+  static bool ApplyPositionReveal (const proto::PositionRevealMove& mv,
+                                   Phase phase,
+                                   proto::BoardState& newState);
 
   friend class BoardTests;
 

--- a/ships/board.hpp
+++ b/ships/board.hpp
@@ -86,6 +86,12 @@ private:
                                        const Phase phase,
                                        proto::BoardState& newState);
 
+  /**
+   * Applies a seed-reveal move (if valid).
+   */
+  static bool ApplySeedReveal (const proto::SeedRevealMove& mv,
+                               const Phase phase, proto::BoardState& newState);
+
   friend class BoardTests;
 
 protected:

--- a/ships/board.hpp
+++ b/ships/board.hpp
@@ -79,6 +79,13 @@ private:
    */
   Phase GetPhase () const;
 
+  /**
+   * Applies a position commitment move (if valid).
+   */
+  static bool ApplyPositionCommitment (const proto::PositionCommitmentMove& mv,
+                                       const Phase phase,
+                                       proto::BoardState& newState);
+
   friend class BoardTests;
 
 protected:

--- a/ships/board.hpp
+++ b/ships/board.hpp
@@ -98,6 +98,12 @@ private:
   static bool ApplyShot (const proto::ShotMove& mv, Phase phase,
                          proto::BoardState& newState);
 
+  /**
+   * Applies a reply move (answering a shot), if valid.
+   */
+  static bool ApplyReply (const proto::ReplyMove& mv, Phase phase,
+                          proto::BoardState& newState);
+
   friend class BoardTests;
 
 protected:

--- a/ships/board.hpp
+++ b/ships/board.hpp
@@ -83,14 +83,20 @@ private:
    * Applies a position commitment move (if valid).
    */
   static bool ApplyPositionCommitment (const proto::PositionCommitmentMove& mv,
-                                       const Phase phase,
+                                       Phase phase,
                                        proto::BoardState& newState);
 
   /**
    * Applies a seed-reveal move (if valid).
    */
-  static bool ApplySeedReveal (const proto::SeedRevealMove& mv,
-                               const Phase phase, proto::BoardState& newState);
+  static bool ApplySeedReveal (const proto::SeedRevealMove& mv, Phase phase,
+                               proto::BoardState& newState);
+
+  /**
+   * Applies a shot move (if valid).
+   */
+  static bool ApplyShot (const proto::ShotMove& mv, Phase phase,
+                         proto::BoardState& newState);
 
   friend class BoardTests;
 

--- a/ships/board.hpp
+++ b/ships/board.hpp
@@ -93,6 +93,12 @@ private:
   static bool ApplyPositionReveal (const proto::PositionRevealMove& mv,
                                    Phase phase,
                                    proto::BoardState& newState);
+  static bool ApplyWinnerStatement (const proto::WinnerStatementMove& mv,
+                                    XayaRpcClient& rpc,
+                                    const xaya::uint256& channelId,
+                                    const xaya::proto::ChannelMetadata& meta,
+                                    Phase phase,
+                                    proto::BoardState& newState);
 
   friend class BoardTests;
 

--- a/ships/board.hpp
+++ b/ships/board.hpp
@@ -120,6 +120,12 @@ public:
 /** The BoardRules instance we use for the ships game.  */
 using ShipsBoardRules = xaya::ProtoBoardRules<ShipsBoardState>;
 
+/**
+ * Returns the initial board state of a game (i.e. just after the second
+ * participant has joined).
+ */
+proto::BoardState InitialBoardState ();
+
 } // namespace ships
 
 #endif // XAYASHIPS_BOARD_HPP

--- a/ships/board.hpp
+++ b/ships/board.hpp
@@ -1,0 +1,104 @@
+// Copyright (C) 2019 The Xaya developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef XAYASHIPS_BOARD_HPP
+#define XAYASHIPS_BOARD_HPP
+
+#include "proto/boardmove.pb.h"
+#include "proto/boardstate.pb.h"
+
+#include <gamechannel/protoboard.hpp>
+#include <gamechannel/proto/metadata.pb.h>
+#include <xayagame/rpc-stubs/xayarpcclient.h>
+
+namespace ships
+{
+
+/** The base ProtoBoardState for our types.  */
+using BaseProtoBoardState
+    = xaya::ProtoBoardState<proto::BoardState, proto::BoardMove>;
+
+/**
+ * The main implementation of the ships board rules.
+ *
+ * Note that these rules apply only for channels with both participants already.
+ * While a channel is waiting for the second player to join, no board functions
+ * are invoked at all (as disputes / resolutions are not allowed by the core
+ * logic itself).
+ */
+class ShipsBoardState : public BaseProtoBoardState
+{
+
+private:
+
+  /** The current "phase" that the game is in according to a board state.  */
+  enum class Phase
+  {
+
+    /** The proto is inconsistent and no phase can be determined.  */
+    INVALID,
+
+    /** The first player should commit their position and random seed.  */
+    FIRST_COMMITMENT,
+
+    /** The second player should commit their position.  */
+    SECOND_COMMITMENT,
+
+    /**
+     * The first player should reveal their random seed to determine who
+     * is the starting player.
+     */
+    FIRST_REVEAL_SEED,
+
+    /** Ordinary game play:  A shot should be made.  */
+    SHOOT,
+
+    /** Ordinary game play:  A shot should be answered.  */
+    ANSWER,
+
+    /**
+     * One player revealed the configuration, and now the second player has
+     * to do so as well.
+     */
+    SECOND_REVEAL_POSITION,
+
+    /** The game is finished and a winning player determined.  */
+    WINNER_DETERMINED,
+
+    /** The game is finished and the winner statement provided already.  */
+    FINISHED,
+
+  };
+
+  /**
+   * Determines the current "phase" of the game according to the proto we have.
+   * The phase is implicit, based on what proto fields are set; this function
+   * looks at those and returns the current phase or INVALID if the proto
+   * state is inconsistent in any way.
+   */
+  Phase GetPhase () const;
+
+  friend class BoardTests;
+
+protected:
+
+  bool ApplyMoveProto (XayaRpcClient& rpc, const proto::BoardMove& mv,
+                       proto::BoardState& newState) const override;
+
+public:
+
+  using BaseProtoBoardState::BaseProtoBoardState;
+
+  bool IsValid () const override;
+  int WhoseTurn () const override;
+  unsigned TurnCount () const override;
+
+};
+
+/** The BoardRules instance we use for the ships game.  */
+using ShipsBoardRules = xaya::ProtoBoardRules<ShipsBoardState>;
+
+} // namespace ships
+
+#endif // XAYASHIPS_BOARD_HPP

--- a/ships/board_tests.cpp
+++ b/ships/board_tests.cpp
@@ -1,0 +1,353 @@
+// Copyright (C) 2019 The Xaya developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "board.hpp"
+
+#include "proto/boardstate.pb.h"
+
+#include <gamechannel/proto/metadata.pb.h>
+#include <xayautil/hash.hpp>
+#include <xayautil/uint256.hpp>
+
+#include <google/protobuf/text_format.h>
+
+#include <gtest/gtest.h>
+
+#include <memory>
+
+using google::protobuf::TextFormat;
+
+namespace ships
+{
+
+/* ************************************************************************** */
+
+class BoardTests : public testing::Test
+{
+
+protected:
+
+  using Phase = ShipsBoardState::Phase;
+
+  const xaya::uint256 channelId = xaya::SHA256::Hash ("foo");
+
+  /**
+   * The metadata used for testing.  This is set to a standard two-player
+   * list by default, but may be modified by tests if they want to check what
+   * happens in other situations (e.g. only one player in the channel yet).
+   */
+  xaya::proto::ChannelMetadata meta;
+
+  ShipsBoardRules rules;
+
+  BoardTests ()
+  {
+    auto* p = meta.add_participants ();
+    p->set_name ("alice");
+    p->set_address ("addr 1");
+
+    p = meta.add_participants ();
+    p->set_name ("bob");
+    p->set_address ("addr 2");
+  }
+
+  /**
+   * Parses a BoardState given as text string into a ShipsBoardState
+   * instance.
+   */
+  std::unique_ptr<ShipsBoardState>
+  ParseState (const std::string& str, const bool allowInvalid = false)
+  {
+    proto::BoardState state;
+    CHECK (TextFormat::ParseFromString (str, &state));
+
+    std::string serialised;
+    CHECK (state.SerializeToString (&serialised));
+
+    auto res = rules.ParseState (channelId, meta, serialised);
+    if (allowInvalid && res == nullptr)
+      return nullptr;
+    CHECK (res != nullptr);
+
+    auto* ptr = dynamic_cast<ShipsBoardState*> (res.get ());
+    CHECK (ptr != nullptr);
+
+    res.release ();
+    return std::unique_ptr<ShipsBoardState> (ptr);
+  }
+
+  /**
+   * Exposes ShipsBoardState::GetPhase to subtests.
+   */
+  Phase
+  GetPhase (const ShipsBoardState& s)
+  {
+    return s.GetPhase ();
+  }
+
+};
+
+namespace
+{
+
+/* ************************************************************************** */
+
+class IsValidTests : public BoardTests
+{
+
+protected:
+
+  void
+  ExpectValid (const std::string& str)
+  {
+    LOG (INFO) << "Expecting state to be valid: " << str;
+
+    auto p = ParseState (str, true);
+    ASSERT_NE (p, nullptr);
+    EXPECT_TRUE (p->IsValid ());
+  }
+
+  void
+  ExpectInvalid (const std::string& str)
+  {
+    LOG (INFO) << "Expecting state to be invalid: " << str;
+    EXPECT_EQ (ParseState (str, true), nullptr);
+  }
+
+};
+
+TEST_F (IsValidTests, MalformedData)
+{
+  EXPECT_EQ (rules.ParseState (channelId, meta, "invalid"), nullptr);
+}
+
+TEST_F (IsValidTests, InvalidPhase)
+{
+  ExpectInvalid (R"(
+    position_hashes: "foo"
+    position_hashes: "bar"
+    position_hashes: "baz"
+  )");
+
+  ExpectInvalid (R"(
+    position_hashes: "foo"
+    position_hashes: "bar"
+    known_ships: {}
+  )");
+
+  ExpectInvalid (R"(
+    position_hashes: "foo"
+    position_hashes: "bar"
+    known_ships: {}
+    known_ships: {}
+    positions: 10
+  )");
+}
+
+TEST_F (IsValidTests, TurnWhenFinished)
+{
+  ExpectValid ("winner_statement: {}");
+  ExpectInvalid (R"(
+    turn: 0
+    winner_statement: {}
+  )");
+}
+
+TEST_F (IsValidTests, MissingTurnWhenNotFinished)
+{
+  ExpectInvalid ("winner: 0");
+}
+
+TEST_F (IsValidTests, TurnOutOfBounds)
+{
+  ExpectInvalid (R"(
+    turn: 2
+    winner: 0
+  )");
+}
+
+TEST_F (IsValidTests, TurnForFirstCommitReveal)
+{
+  ExpectValid ("turn: 0");
+  ExpectInvalid ("turn: 1");
+
+  ExpectValid (R"(
+    turn: 0
+    position_hashes: "a"
+    position_hashes: "b"
+  )");
+  ExpectInvalid (R"(
+    turn: 1
+    position_hashes: "a"
+    position_hashes: "b"
+  )");
+}
+
+TEST_F (IsValidTests, TurnForSecondCommit)
+{
+  ExpectValid (R"(
+    turn: 1
+    position_hashes: "foo"
+  )");
+  ExpectInvalid (R"(
+    turn: 0
+    position_hashes: "foo"
+  )");
+}
+
+TEST_F (IsValidTests, TurnForRevealPosition)
+{
+  ExpectValid (R"(
+    turn: 0
+    position_hashes: "a"
+    position_hashes: "b"
+    known_ships: {}
+    known_ships: {}
+    positions: 0
+    positions: 10
+  )");
+  ExpectValid (R"(
+    turn: 1
+    position_hashes: "a"
+    position_hashes: "b"
+    known_ships: {}
+    known_ships: {}
+    positions: 10
+    positions: 0
+  )");
+
+  ExpectInvalid (R"(
+    turn: 1
+    position_hashes: "a"
+    position_hashes: "b"
+    known_ships: {}
+    known_ships: {}
+    positions: 0
+    positions: 10
+  )");
+  ExpectInvalid (R"(
+    turn: 0
+    position_hashes: "a"
+    position_hashes: "b"
+    known_ships: {}
+    known_ships: {}
+    positions: 10
+    positions: 0
+  )");
+}
+
+TEST_F (IsValidTests, TurnForWinnerDetermined)
+{
+  ExpectValid (R"(
+    turn: 0
+    winner: 1
+  )");
+  ExpectValid (R"(
+    turn: 1
+    winner: 0
+  )");
+
+  ExpectInvalid (R"(
+    turn: 0
+    winner: 0
+  )");
+  ExpectInvalid (R"(
+    turn: 1
+    winner: 1
+  )");
+}
+
+/* ************************************************************************** */
+
+using GetPhaseTests = BoardTests;
+
+TEST_F (GetPhaseTests, PositionCommitments)
+{
+  EXPECT_EQ (GetPhase (*ParseState ("turn: 0")), Phase::FIRST_COMMITMENT);
+
+  EXPECT_EQ (GetPhase (*ParseState (R"(
+    turn: 1
+    position_hashes: "foo"
+  )")), Phase::SECOND_COMMITMENT);
+}
+
+TEST_F (GetPhaseTests, RevealSeed)
+{
+  EXPECT_EQ (GetPhase (*ParseState (R"(
+    turn: 0
+    position_hashes: "a"
+    position_hashes: "b"
+  )")), Phase::FIRST_REVEAL_SEED);
+}
+
+TEST_F (GetPhaseTests, ShotAndAnswer)
+{
+  EXPECT_EQ (GetPhase (*ParseState (R"(
+    turn: 0
+    position_hashes: "a"
+    position_hashes: "b"
+    known_ships: {}
+    known_ships: {}
+  )")), Phase::SHOOT);
+
+  EXPECT_EQ (GetPhase (*ParseState (R"(
+    turn: 0
+    position_hashes: "a"
+    position_hashes: "b"
+    known_ships: {}
+    known_ships: {}
+    current_shot: 42
+  )")), Phase::ANSWER);
+}
+
+TEST_F (GetPhaseTests, RevealPosition)
+{
+  EXPECT_EQ (GetPhase (*ParseState (R"(
+    turn: 0
+    position_hashes: "a"
+    position_hashes: "b"
+    known_ships: {}
+    known_ships: {}
+    positions: 0
+    positions: 10
+  )")), Phase::SECOND_REVEAL_POSITION);
+}
+
+TEST_F (GetPhaseTests, EndOfGame)
+{
+  EXPECT_EQ (GetPhase (*ParseState ("winner_statement: {}")), Phase::FINISHED);
+
+  EXPECT_EQ (GetPhase (*ParseState (R"(
+    turn: 1
+    winner: 0
+  )")), Phase::WINNER_DETERMINED);
+}
+
+/* ************************************************************************** */
+
+using WhoseTurnTests = BoardTests;
+
+TEST_F (WhoseTurnTests, TurnSet)
+{
+  EXPECT_EQ (ParseState (R"(
+    turn: 0
+    winner: 1
+  )")->WhoseTurn (), 0);
+
+  EXPECT_EQ (ParseState (R"(
+    turn: 1
+    winner: 0
+  )")->WhoseTurn (), 1);
+}
+
+TEST_F (WhoseTurnTests, TurnNotSet)
+{
+  EXPECT_EQ (ParseState ("winner_statement: {}")->WhoseTurn (),
+             xaya::ParsedBoardState::NO_TURN);
+}
+
+/* ************************************************************************** */
+
+} // anonymous namespace
+} // namespace ships

--- a/ships/board_tests.cpp
+++ b/ships/board_tests.cpp
@@ -174,6 +174,28 @@ namespace
 
 /* ************************************************************************** */
 
+using InitialBoardStateTests = BoardTests;
+
+TEST_F (InitialBoardStateTests, CorrectInitialState)
+{
+  const auto actual = InitialBoardState ();
+  const auto expected = TextState ("turn: 0");
+  EXPECT_TRUE (MessageDifferencer::Equals (actual, expected));
+}
+
+TEST_F (InitialBoardStateTests, Phase)
+{
+  EXPECT_EQ (GetPhase (*ParseState (InitialBoardState ())),
+             Phase::FIRST_COMMITMENT);
+}
+
+TEST_F (InitialBoardStateTests, WhoseTurn)
+{
+  EXPECT_EQ (ParseState (InitialBoardState ())->WhoseTurn (), 0);
+}
+
+/* ************************************************************************** */
+
 class IsValidTests : public BoardTests
 {
 

--- a/ships/board_tests.cpp
+++ b/ships/board_tests.cpp
@@ -194,6 +194,11 @@ TEST_F (InitialBoardStateTests, WhoseTurn)
   EXPECT_EQ (ParseState (InitialBoardState ())->WhoseTurn (), 0);
 }
 
+TEST_F (InitialBoardStateTests, TurnCount)
+{
+  EXPECT_EQ (ParseState (InitialBoardState ())->TurnCount (), 0);
+}
+
 /* ************************************************************************** */
 
 class IsValidTests : public BoardTests
@@ -453,7 +458,7 @@ TEST_F (WhoseTurnTests, TurnNotSet)
 
 /* ************************************************************************** */
 
-class ApplyMoveTests : public BoardTests
+class ApplyMoveAndTurnCountTests : public BoardTests
 {
 
 private:
@@ -480,7 +485,7 @@ private:
 
 protected:
 
-  ApplyMoveTests ()
+  ApplyMoveAndTurnCountTests ()
     : httpServer(xaya::MockXayaRpcServer::HTTP_PORT),
       httpClient(xaya::MockXayaRpcServer::HTTP_URL),
       mockXayaServer(httpServer),
@@ -489,7 +494,7 @@ protected:
     mockXayaServer.StartListening ();
   }
 
-  ~ApplyMoveTests ()
+  ~ApplyMoveAndTurnCountTests ()
   {
     mockXayaServer.StopListening ();
   }
@@ -506,7 +511,8 @@ protected:
 
   /**
    * Applies a move onto the given state and expects that the new state matches
-   * the given proto.
+   * the given proto.  This also verifies that the turn count increases by
+   * exactly one for the applied move.
    */
   void
   ExpectNewState (const proto::BoardState& oldState, const proto::BoardMove& mv,
@@ -518,6 +524,9 @@ protected:
     EXPECT_TRUE (MessageDifferencer::Equals (actual, expected))
         << "Actual new game state: " << actual
         << "\n  does not equal expected new state: " << expected;
+
+    EXPECT_EQ (ParseState (oldState)->TurnCount () + 1,
+               ParseState (expected)->TurnCount ());
   }
 
   /**
@@ -542,14 +551,14 @@ protected:
 
 };
 
-TEST_F (ApplyMoveTests, NoCaseSelected)
+TEST_F (ApplyMoveAndTurnCountTests, NoCaseSelected)
 {
   ExpectInvalid (TextState ("turn: 0"), TextMove (""));
 }
 
 /* ************************************************************************** */
 
-using PositionCommitmentTests = ApplyMoveTests;
+using PositionCommitmentTests = ApplyMoveAndTurnCountTests;
 
 TEST_F (PositionCommitmentTests, InvalidPositionHash)
 {
@@ -696,7 +705,7 @@ TEST_F (PositionCommitmentTests, InvalidSecondCommitment)
 
 /* ************************************************************************** */
 
-using SeedRevealTests = ApplyMoveTests;
+using SeedRevealTests = ApplyMoveAndTurnCountTests;
 
 TEST_F (SeedRevealTests, InvalidPhase)
 {
@@ -816,7 +825,7 @@ TEST_F (SeedRevealTests, MissingSeed1)
 
 /* ************************************************************************** */
 
-class ShotTests : public ApplyMoveTests
+class ShotTests : public ApplyMoveAndTurnCountTests
 {
 
 protected:
@@ -886,7 +895,7 @@ TEST_F (ShotTests, ValidShot)
 
 /* ************************************************************************** */
 
-class ReplyTests : public ApplyMoveTests
+class ReplyTests : public ApplyMoveAndTurnCountTests
 {
 
 protected:
@@ -996,7 +1005,7 @@ TEST_F (ReplyTests, Hit)
 
 /* ************************************************************************** */
 
-class PositionRevealTests : public ApplyMoveTests
+class PositionRevealTests : public ApplyMoveAndTurnCountTests
 {
 
 protected:
@@ -1265,7 +1274,7 @@ TEST_F (PositionRevealTests, NotAllShipsHitSecondWins)
 
 /* ************************************************************************** */
 
-class WinnerStatementTests : public ApplyMoveTests
+class WinnerStatementTests : public ApplyMoveAndTurnCountTests
 {
 
 protected:

--- a/ships/coord.cpp
+++ b/ships/coord.cpp
@@ -1,0 +1,103 @@
+// Copyright (C) 2019 The Xaya developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "coord.hpp"
+
+#include <glog/logging.h>
+
+namespace ships
+{
+
+Direction
+operator- (const Direction d)
+{
+  switch (d)
+    {
+    case Direction::LEFT:
+      return Direction::RIGHT;
+    case Direction::RIGHT:
+      return Direction::LEFT;
+
+    case Direction::UP:
+      return Direction::DOWN;
+    case Direction::DOWN:
+      return Direction::UP;
+    }
+
+  LOG (FATAL) << "Invalid direction: " << static_cast<int> (d);
+}
+
+Coord::Coord (const int ind)
+{
+  column = ind % SIDE;
+  row = ind / SIDE;
+
+  /* Note:  The C++ language guarantees that (row * SIDE + column == ind)
+     with the definitions above.  This implies, in particular, that at least
+     one of row and column is negative for a negative ind.  Thus that case
+     is "handled fine", because all we need is that it yields an out-of-board
+     coordinate.  It does not matter which value is negative.  */
+}
+
+bool
+Coord::IsOnBoard () const
+{
+  if (row < 0 || row >= SIDE)
+    return false;
+  if (column < 0 || column >= SIDE)
+    return false;
+
+  return true;
+}
+
+int
+Coord::GetIndex () const
+{
+  CHECK (IsOnBoard ());
+
+  const int res = row * SIDE + column;
+  CHECK_GE (res, 0);
+  CHECK_LT (res, CELLS);
+
+  return res;
+}
+
+Coord
+Coord::operator+ (const Direction d) const
+{
+  switch (d)
+    {
+    case Direction::LEFT:
+      return Coord (row, column - 1);
+    case Direction::RIGHT:
+      return Coord (row, column + 1);
+
+    case Direction::UP:
+      return Coord (row - 1, column);
+    case Direction::DOWN:
+      return Coord (row + 1, column);
+    }
+
+  LOG (FATAL) << "Invalid direction: " << static_cast<int> (d);
+}
+
+Coord
+Coord::operator- (const Direction d) const
+{
+  return (*this) + (-d);
+}
+
+bool
+operator== (const Coord& a, const Coord& b)
+{
+  return a.row == b.row && a.column == b.column;
+}
+
+bool
+operator!= (const Coord& a, const Coord& b)
+{
+  return !(a == b);
+}
+
+} // namespace ships

--- a/ships/coord.hpp
+++ b/ships/coord.hpp
@@ -1,0 +1,108 @@
+// Copyright (C) 2019 The Xaya developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef XAYASHIPS_COORD_HPP
+#define XAYASHIPS_COORD_HPP
+
+#include <cmath>
+
+namespace ships
+{
+
+/**
+ * Directions on the board.  The grid is laid out like a matrix.
+ */
+enum class Direction
+{
+
+  /** Decreasing column.  */
+  LEFT,
+
+  /** Increasing column.  */
+  RIGHT,
+
+  /** Decreasing row.  */
+  UP,
+
+  /** Decreasing column.  */
+  DOWN,
+
+};
+
+/**
+ * Returns the "inverse" direction.
+ */
+Direction operator- (Direction d);
+
+/**
+ * A coordinate on the 8x8 grid of the game.  This class can translate between
+ * (r, c) coordinates and direct indices, and it can determine neighbours
+ * and whether they are out of the board.
+ */
+class Coord
+{
+
+private:
+
+  /**
+   * The row in the range 0..7.  For coordinates that are outside of the board,
+   * the value may be out of that range.
+   */
+  int row = 0;
+
+  /** The column in the range 0..7.  Might be outside of the range.  */
+  int column = 0;
+
+public:
+
+  /** The size of the board (side length).  */
+  static constexpr int SIDE = 8;
+  /** The size of the board in total number of cells.  */
+  static constexpr int CELLS = std::pow (SIDE, 2);
+
+  Coord () = default;
+  Coord (const Coord&) = default;
+  Coord& operator= (const Coord&) = default;
+
+  /**
+   * Initialises an instance from the linearised index.
+   */
+  explicit Coord (int ind);
+
+  /**
+   * Initialises an instance from the (r, c) coordinates.
+   */
+  explicit Coord (const int r, const int c)
+    : row(r), column(c)
+  {}
+
+  /**
+   * Returns true if the coordinate is on the board.
+   */
+  bool IsOnBoard () const;
+
+  /**
+   * Returns the linearised index for this coordinate.  Must only be called
+   * if the coordinate is on the board.
+   */
+  int GetIndex () const;
+
+  /**
+   * Changes the coordinate in the given direction.
+   */
+  Coord operator+ (Direction d) const;
+
+  /**
+   * Changes the coordinate in the inverse direction.
+   */
+  Coord operator- (Direction d) const;
+
+  friend bool operator== (const Coord& a, const Coord& b);
+  friend bool operator!= (const Coord& a, const Coord& b);
+
+};
+
+} // namespace ships
+
+#endif // XAYASHIPS_COORD_HPP

--- a/ships/coord_tests.cpp
+++ b/ships/coord_tests.cpp
@@ -1,0 +1,105 @@
+// Copyright (C) 2019 The Xaya developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "coord.hpp"
+
+#include <gtest/gtest.h>
+
+namespace ships
+{
+namespace
+{
+
+using DirectionTests = testing::Test;
+
+TEST_F (DirectionTests, ValidInversion)
+{
+  EXPECT_EQ (-Direction::RIGHT, Direction::LEFT);
+  EXPECT_EQ (Direction::RIGHT, -Direction::LEFT);
+
+  EXPECT_EQ (-Direction::UP, Direction::DOWN);
+  EXPECT_EQ (Direction::UP, -Direction::DOWN);
+}
+
+TEST_F (DirectionTests, InvalidInversion)
+{
+  EXPECT_DEATH (-static_cast<Direction> (42), "Invalid direction");
+}
+
+using CoordTests = testing::Test;
+
+TEST_F (CoordTests, Comparison)
+{
+  EXPECT_EQ (Coord (5, 2), Coord (5, 2));
+  EXPECT_NE (Coord (5, 2), Coord (5, 3));
+  EXPECT_NE (Coord (5, 2), Coord (4, 2));
+}
+
+TEST_F (CoordTests, FromIndex)
+{
+  EXPECT_EQ (Coord (0), Coord (0, 0));
+  EXPECT_EQ (Coord (5), Coord (0, 5));
+  EXPECT_EQ (Coord (8), Coord (1, 0));
+  EXPECT_EQ (Coord (60), Coord (7, 4));
+  EXPECT_EQ (Coord (63), Coord (7, 7));
+}
+
+TEST_F (CoordTests, GetIndex)
+{
+  for (int ind = 0; ind < Coord::CELLS; ++ind)
+    EXPECT_EQ (Coord (ind).GetIndex (), ind);
+}
+
+TEST_F (CoordTests, IsOnBoard)
+{
+  EXPECT_TRUE (Coord (0, 0).IsOnBoard ());
+  EXPECT_TRUE (Coord (7, 7).IsOnBoard ());
+  for (int ind = 0; ind < Coord::CELLS; ++ind)
+    EXPECT_TRUE (Coord (ind).IsOnBoard ());
+
+  EXPECT_FALSE (Coord (0, 8).IsOnBoard ());
+  EXPECT_FALSE (Coord (8, 0).IsOnBoard ());
+  EXPECT_FALSE (Coord (-1, 0).IsOnBoard ());
+  EXPECT_FALSE (Coord (0, -1).IsOnBoard ());
+  EXPECT_FALSE (Coord (8, -1).IsOnBoard ());
+  EXPECT_FALSE (Coord (-1, 8).IsOnBoard ());
+  EXPECT_FALSE (Coord (-1, -1).IsOnBoard ());
+  EXPECT_FALSE (Coord (-1, -1).IsOnBoard ());
+
+  EXPECT_FALSE (Coord (-1).IsOnBoard ());
+  EXPECT_FALSE (Coord (-1000).IsOnBoard ());
+  EXPECT_FALSE (Coord (64).IsOnBoard ());
+  EXPECT_FALSE (Coord (1000000).IsOnBoard ());
+}
+
+TEST_F (CoordTests, PlusDirection)
+{
+  EXPECT_EQ (Coord (5, 2) + Direction::LEFT, Coord (5, 1));
+  EXPECT_EQ (Coord (5, 2) + Direction::RIGHT, Coord (5, 3));
+  EXPECT_EQ (Coord (5, 2) + Direction::UP, Coord (4, 2));
+  EXPECT_EQ (Coord (5, 2) + Direction::DOWN, Coord (6, 2));
+
+  EXPECT_EQ (Coord (2, 0) + Direction::LEFT, Coord (2, -1));
+  EXPECT_EQ (Coord (2, 7) + Direction::RIGHT, Coord (2, 8));
+  EXPECT_EQ (Coord (0, 2) + Direction::UP, Coord (-1, 2));
+  EXPECT_EQ (Coord (7, 2) + Direction::DOWN, Coord (8, 2));
+}
+
+TEST_F (CoordTests, MinusDirection)
+{
+  EXPECT_EQ (Coord (5, 2) - Direction::LEFT, Coord (5, 3));
+  EXPECT_EQ (Coord (5, 2) - Direction::RIGHT, Coord (5, 1));
+  EXPECT_EQ (Coord (5, 2) - Direction::UP, Coord (6, 2));
+  EXPECT_EQ (Coord (5, 2) - Direction::DOWN, Coord (4, 2));
+}
+
+TEST_F (CoordTests, PlusMinusInvalidDirection)
+{
+  const Direction invalid = static_cast<Direction> (42);
+  EXPECT_DEATH (Coord (5, 2) + invalid, "Invalid direction");
+  EXPECT_DEATH (Coord (5, 2) - invalid, "Invalid direction");
+}
+
+} // anonymous namespace
+} // namespace ships

--- a/ships/grid.cpp
+++ b/ships/grid.cpp
@@ -6,8 +6,32 @@
 
 #include <glog/logging.h>
 
+#include <map>
+
 namespace ships
 {
+
+namespace
+{
+
+/**
+ * An entry for the configuration of available ships.
+ */
+struct AvailableShipType
+{
+  unsigned size;
+  unsigned number;
+};
+
+/** The ships that should be placed for a valid position.  */
+constexpr AvailableShipType AVAILABLE_SHIPS[] =
+  {
+    {2, 4},
+    {3, 2},
+    {4, 1},
+  };
+
+} // anonymous namespace
 
 bool
 Grid::Get (const Coord& c) const
@@ -53,6 +77,166 @@ Grid::Blob () const
   CHECK_EQ (remaining, 0);
 
   return res;
+}
+
+int
+Grid::TotalShipCells ()
+{
+  int res = 0;
+  for (const auto& t : AVAILABLE_SHIPS)
+    res += t.size * t.number;
+
+  return res;
+}
+
+bool
+VerifyPositionForAnswers (const Grid& position, const Grid& targeted,
+                          const Grid& hits)
+{
+  CHECK_EQ (hits.GetBits () & targeted.GetBits (), hits.GetBits ())
+      << "Hit positions are not a subset of targeted positions";
+  return (position.GetBits () & targeted.GetBits ()) == hits.GetBits ();
+}
+
+namespace
+{
+
+/**
+ * Checks if the given coordinate has a ship on the board.  This verifies
+ * that it is not out of board and if so, that there is a bit set.
+ */
+bool
+HasShip (const Grid& g, const Coord& c)
+{
+  if (!c.IsOnBoard ())
+    return false;
+
+  return g.Get (c);
+}
+
+/**
+ * Given a starting coordinate (top/left most of a ship) and the direction
+ * of the ship (as well as the orthogonal direction), follow it until the
+ * end and figure out how large it is.
+ *
+ * This also verifies that the placement is valid, which means that all
+ * neighbour coordinates must be free (or out-of-board).
+ *
+ * Returns true if the placement is valid.  In that case, size will be
+ * set to the size of the ship.
+ */
+bool
+CheckShip (const Grid& g, Coord c,
+           const Direction dir, const Direction otherDir,
+           unsigned& size)
+{
+  CHECK (HasShip (g, c));
+
+  /* Check that there are no other ships at the "head side" of it.  */
+  if (HasShip (g, c - dir)
+        || HasShip (g, c - dir - otherDir)
+        || HasShip (g, c - dir + otherDir))
+    {
+      LOG (WARNING) << "There is another ship at the 'head side'";
+      return false;
+    }
+
+  /* Traverse along the ship and check that there are no other ships next
+     to the current tile.  */
+  size = 0;
+  for (; HasShip (g, c); c = c + dir)
+    {
+      ++size;
+      if (HasShip (g, c - otherDir) || HasShip (g, c + otherDir))
+        {
+          LOG (WARNING) << "There is another ship next to it";
+          return false;
+        }
+    }
+
+  /* Finally, verify that there is no other ship at the "tail side".  */
+  if (HasShip (g, c - otherDir) || HasShip (g, c + otherDir))
+    {
+      LOG (WARNING) << "There is another ship at the 'tail side'";
+      return false;
+    }
+
+  return true;
+}
+
+} // anonymous namespace
+
+bool
+VerifyPositionOfShips (const Grid& position)
+{
+  std::map<unsigned, unsigned> foundShips;
+  for (int i = 0; i < Coord::CELLS; ++i)
+    {
+      const Coord c(i);
+      if (!position.Get (c))
+        continue;
+
+      /* If there is a ship also to the left or above, then we ignore this
+         for now as well.  Those tiles are processed when walking that ship,
+         starting from the top-most / left-most tile.  */
+      if (HasShip (position, c + Direction::UP)
+            || HasShip (position, c + Direction::LEFT))
+        continue;
+
+      /* Try whether this ship is horizontal or vertical.  */
+      Direction dir;
+      Direction otherDir;
+      if (HasShip (position, c + Direction::DOWN))
+        {
+          dir = Direction::DOWN;
+          otherDir = Direction::RIGHT;
+        }
+      else
+        {
+          /* Here, we do not check whether there really is another ship to
+             the right.  If there is not, then this will simply be seen
+             as a size-one ship.  */
+          dir = Direction::RIGHT;
+          otherDir = Direction::DOWN;
+        }
+
+      unsigned size;
+      if (!CheckShip (position, c, dir, otherDir, size))
+        return false;
+
+      ++foundShips[size];
+    }
+
+  /* Finally, verify the number of each type of ship.  */
+  unsigned availableTypes = 0;
+  for (const auto& t : AVAILABLE_SHIPS)
+    {
+      ++availableTypes;
+
+      const auto mit = foundShips.find (t.size);
+      if (mit == foundShips.end ())
+        {
+          LOG (WARNING) << "Found no ships of size " << t.size;
+          return false;
+        }
+
+      if (mit->second != t.number)
+        {
+          LOG (WARNING)
+              << "Found " << mit->second << " ships of size " << t.size
+              << ", expected " << t.number;
+          return false;
+        }
+    }
+  if (availableTypes != foundShips.size ())
+    {
+      LOG (WARNING)
+          << "Found " << foundShips.size ()
+          << " types of ships, expected " << availableTypes;
+      return false;
+    }
+
+  return true;
 }
 
 } // namespace ships

--- a/ships/grid.cpp
+++ b/ships/grid.cpp
@@ -1,0 +1,58 @@
+// Copyright (C) 2019 The Xaya developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "grid.hpp"
+
+#include <glog/logging.h>
+
+namespace ships
+{
+
+bool
+Grid::Get (const Coord& c) const
+{
+  return (bits >> c.GetIndex ()) % 2 > 0;
+}
+
+void
+Grid::Set (const Coord& c)
+{
+  const uint64_t mask = (static_cast<uint64_t> (1) << c.GetIndex ());
+  CHECK_EQ (bits & mask, 0);
+  bits |= mask;
+}
+
+int
+Grid::CountOnes () const
+{
+  uint64_t remaining = bits;
+
+  int res = 0;
+  while (remaining > 0)
+    {
+      res += remaining % 2;
+      remaining >>= 1;
+    }
+
+  return res;
+}
+
+std::string
+Grid::Blob () const
+{
+  uint64_t remaining = bits;
+
+  std::string res(8, '\0');
+  for (size_t i = 0; i < res.size (); ++i)
+    {
+      res[i] = static_cast<char> (remaining & 0xFF);
+      remaining >>= 8;
+    }
+
+  CHECK_EQ (remaining, 0);
+
+  return res;
+}
+
+} // namespace ships

--- a/ships/grid.hpp
+++ b/ships/grid.hpp
@@ -74,7 +74,27 @@ public:
    */
   std::string Blob () const;
 
+  /**
+   * Returns the number of cells covered by ships in a valid configuration.
+   */
+  static int TotalShipCells ();
+
 };
+
+/**
+ * Verifies if the given grid of ship positions matches previous answers made
+ * by a player to shots (based on a grid of where shots were made and which of
+ * those were replied to as "hit").  The "hits" must be a subset of the
+ * "targeted" positions.
+ */
+bool VerifyPositionForAnswers (const Grid& position, const Grid& targeted,
+                               const Grid& hits);
+
+/**
+ * Verifies whether a given position of ships is valid with respect to the
+ * number of ships and the placement rules.
+ */
+bool VerifyPositionOfShips (const Grid& position);
 
 } // namespace ships
 

--- a/ships/grid.hpp
+++ b/ships/grid.hpp
@@ -1,0 +1,81 @@
+// Copyright (C) 2019 The Xaya developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef XAYASHIPS_GRID_HPP
+#define XAYASHIPS_GRID_HPP
+
+#include "coord.hpp"
+
+#include <cstdint>
+#include <string>
+
+namespace ships
+{
+
+/**
+ * A bit vector with entries for every cell on the board.  Such a value
+ * is used to represent the positions of ships, the hits and the already
+ * guessed locations.
+ */
+class Grid
+{
+
+private:
+
+  /** The underlying uint64, which we use as bit vector.  */
+  uint64_t bits = 0;
+
+  /* Verify that the size of our bit field matches the defined size of
+     the board according to Coord.  */
+  static_assert (sizeof (bits) * 8 == Coord::CELLS,
+                 "Mismatch between Grid bit field and Coord::CELLS");
+
+public:
+
+  Grid () = default;
+
+  explicit Grid (const uint64_t b)
+    : bits(b)
+  {}
+
+  Grid (const Grid&) = default;
+  Grid& operator= (const Grid&) = default;
+
+  /**
+   * Returns the raw bit vector value.  This is used for encoding it into
+   * a protocol buffer.
+   */
+  uint64_t
+  GetBits () const
+  {
+    return bits;
+  }
+
+  /**
+   * Retrieves the bit for the given coordinate.
+   */
+  bool Get (const Coord& c) const;
+
+  /**
+   * Sets the bit at the given coordinate to true.  Must not be called if
+   * the bit is already true.
+   */
+  void Set (const Coord& c);
+
+  /**
+   * Counts how many bits are true.
+   */
+  int CountOnes () const;
+
+  /**
+   * Returns the little-endian encoding of the bits as individual bytes.
+   * This is used for hashing the value in a deterministic way.
+   */
+  std::string Blob () const;
+
+};
+
+} // namespace ships
+
+#endif // XAYASHIPS_GRID_HPP

--- a/ships/grid_tests.cpp
+++ b/ships/grid_tests.cpp
@@ -1,0 +1,77 @@
+// Copyright (C) 2019 The Xaya developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "grid.hpp"
+
+#include <gtest/gtest.h>
+
+namespace ships
+{
+namespace
+{
+
+using GridTests = testing::Test;
+
+TEST_F (GridTests, ConstructorGetBits)
+{
+  EXPECT_EQ (Grid ().GetBits (), 0);
+  EXPECT_EQ (Grid (12345).GetBits (), 12345);
+}
+
+TEST_F (GridTests, BasicGetSet)
+{
+  Grid g(0x101);
+  EXPECT_TRUE (g.Get (Coord (0)));
+  EXPECT_TRUE (g.Get (Coord (8)));
+  EXPECT_FALSE (g.Get (Coord (1)));
+  EXPECT_FALSE (g.Get (Coord (63)));
+
+  g.Set (Coord (5));
+  g.Set (Coord (63));
+  EXPECT_TRUE (g.Get (Coord (0)));
+  EXPECT_TRUE (g.Get (Coord (5)));
+  EXPECT_TRUE (g.Get (Coord (8)));
+  EXPECT_FALSE (g.Get (Coord (4)));
+  EXPECT_FALSE (g.Get (Coord (6)));
+  EXPECT_FALSE (g.Get (Coord (62)));
+  EXPECT_TRUE (g.Get (Coord (63)));
+}
+
+TEST_F (GridTests, ExhaustiveSet)
+{
+  for (int i = 0; i < Coord::CELLS; ++i)
+    {
+      Grid g;
+      g.Set (Coord (i));
+      for (int j = 0; j < Coord::CELLS; ++j)
+        EXPECT_EQ (g.Get (Coord (j)), i == j);
+    }
+}
+
+TEST_F (GridTests, CountOne)
+{
+  Grid g;
+  EXPECT_EQ (g.CountOnes (), 0);
+
+  for (int i = 0; i < Coord::CELLS; ++i)
+    {
+      g.Set (Coord (i));
+      EXPECT_EQ (g.CountOnes (), i + 1);
+    }
+}
+
+TEST_F (GridTests, Blob)
+{
+  Grid g(0x102);
+  g.Set (Coord (63));
+
+  const std::string blob = g.Blob ();
+  ASSERT_EQ (blob.size (), 8);
+  EXPECT_EQ (blob[0], static_cast<char> (2));
+  EXPECT_EQ (blob[1], static_cast<char> (1));
+  EXPECT_EQ (blob[7], static_cast<char> (0x80));
+}
+
+} // anonymous namespace
+} // namespace ships

--- a/ships/proto/boardmove.proto
+++ b/ships/proto/boardmove.proto
@@ -1,0 +1,127 @@
+// Copyright (C) 2019 The Xaya developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+syntax = "proto2";
+
+import "gamechannel/proto/signatures.proto";
+
+package ships.proto;
+
+/**
+ * A move that creates the position commitment for either of the players.
+ * Depending on whether this is the first or second player's move, either
+ * the seed hash or the seed (as preimage) will be set.
+ */
+message PositionCommitmentMove
+{
+
+  /** The uint256 salted hash of the position.  */
+  optional bytes position_hash = 1;
+
+  /** If this is player 0's move, then the hash of the random seed data.  */
+  optional bytes seed_hash = 2;
+
+  /**
+   * For player 1's move, the "preimage" of the random seed data.  This can
+   * be any string of bytes up to 32 in length (256 bit).
+   */
+  optional bytes seed = 3;
+
+}
+
+/**
+ * The move of player 0 revealing the random seed preimage.
+ */
+message SeedRevealMove
+{
+
+  /**
+   * The preimage data for the previous seed hash.  This can be any string of
+   * bytes up to 32 in length (256 bit), and it must match the previously
+   * committed SHA-256 hash.
+   */
+  optional bytes seed = 4;
+
+}
+
+/**
+ * A move that guesses a location for a shot.
+ */
+message ShotMove
+{
+
+  /** The targeted location as index into the bit vectors (0..63).  */
+  optional uint32 location = 1;
+
+}
+
+/**
+ * A move that replies to a shot
+ */
+message ReplyMove
+{
+
+  /** Possible reply values.  */
+  enum ReplyType
+  {
+    INVALID = 0;
+    HIT = 1;
+    MISS = 2;
+  }
+
+  /** The reply for the previously targeted location.  */
+  optional ReplyType reply = 1;
+
+}
+
+/**
+ * A move revealing the original ship configuration and salt.
+ */
+message PositionRevealMove
+{
+
+  /** The full position of ships, encoded as bit vector.  */
+  optional uint64 position = 1;
+
+  /**
+   * The salt data, which can be an arbitrary string up to 32 bytes (256 bit)
+   * in length.  The commitment hash is computed by concatenating the 8 bytes
+   * of the position in little endian and the salt bytes.
+   */
+  optional bytes salt = 2;
+
+}
+
+/**
+ * The last move in the game, where the loser provides a signed WinnerStatement.
+ */
+message WinnerStatementMove
+{
+
+  /**
+   * An encoded WinnerStatement message matching the game's result and signed
+   * by the losing player (who is also the player sending this move).
+   */
+  optional xaya.proto.SignedData statement = 1;
+
+}
+
+/**
+ * One move in the channel game.  The std::string-encoded BoardMove bytes
+ * correspond to a serialised message of this type.
+ */
+message BoardMove
+{
+
+  oneof move
+  {
+    PositionCommitmentMove position_commitment = 1;
+    SeedRevealMove seed_reveal = 2;
+    ShotMove shot = 3;
+    ReplyMove reply = 4;
+    PositionRevealMove position_reveal = 5;
+    WinnerStatementMove winner_statement = 6;
+  }
+
+}

--- a/ships/proto/boardstate.proto
+++ b/ships/proto/boardstate.proto
@@ -89,6 +89,9 @@ message BoardState
    * holding the target location.  The shot is always by the player whose
    * turn it is not, and the player whose turn it is should answer in the
    * next move.
+   *
+   * If a player reveals their position instead of answering the shot, this
+   * field remains set.  That allows us to accurately count turns.
    */
   optional uint32 current_shot = 6;
 

--- a/ships/proto/boardstate.proto
+++ b/ships/proto/boardstate.proto
@@ -1,0 +1,117 @@
+// Copyright (C) 2019 The Xaya developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+syntax = "proto2";
+
+import "gamechannel/proto/signatures.proto";
+
+package ships.proto;
+
+/**
+ * The "known information" about the ship configuration of one player:
+ * Where coordinates have been guessed and where (those) have been hits.
+ * Both are boolean arrays encoded directly into a uint64.
+ */
+message KnownShips
+{
+
+  /** The coordinates that have been guessed "against" this player.  */
+  optional fixed64 guessed = 1;
+
+  /** Those of the guessed coordinates that were hits.  */
+  optional fixed64 hits = 2;
+
+}
+
+/**
+ * The full board state of a game channel of Xayaships.  The generic board state
+ * for libgamechannel (std::string) is the serialised form of this message.
+ *
+ * This state applies only to channels that already have both participants.
+ * While waiting for the second player to join, the core game logic never
+ * invokes any board functions at all, as no disputes / resolutions are possible
+ * in that case.
+ */
+message BoardState
+{
+
+  /**
+   * Which player (index into participants array) is the current one.  Missing
+   * in a "no turn" situation, i.e. when the game is finished.
+   *
+   * Note that this information is sometimes redundant (e.g. when the initial
+   * commitment from player 0 is there but not yet the commitment from player 1,
+   * then it is clear that it's player 1's turn).  The field is still always
+   * set (and must match the implicit value where applicable) to simplify
+   * the "whose turn" method.
+   */
+  optional uint32 turn = 1;
+
+  /**
+   * The two position commitments from both players (or only one if the second
+   * is now to be made).  These are bytes encoding 256-bit hashes.
+   *
+   * When the game is ended and the positions are revealed, the corresponding
+   * hash is cleared to save space.  The fields remain set, though, just the
+   * bytes are set to an empty string.
+   */
+  repeated bytes position_hashes = 2;
+
+  /**
+   * The hash commitment of the "random seed" of player 0 when determining who
+   * starts the game.  This field is cleared again when the preimage has
+   * been revealed.  Like position_hashes, this encodes a 256-bit hash.
+   */
+  optional bytes seed_hash_0 = 3;
+
+  /**
+   * The preimage of the "random seed" of player 1.  This can be arbitrary
+   * data up to 32 bytes in length.  This field is cleared when the starting
+   * player has been determined.
+   */
+  optional bytes seed_1 = 4;
+
+  /**
+   * The information known so far about the ship configurations of both
+   * players.  These fields are initialised (with all zeros for both players)
+   * when the starting player has been determined.
+   *
+   * This data could be removed as soon as the position is revealed (and checked
+   * against previous answers), but we keep the field set since that data can
+   * be used by frontends to show the guesses against the final position
+   * of the other player.
+   */
+  repeated KnownShips known_ships = 5;
+
+  /**
+   * If a shot has been made and not yet answered, then this field is set
+   * holding the target location.  The shot is always by the player whose
+   * turn it is not, and the player whose turn it is should answer in the
+   * next move.
+   */
+  optional uint32 current_shot = 6;
+
+  /**
+   * The revealed full ship configurations as 64-bit vectors.  When the first
+   * player reveals, this is initialised to two zero elements (and then the
+   * revealed position set).  So the array might have zero or two elements
+   * at any point in time.
+   *
+   * Note that in theory it is not necessary to keep this information in the
+   * game state, as it is enough to just verify the commitment when the move
+   * is made.  But having it in the game state is useful for frontends.
+   */
+  repeated fixed64 positions = 7;
+
+  /** If it is already determined who won, the player's index.  */
+  optional uint32 winner = 8;
+
+  /**
+   * An encoded WinnerStatement message signed by the loser.  This is set as
+   * the last move in the game by the loser after the result has been
+   * determined.  It allows the winner to claim the result on chain.
+   */
+  optional xaya.proto.SignedData winner_statement = 9;
+
+}

--- a/ships/proto/winnerstatement.proto
+++ b/ships/proto/winnerstatement.proto
@@ -1,0 +1,23 @@
+// Copyright (C) 2019 The Xaya developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+syntax = "proto2";
+
+package ships.proto;
+
+/**
+ * A message stating that one of the players won the game in some channel.
+ */
+message WinnerStatement
+{
+
+  /** The winner as index into the list of participents.  */
+  optional uint32 winner = 1;
+
+  /* Note that message signatures in general (thus also the signature made
+     on a winner statement) are already tied to a particular channel ID.
+     Thus it is not necessary to include the channel ID or any other metadata
+     (like the Xaya names of participants) in the message.  */
+
+}

--- a/ships/testutils.cpp
+++ b/ships/testutils.cpp
@@ -1,0 +1,35 @@
+// Copyright (C) 2019 The Xaya developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "testutils.hpp"
+
+#include "coord.hpp"
+
+#include <glog/logging.h>
+
+namespace ships
+{
+
+Grid
+GridFromString (const std::string& str)
+{
+  CHECK_EQ (str.size (), Coord::CELLS);
+
+  Grid g;
+  for (int i = 0; i < Coord::CELLS; ++i)
+    switch (str[i])
+      {
+      case '.':
+        break;
+      case 'x':
+        g.Set (Coord (i));
+        break;
+      default:
+        LOG (FATAL) << "Invalid character in position string: " << str[i];
+      }
+
+  return g;
+}
+
+} // namespace ships

--- a/ships/testutils.hpp
+++ b/ships/testutils.hpp
@@ -1,0 +1,24 @@
+// Copyright (C) 2019 The Xaya developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef XAYASHIPS_TESTUTILS_HPP
+#define XAYASHIPS_TESTUTILS_HPP
+
+#include "grid.hpp"
+
+#include <string>
+
+namespace ships
+{
+
+/**
+ * Parses a ship position given as string and returns it.  The string must be
+ * 64 characters long (and may be split into 8 lines in code), consisting only
+ * of the characters "." for zeros and "x" for ones.
+ */
+Grid GridFromString (const std::string& str);
+
+} // namespace ships
+
+#endif // XAYASHIPS_TESTUTILS_HPP


### PR DESCRIPTION
This set of changes creates a new folder `ships`, which will hold the code for the Xayaships game-channel demo.  For now, we define the basic board rules (i.e. for the game itself that happens on the channel) and implement them.  This implementation features not only basic battleships rules, but also provably fair random numbers to determine the beginning player and hash commitments to ensure that noone can cheat with their ship positions.