### PR TITLE
Introduce "reinitisation states" for channels

### DIFF
--- a/gamechannel/channelgame.cpp
+++ b/gamechannel/channelgame.cpp
@@ -7,6 +7,8 @@
 #include "schema.hpp"
 #include "stateproof.hpp"
 
+#include <xayautil/hash.hpp>
+
 #include <glog/logging.h>
 
 namespace xaya
@@ -131,6 +133,16 @@ ChannelGame::ProcessResolution (ChannelData& ch, const proto::StateProof& proof)
   ch.SetStateProof (proof);
   ch.ClearDispute ();
   return true;
+}
+
+void
+UpdateMetadataReinit (const uint256& txid, proto::ChannelMetadata& meta)
+{
+  SHA256 hasher;
+  hasher << meta.reinit ();
+  hasher << txid;
+
+  meta.set_reinit (hasher.Finalise ().GetBinaryString ());
 }
 
 } // namespace xaya

--- a/gamechannel/channelgame.cpp
+++ b/gamechannel/channelgame.cpp
@@ -32,17 +32,17 @@ ChannelGame::ProcessDispute (ChannelData& ch, const unsigned height,
 
   const auto& id = ch.GetId ();
   const auto& meta = ch.GetMetadata ();
-  const auto& onChainState = ch.GetLatestState ();
   const auto& rules = GetBoardRules ();
 
   BoardState provenState;
-  if (!VerifyStateProof (GetXayaRpc (), rules, id, meta, onChainState, proof,
-                         provenState))
+  if (!VerifyStateProof (GetXayaRpc (), rules, id, meta, ch.GetReinitState (),
+                         proof, provenState))
     {
       LOG (WARNING) << "Dispute has invalid state proof";
       return false;
     }
 
+  const auto& onChainState = ch.GetLatestState ();
   const auto onChainParsed = rules.ParseState (id, meta, onChainState);
   CHECK (onChainParsed != nullptr);
   const auto provenParsed = rules.ParseState (id, meta, provenState);
@@ -103,18 +103,17 @@ ChannelGame::ProcessResolution (ChannelData& ch, const proto::StateProof& proof)
 {
   const auto& id = ch.GetId ();
   const auto& meta = ch.GetMetadata ();
-  const auto& onChainState = ch.GetLatestState ();
   const auto& rules = GetBoardRules ();
 
   BoardState provenState;
-  if (!VerifyStateProof (GetXayaRpc (), rules, id, meta, onChainState, proof,
-                         provenState))
+  if (!VerifyStateProof (GetXayaRpc (), rules, id, meta, ch.GetReinitState (),
+                         proof, provenState))
     {
-      LOG (WARNING) << "Dispute has invalid state proof";
+      LOG (WARNING) << "Resolution has invalid state proof";
       return false;
     }
 
-  const auto onChainParsed = rules.ParseState (id, meta, onChainState);
+  const auto onChainParsed = rules.ParseState (id, meta, ch.GetLatestState ());
   CHECK (onChainParsed != nullptr);
   const auto provenParsed = rules.ParseState (id, meta, provenState);
   CHECK (provenParsed != nullptr);

--- a/gamechannel/channelgame.cpp
+++ b/gamechannel/channelgame.cpp
@@ -18,59 +18,6 @@ ChannelGame::SetupGameChannelsSchema (sqlite3* db)
   InternalSetupGameChannelsSchema (db);
 }
 
-namespace
-{
-
-/**
- * Verifies if the given state proof is valid and for a state later
- * than (in turn count) the current on-chain state.  If the turn count is the
- * same, then a dispute being applied counts as "later" than a previous
- * non-disputed state.  This is logic in common between ProcessDispute and
- * ProcessResolution.
- */
-bool
-CheckStateProofIsLater (XayaRpcClient& rpc, const BoardRules& rules,
-                        const ChannelData& ch, const proto::StateProof& proof,
-                        const bool provenIsDispute, BoardState& provenState)
-{
-  const auto& id = ch.GetId ();
-  const auto& meta = ch.GetMetadata ();
-  const auto& onChainState = ch.GetState ();
-
-  if (!VerifyStateProof (rpc, rules, id, meta, onChainState, proof,
-                         provenState))
-    {
-      LOG (WARNING) << "Dispute/resolution has invalid state proof";
-      return false;
-    }
-
-  const auto onChainParsed = rules.ParseState (id, meta, onChainState);
-  CHECK (onChainParsed != nullptr);
-  const auto provenParsed = rules.ParseState (id, meta, provenState);
-  CHECK (provenParsed != nullptr);
-
-  const bool onChainIsDispute = ch.HasDispute ();
-  const unsigned onChainCnt = onChainParsed->TurnCount ();
-  const unsigned provenCnt = provenParsed->TurnCount ();
-
-  if (provenCnt > onChainCnt)
-    return true;
-  if (provenCnt == onChainCnt && !onChainIsDispute && provenIsDispute)
-    {
-      LOG (INFO)
-          << "Allowing dispute to be filed for non-disputed on-chain state"
-             " of the same turn count " << provenCnt;
-      return true;
-    }
-
-  LOG (WARNING)
-      << "Dispute/resolution has turn count " << provenCnt
-      << ", which is not beyond the on-chain count " << onChainCnt;
-  return false;
-}
-
-} // anonymous namespace
-
 bool
 ChannelGame::ProcessDispute (ChannelData& ch, const unsigned height,
                              const proto::StateProof& proof)
@@ -83,42 +30,106 @@ ChannelGame::ProcessDispute (ChannelData& ch, const unsigned height,
 
   const auto& id = ch.GetId ();
   const auto& meta = ch.GetMetadata ();
+  const auto& onChainState = ch.GetState ();
   const auto& rules = GetBoardRules ();
 
   BoardState provenState;
-  if (!CheckStateProofIsLater (GetXayaRpc (), rules, ch, proof,
-                               true, provenState))
-    return false;
+  if (!VerifyStateProof (GetXayaRpc (), rules, id, meta, onChainState, proof,
+                         provenState))
+    {
+      LOG (WARNING) << "Dispute has invalid state proof";
+      return false;
+    }
 
+  const auto onChainParsed = rules.ParseState (id, meta, onChainState);
+  CHECK (onChainParsed != nullptr);
   const auto provenParsed = rules.ParseState (id, meta, provenState);
   CHECK (provenParsed != nullptr);
+
   if (provenParsed->WhoseTurn () == ParsedBoardState::NO_TURN)
     {
       LOG (WARNING) << "Cannot file dispute for 'no turn' situation";
       return false;
     }
 
-  VLOG (1) << "Dispute is valid, updating state...";
+  const unsigned onChainCnt = onChainParsed->TurnCount ();
+  const unsigned provenCnt = provenParsed->TurnCount ();
 
-  ch.SetState (provenState);
+  if (provenCnt > onChainCnt)
+    {
+      VLOG (1)
+          << "Disputing on-chain state at " << onChainCnt
+          << " with new state at turn count " << provenCnt;
+      ch.SetState (provenState);
+      ch.SetDisputeHeight (height);
+      return true;
+    }
+
+  if (provenCnt < onChainCnt)
+    {
+      LOG (WARNING)
+          << "Dispute with state at turn " << provenCnt
+          << " is invalid, on-chain state is at " << onChainCnt;
+      return false;
+    }
+
+  CHECK_EQ (provenCnt, onChainCnt);
+
+  if (ch.HasDispute ())
+    {
+      LOG (WARNING)
+          << "Dispute has same turn count (" << provenCnt << ") as"
+          << " on-chain state, which is already disputed";
+      return false;
+    }
+
+  if (!provenParsed->Equals (onChainState))
+    {
+      LOG (WARNING)
+          << "Dispute has same turn count as on-chain state (" << provenCnt
+          << "), but a differing state";
+      return false;
+    }
+
+  VLOG (1) << "Disputing existing on-chain state at turn " << provenCnt;
   ch.SetDisputeHeight (height);
-
   return true;
 }
 
 bool
 ChannelGame::ProcessResolution (ChannelData& ch, const proto::StateProof& proof)
 {
+  const auto& id = ch.GetId ();
+  const auto& meta = ch.GetMetadata ();
+  const auto& onChainState = ch.GetState ();
+  const auto& rules = GetBoardRules ();
+
   BoardState provenState;
-  if (!CheckStateProofIsLater (GetXayaRpc (), GetBoardRules (), ch, proof,
-                               false, provenState))
-    return false;
+  if (!VerifyStateProof (GetXayaRpc (), rules, id, meta, onChainState, proof,
+                         provenState))
+    {
+      LOG (WARNING) << "Dispute has invalid state proof";
+      return false;
+    }
+
+  const auto onChainParsed = rules.ParseState (id, meta, onChainState);
+  CHECK (onChainParsed != nullptr);
+  const auto provenParsed = rules.ParseState (id, meta, provenState);
+  CHECK (provenParsed != nullptr);
+
+  const unsigned onChainCnt = onChainParsed->TurnCount ();
+  const unsigned provenCnt = provenParsed->TurnCount ();
+  if (provenCnt <= onChainCnt)
+    {
+      LOG (WARNING)
+          << "Resolution for state at turn " << provenCnt
+          << " is invalid, on-chain state is already at " << onChainCnt;
+      return false;
+    }
 
   VLOG (1) << "Resolution is valid, updating state...";
-
   ch.SetState (provenState);
   ch.ClearDispute ();
-
   return true;
 }
 

--- a/gamechannel/channelgame.cpp
+++ b/gamechannel/channelgame.cpp
@@ -30,7 +30,7 @@ ChannelGame::ProcessDispute (ChannelData& ch, const unsigned height,
 
   const auto& id = ch.GetId ();
   const auto& meta = ch.GetMetadata ();
-  const auto& onChainState = ch.GetState ();
+  const auto& onChainState = ch.GetLatestState ();
   const auto& rules = GetBoardRules ();
 
   BoardState provenState;
@@ -60,7 +60,7 @@ ChannelGame::ProcessDispute (ChannelData& ch, const unsigned height,
       VLOG (1)
           << "Disputing on-chain state at " << onChainCnt
           << " with new state at turn count " << provenCnt;
-      ch.SetState (provenState);
+      ch.SetStateProof (proof);
       ch.SetDisputeHeight (height);
       return true;
     }
@@ -101,7 +101,7 @@ ChannelGame::ProcessResolution (ChannelData& ch, const proto::StateProof& proof)
 {
   const auto& id = ch.GetId ();
   const auto& meta = ch.GetMetadata ();
-  const auto& onChainState = ch.GetState ();
+  const auto& onChainState = ch.GetLatestState ();
   const auto& rules = GetBoardRules ();
 
   BoardState provenState;
@@ -128,7 +128,7 @@ ChannelGame::ProcessResolution (ChannelData& ch, const proto::StateProof& proof)
     }
 
   VLOG (1) << "Resolution is valid, updating state...";
-  ch.SetState (provenState);
+  ch.SetStateProof (proof);
   ch.ClearDispute ();
   return true;
 }

--- a/gamechannel/channelgame.hpp
+++ b/gamechannel/channelgame.hpp
@@ -38,10 +38,14 @@ protected:
    * current block height for the given game channel and based on the
    * given state proof.  If the request is valid (mainly meaning that the
    * state proof is valid and for a "later" state than the current on-chain
-   * state or at least the same as the current state and it does not have
-   * a dispute yet), then the dispute is opened on the ChannelData instance and
+   * state), then the dispute is opened on the ChannelData instance and
    * true is returned.  If it is not valid, then no changes are made and
    * false is returned.
+   *
+   * It is valid to open a dispute for the state that is currently on-chain
+   * (same turn height but only if it actually Equals() that state) if there
+   * was not already a dispute for it.  This is necessary to avoid a situation
+   * as in https://github.com/xaya/libxayagame/issues/51.
    */
   bool ProcessDispute (ChannelData& ch, unsigned height,
                        const proto::StateProof& proof);

--- a/gamechannel/channelgame.hpp
+++ b/gamechannel/channelgame.hpp
@@ -8,9 +8,11 @@
 #include "boardrules.hpp"
 #include "database.hpp"
 
+#include "proto/metadata.pb.h"
 #include "proto/stateproof.pb.h"
 
 #include <xayagame/sqlitegame.hpp>
+#include <xayautil/uint256.hpp>
 
 namespace xaya
 {
@@ -74,6 +76,15 @@ public:
   using SQLiteGame::SQLiteGame;
 
 };
+
+/**
+ * Updates the reinitialisation ID in the given metadata proto for an update
+ * done by the passed-in txid.  This is one way to update the reinit IDs and
+ * make sure that they yield a unique sequence that does not allow for any
+ * replay attacks.  It need not be used by games, though, in case they have
+ * a more suitable update mechanism.
+ */
+void UpdateMetadataReinit (const uint256& txid, proto::ChannelMetadata& meta);
 
 } // namespace xaya
 

--- a/gamechannel/channelgame_tests.cpp
+++ b/gamechannel/channelgame_tests.cpp
@@ -328,5 +328,28 @@ TEST_F (ResolutionTests, ResolvesToNoTurnState)
 
 /* ************************************************************************** */
 
+TEST (UpdateMetadataReinitTests, Works)
+{
+  proto::ChannelMetadata meta;
+  const std::string reinit1 = meta.reinit ();
+
+  UpdateMetadataReinit (SHA256::Hash ("foo"), meta);
+  const std::string reinit2 = meta.reinit ();
+
+  UpdateMetadataReinit (SHA256::Hash ("bar"), meta);
+  const std::string reinit3 = meta.reinit ();
+
+  EXPECT_NE (reinit1, reinit2);
+  EXPECT_NE (reinit1, reinit3);
+  EXPECT_NE (reinit2, reinit3);
+
+  uint256 val;
+  val.FromBlob (reinterpret_cast<const unsigned char*> (reinit2.data ()));
+  EXPECT_EQ (val.ToHex (),
+      "c7ade88fc7a21498a6a5e5c385e1f68bed822b72aa63c4a9a48a02c2466ee29e");
+}
+
+/* ************************************************************************** */
+
 } // anonymous namespace
 } // namespace xaya

--- a/gamechannel/channelgame_tests.cpp
+++ b/gamechannel/channelgame_tests.cpp
@@ -115,27 +115,7 @@ TEST_F (DisputeTests, InvalidStateClaimed)
   EXPECT_FALSE (ch->HasDispute ());
 }
 
-TEST_F (DisputeTests, NoLaterTurnPreviousDispute)
-{
-  auto ch = GetChannel ("test");
-  ch->SetDisputeHeight (50);
-  ch->SetState ("10 5");
-
-  ASSERT_FALSE (game.ProcessDispute (*ch, 100, ParseStateProof (R"(
-    initial_state:
-      {
-        data: "20 5"
-        signatures: "sgn0"
-        signatures: "sgn1"
-      }
-  )")));
-
-  EXPECT_EQ (ch->GetState (), "10 5");
-  ASSERT_TRUE (ch->HasDispute ());
-  EXPECT_EQ (ch->GetDisputeHeight (), 50);
-}
-
-TEST_F (DisputeTests, EarlierTurnPreviousResolution)
+TEST_F (DisputeTests, EarlierTurn)
 {
   auto ch = GetChannel ("test");
   ch->SetState ("10 5");
@@ -151,6 +131,44 @@ TEST_F (DisputeTests, EarlierTurnPreviousResolution)
 
   EXPECT_EQ (ch->GetState (), "10 5");
   EXPECT_FALSE (ch->HasDispute ());
+}
+
+TEST_F (DisputeTests, SameTurnAndDifferentState)
+{
+  auto ch = GetChannel ("test");
+  ch->SetState ("10 5");
+
+  ASSERT_FALSE (game.ProcessDispute (*ch, 100, ParseStateProof (R"(
+    initial_state:
+      {
+        data: "20 5"
+        signatures: "sgn0"
+        signatures: "sgn1"
+      }
+  )")));
+
+  EXPECT_EQ (ch->GetState (), "10 5");
+  EXPECT_FALSE (ch->HasDispute ());
+}
+
+TEST_F (DisputeTests, SameTurnAndStatePreviousDispute)
+{
+  auto ch = GetChannel ("test");
+  ch->SetDisputeHeight (50);
+  ch->SetState ("10 5");
+
+  ASSERT_FALSE (game.ProcessDispute (*ch, 100, ParseStateProof (R"(
+    initial_state:
+      {
+        data: "10 5"
+        signatures: "sgn0"
+        signatures: "sgn1"
+      }
+  )")));
+
+  EXPECT_EQ (ch->GetState (), "10 5");
+  ASSERT_TRUE (ch->HasDispute ());
+  EXPECT_EQ (ch->GetDisputeHeight (), 50);
 }
 
 TEST_F (DisputeTests, NoTurnState)
@@ -190,7 +208,7 @@ TEST_F (DisputeTests, SettingValidDispute)
   EXPECT_EQ (ch->GetDisputeHeight (), 100);
 }
 
-TEST_F (DisputeTests, SameTurnAsPreviousResolution)
+TEST_F (DisputeTests, SameTurnAndStatePreviousResolution)
 {
   auto ch = GetChannel ("test");
   ch->SetState ("10 5");
@@ -198,13 +216,13 @@ TEST_F (DisputeTests, SameTurnAsPreviousResolution)
   ASSERT_TRUE (game.ProcessDispute (*ch, 100, ParseStateProof (R"(
     initial_state:
       {
-        data: "20 5"
+        data: "  10 5  "
         signatures: "sgn0"
         signatures: "sgn1"
       }
   )")));
 
-  EXPECT_EQ (ch->GetState (), "20 5");
+  EXPECT_EQ (ch->GetState (), "10 5");
   ASSERT_TRUE (ch->HasDispute ());
   EXPECT_EQ (ch->GetDisputeHeight (), 100);
 }
@@ -271,7 +289,7 @@ TEST_F (ResolutionTests, InvalidStateClaimed)
   EXPECT_EQ (ch->GetDisputeHeight (), 100);
 }
 
-TEST_F (ResolutionTests, NoLaterTurnPreviousDispute)
+TEST_F (ResolutionTests, NoLaterTurn)
 {
   auto ch = GetChannel ("test");
   ch->SetDisputeHeight (100);
@@ -289,24 +307,6 @@ TEST_F (ResolutionTests, NoLaterTurnPreviousDispute)
   EXPECT_EQ (ch->GetState (), "10 5");
   ASSERT_TRUE (ch->HasDispute ());
   EXPECT_EQ (ch->GetDisputeHeight (), 100);
-}
-
-TEST_F (ResolutionTests, NoLaterTurnPreviousResolution)
-{
-  auto ch = GetChannel ("test");
-  ch->SetState ("10 5");
-
-  ASSERT_FALSE (game.ProcessResolution (*ch, ParseStateProof (R"(
-    initial_state:
-      {
-        data: "20 5"
-        signatures: "sgn0"
-        signatures: "sgn1"
-      }
-  )")));
-
-  EXPECT_EQ (ch->GetState (), "10 5");
-  EXPECT_FALSE (ch->HasDispute ());
 }
 
 TEST_F (ResolutionTests, Valid)

--- a/gamechannel/database.cpp
+++ b/gamechannel/database.cpp
@@ -172,6 +172,10 @@ ChannelData::Reinitialise (const proto::ChannelMetadata& m,
       << "Reinitialising channel " << id.ToHex ()
       << " to new state: " << initialisedState;
 
+  if (initialised)
+    CHECK_NE (metadata.reinit (), m.reinit ())
+        << "Metadata reinitialisation ID is not changed in reinit of channel";
+
   metadata = m;
   reinit = initialisedState;
   StateProofFromReinit (reinit, proof);

--- a/gamechannel/database.hpp
+++ b/gamechannel/database.hpp
@@ -8,6 +8,7 @@
 #include "boardrules.hpp"
 
 #include "proto/metadata.pb.h"
+#include "proto/stateproof.pb.h"
 
 #include <xayautil/uint256.hpp>
 
@@ -40,8 +41,17 @@ private:
   /** The channel's metadata.  */
   proto::ChannelMetadata metadata;
 
-  /** The channel's current state.  */
-  BoardState state;
+  /** The channel's reinitialisation state.  */
+  BoardState reinit;
+
+  /** The latest state proof.  */
+  proto::StateProof proof;
+
+  /**
+   * Set to true if we have initialised metadata and reinit state.  This is
+   * false initially for newly constructed channels.
+   */
+  bool initialised;
 
   /** The dispute height or 0 if there is no dispute.  */
   unsigned disputeHeight;
@@ -68,7 +78,7 @@ public:
 
   /**
    * If this instance has been modified, the destructor updates the
-   * database to reflect the new state.
+   * database to reflect the changes not directly saved to the DB.
    */
   ~ChannelData ();
 
@@ -82,31 +92,20 @@ public:
     return id;
   }
 
-  const proto::ChannelMetadata&
-  GetMetadata () const
-  {
-    return metadata;
-  }
+  const proto::ChannelMetadata& GetMetadata () const;
 
-  proto::ChannelMetadata&
-  MutableMetadata ()
-  {
-    dirty = true;
-    return metadata;
-  }
+  const BoardState& GetReinitState () const;
 
-  const BoardState&
-  GetState () const
-  {
-    return state;
-  }
+  /**
+   * Reinitialises the channel.  This allows changes to the metadata, purges
+   * all archived states and sets the state to the given initial state.
+   */
+  void Reinitialise (const proto::ChannelMetadata& m,
+                     const BoardState& initialState);
 
-  void
-  SetState (const BoardState& s)
-  {
-    dirty = true;
-    state = s;
-  }
+  const proto::StateProof& GetStateProof () const;
+  const BoardState& GetLatestState () const;
+  void SetStateProof (const proto::StateProof& p);
 
   bool
   HasDispute () const

--- a/gamechannel/database_tests.cpp
+++ b/gamechannel/database_tests.cpp
@@ -75,12 +75,14 @@ TEST_F (ChannelDbTests, UpdatingWithReinit)
   ASSERT_NE (h, nullptr);
   EXPECT_EQ (h->GetId (), SHA256::Hash ("id"));
   EXPECT_EQ (h->GetMetadata ().participants_size (), 1);
+  EXPECT_EQ (h->GetMetadata ().reinit (), "");
   EXPECT_EQ (h->GetReinitState (), "state");
   EXPECT_EQ (h->GetLatestState (), "state");
   ASSERT_TRUE (h->HasDispute ());
   EXPECT_EQ (h->GetDisputeHeight (), 1234);
 
   meta.Clear ();
+  meta.set_reinit ("init 2");
   h->Reinitialise (meta, "other state");
   h->ClearDispute ();
   h.reset ();
@@ -89,6 +91,7 @@ TEST_F (ChannelDbTests, UpdatingWithReinit)
   ASSERT_NE (h, nullptr);
   EXPECT_EQ (h->GetId (), SHA256::Hash ("id"));
   EXPECT_EQ (h->GetMetadata ().participants_size (), 0);
+  EXPECT_EQ (h->GetMetadata ().reinit (), "init 2");
   EXPECT_EQ (h->GetReinitState (), "other state");
   EXPECT_EQ (h->GetLatestState (), "other state");
   EXPECT_FALSE (h->HasDispute ());

--- a/gamechannel/gamestatejson.cpp
+++ b/gamechannel/gamestatejson.cpp
@@ -31,10 +31,10 @@ ChannelToGameStateJson (const ChannelData& ch, const BoardRules& r)
   res["meta"] = meta;
 
   Json::Value state(Json::objectValue);
-  auto parsed = r.ParseState (id, metaPb, ch.GetState ());
+  auto parsed = r.ParseState (id, metaPb, ch.GetLatestState ());
   CHECK (parsed != nullptr)
       << "Channel " << id.ToHex () << " has invalid state on chain: "
-      << ch.GetState ();
+      << ch.GetLatestState ();
   state["data"] = parsed->ToJson ();
 
   state["whoseturn"] = Json::Value ();

--- a/gamechannel/gamestatejson.cpp
+++ b/gamechannel/gamestatejson.cpp
@@ -1,11 +1,55 @@
 #include "gamestatejson.hpp"
 
+#include <xayautil/base64.hpp>
+
 #include <glog/logging.h>
 
 #include <sqlite3.h>
 
 namespace xaya
 {
+
+namespace
+{
+
+/**
+ * Encodes a protocol buffer as base64 string.
+ */
+template <typename Proto>
+  std::string
+  EncodeProto (const Proto& msg)
+{
+  std::string serialised;
+  CHECK (msg.SerializeToString (&serialised));
+  return EncodeBase64 (serialised);
+}
+
+/**
+ * Encodes a board state as JSON object.
+ */
+Json::Value
+EncodeBoardState (const ChannelData& ch, const BoardRules& r,
+                  const BoardState& state)
+{
+  const auto& id = ch.GetId ();
+
+  Json::Value res(Json::objectValue);
+  auto parsed = r.ParseState (id, ch.GetMetadata (), state);
+  CHECK (parsed != nullptr)
+      << "Channel " << id.ToHex () << " has invalid state on chain: "
+      << state;
+  res["data"] = parsed->ToJson ();
+
+  res["whoseturn"] = Json::Value ();
+  const int turn = parsed->WhoseTurn ();
+  if (turn != ParsedBoardState::NO_TURN)
+    res["whoseturn"] = turn;
+  res["turncount"] = static_cast<int> (parsed->TurnCount ());
+
+  return res;
+}
+
+} // anonymous namespace
 
 Json::Value
 ChannelToGameStateJson (const ChannelData& ch, const BoardRules& r)
@@ -28,21 +72,13 @@ ChannelToGameStateJson (const ChannelData& ch, const BoardRules& r)
       participants.append (cur);
     }
   meta["participants"] = participants;
+  meta["reinit"] = EncodeBase64 (metaPb.reinit ());
+  meta["proto"] = EncodeProto (metaPb);
   res["meta"] = meta;
 
-  Json::Value state(Json::objectValue);
-  auto parsed = r.ParseState (id, metaPb, ch.GetLatestState ());
-  CHECK (parsed != nullptr)
-      << "Channel " << id.ToHex () << " has invalid state on chain: "
-      << ch.GetLatestState ();
-  state["data"] = parsed->ToJson ();
-
-  state["whoseturn"] = Json::Value ();
-  const int turn = parsed->WhoseTurn ();
-  if (turn != ParsedBoardState::NO_TURN)
-    state["whoseturn"] = turn;
-  state["turncount"] = static_cast<int> (parsed->TurnCount ());
-  res["state"] = state;
+  res["state"] = EncodeBoardState (ch, r, ch.GetLatestState ());
+  res["state"]["proof"] = EncodeProto (ch.GetStateProof ());
+  res["reinit"] = EncodeBoardState (ch, r, ch.GetReinitState ());
 
   return res;
 }

--- a/gamechannel/proto/metadata.proto
+++ b/gamechannel/proto/metadata.proto
@@ -25,4 +25,24 @@ message ChannelMetadata
   /** The participants of the channel.  The order matters.  */
   repeated ChannelParticipant participants = 1;
 
+  /**
+   * Identifier for the current "reinitialisation" of the channel.  This should
+   * be a string of bytes that uniquely identifies the current state of the
+   * channel with respect to changes to metadata and other "significant"
+   * on-chain changes.  For instance, if some participant joins the channel
+   * or leaves it, the reinitialisation should be updated.  But also if at
+   * a later stage the channel again has the same set of participants as
+   * previously, it should probably have a different reinitialisation ID then.
+   *
+   * The exact format of this string and how it is updated may depend on the
+   * particular game and its rules for how metadata and participants can change.
+   * A good rule of thumb could be to set this to a hash based on the previous
+   * identifier and the txid that led to the update.
+   *
+   * Leaving this field unset is equivalent to an empty string.  This is fine,
+   * e.g. for the very first state of a channel that was just created, as long
+   * as it will be set to something else later on when more changes happen.
+   */
+  optional bytes reinit = 2;
+
 }

--- a/gamechannel/proto/signatures.proto
+++ b/gamechannel/proto/signatures.proto
@@ -21,8 +21,8 @@ message SignedData
    * is the "signmessage" output of Xaya Core, but base64-decoded to binary.
    *
    * For the message, the channel's ID (uint256) is concatenated with
-   * a string describing what the data is (e.g. "state"), a nul byte
-   * and finally the value of "data".
+   * the base64-encoded reinit ID, a nul byte, a string describing what the
+   * data is (e.g. "state"), another nul byte and finally the value of "data".
    *
    * All this is hashed with SHA-256 and then converted to a lower-case
    * hex string, which is the "message" for "signmessage".

--- a/gamechannel/proto/stateproof.proto
+++ b/gamechannel/proto/stateproof.proto
@@ -30,11 +30,20 @@ message StateTransition
 /**
  * A full proof of some state of the game channel and that every participant
  * agrees to it.  This starts off some base state and then applies state
- * transitions ending at the target state.  As long as the base or any later
- * state was known to be good (i.e. already put on-chain) or every participant
- * signed a state during the steps, this is ensured.  It is also fine
- * if someone signed only a state even if they were not the one who did a move,
- * although that is unlikely to occur in practice.
+ * transitions ending at the target state.  This is valid as long as the
+ * transitions themselves are valid and all channel participants signed one
+ * of the intermediate states.  If the initial state is the channel's
+ * reinitialisation state, then that is also good and no signatures are
+ * required (as long as the transitions themselves are signed by the
+ * proper players).  It is also fine if someone signed only a state even
+ * if they were not the one who did a move, although that is unlikely to occur
+ * in practice.
+ *
+ * A state proof is always seen in context of a particular channel and its
+ * current reinitialisation (i.e. these are not part of the explicit
+ * state proof itself).  This is enforced since that data is part of the
+ * signatures made, so that a state proof moved to a different channel
+ * or reinit of the same channel is not valid anymore.
  *
  * Note that there are possible efficiency-improvements to the format
  * and rules of such a state proof.  For instance, it would be enough if for

--- a/gamechannel/schema.sql
+++ b/gamechannel/schema.sql
@@ -12,8 +12,12 @@ CREATE TABLE IF NOT EXISTS `xayagame_game_channels` (
   -- ChannelMetadata protocol buffer instance.
   `metadata` BLOB NOT NULL,
 
-  -- The latest board state that is put on-chain as encoded data.
-  `state` BLOB NOT NULL,
+  -- The encoded state at the last reinitialisation.
+  `reinit` BLOB NOT NULL,
+
+  -- The latest known state as a full serialised state proof.  Can be NULL
+  -- if there is no state beyond the reinit state.
+  `stateproof` BLOB NULL,
 
   -- If there is a dispute open (based on the current proven state), then
   -- the block height when it was filed.

--- a/gamechannel/signatures.cpp
+++ b/gamechannel/signatures.cpp
@@ -17,15 +17,18 @@ namespace xaya
 
 std::string
 GetChannelSignatureMessage (const uint256& channelId,
+                            const proto::ChannelMetadata& meta,
                             const std::string& topic,
                             const std::string& data)
 {
   CHECK_EQ (topic.find ('\0'), std::string::npos)
       << "Topic string contains nul character";
+  const std::string nulByte("\0", 1);
 
   SHA256 hasher;
   hasher << channelId;
-  hasher << topic << std::string ("\0", 1);
+  hasher << EncodeBase64 (meta.reinit ()) << nulByte;
+  hasher << topic << nulByte;
   hasher << data;
 
   return hasher.Finalise ().ToHex ();
@@ -38,7 +41,7 @@ VerifyParticipantSignatures (XayaRpcClient& rpc,
                              const std::string& topic,
                              const proto::SignedData& data)
 {
-  const std::string msg = GetChannelSignatureMessage (channelId, topic,
+  const std::string msg = GetChannelSignatureMessage (channelId, meta, topic,
                                                       data.data ());
 
   std::set<std::string> addresses;

--- a/gamechannel/signatures.hpp
+++ b/gamechannel/signatures.hpp
@@ -28,6 +28,7 @@ namespace xaya
  * values can be used for game-specific needs.
  */
 std::string GetChannelSignatureMessage (const uint256& channelId,
+                                        const proto::ChannelMetadata& meta,
                                         const std::string& topic,
                                         const std::string& data);
 

--- a/gamechannel/stateproof.cpp
+++ b/gamechannel/stateproof.cpp
@@ -94,7 +94,7 @@ bool
 VerifyStateProof (XayaRpcClient& rpc, const BoardRules& rules,
                   const uint256& channelId,
                   const proto::ChannelMetadata& meta,
-                  const BoardState& onChainState,
+                  const BoardState& reinitState,
                   const proto::StateProof& proof,
                   BoardState& endState)
 {
@@ -111,7 +111,7 @@ VerifyStateProof (XayaRpcClient& rpc, const BoardRules& rules,
     }
 
   endState = proof.initial_state ().data ();
-  bool foundOnChain = parsed->Equals (onChainState);
+  const bool foundOnChain = parsed->Equals (reinitState);
 
   for (const auto& t : proof.transitions ())
     {
@@ -124,13 +124,11 @@ VerifyStateProof (XayaRpcClient& rpc, const BoardRules& rules,
       signatures.insert (newSignatures.begin (), newSignatures.end ());
       parsed = std::move (parsedNew);
       endState = t.new_state ().data ();
-      if (!foundOnChain)
-        foundOnChain = parsed->Equals (onChainState);
     }
 
   if (foundOnChain)
     {
-      VLOG (1) << "StateProof has on-chain state and is valid";
+      VLOG (1) << "StateProof starts from reinit state and is valid";
       return true;
     }
 

--- a/gamechannel/stateproof_tests.cpp
+++ b/gamechannel/stateproof_tests.cpp
@@ -327,35 +327,6 @@ TEST_F (StateProofTests, MissingSignature)
   )"));
 }
 
-TEST_F (StateProofTests, IntermediateStateOnChain)
-{
-  ASSERT_TRUE (VerifyProof (" 44 11 ", R"(
-    initial_state:
-      {
-        data: "42 10"
-      }
-    transitions:
-      {
-        move: "2"
-        new_state:
-          {
-            data: "44 11"
-            signatures: "sgn0"
-          }
-      }
-    transitions:
-      {
-        move: "2"
-        new_state:
-          {
-            data: "46 12"
-            signatures: "sgn0"
-          }
-      }
-  )"));
-  EXPECT_EQ (endState, "46 12");
-}
-
 TEST_F (StateProofTests, SignedInitialState)
 {
   ASSERT_TRUE (VerifyProof ("0 1", R"(

--- a/gamechannel/stateproof_tests.cpp
+++ b/gamechannel/stateproof_tests.cpp
@@ -31,6 +31,7 @@ protected:
 
   GeneralStateProofTests ()
   {
+    meta.set_reinit ("reinit");
     meta.add_participants ()->set_address ("addr0");
     meta.add_participants ()->set_address ("addr1");
 
@@ -139,7 +140,8 @@ TEST_F (StateTransitionTests, InvalidSignature)
 
 TEST_F (StateTransitionTests, Valid)
 {
-  ExpectSignature (channelId, "state", " 11 2 ", "signed by zero", "addr0");
+  ExpectSignature (channelId, meta, "state",
+                   " 11 2 ", "signed by zero", "addr0");
 
   EXPECT_TRUE (VerifyTransition ("10 1", R"(
     move: "1",
@@ -237,8 +239,8 @@ TEST_F (StateProofTests, OnlyInitialOnChain)
 
 TEST_F (StateProofTests, OnlyInitialSigned)
 {
-  ExpectSignature (channelId, "state", "42 5", "signature 0", "addr0");
-  ExpectSignature (channelId, "state", "42 5", "signature 1", "addr1");
+  ExpectSignature (channelId, meta, "state", "42 5", "signature 0", "addr0");
+  ExpectSignature (channelId, meta, "state", "42 5", "signature 1", "addr1");
 
   ASSERT_TRUE (VerifyProof ("0 1", R"(
     initial_state:

--- a/gamechannel/testgame.cpp
+++ b/gamechannel/testgame.cpp
@@ -207,6 +207,7 @@ TestGameFixture::ValidSignature (const std::string& sgn,
 
 void
 TestGameFixture::ExpectSignature (const uint256& channelId,
+                                  const proto::ChannelMetadata& meta,
                                   const std::string& topic,
                                   const std::string& msg,
                                   const std::string& sgn,
@@ -216,7 +217,8 @@ TestGameFixture::ExpectSignature (const uint256& channelId,
   res["valid"] = true;
   res["address"] = addr;
 
-  const std::string hashed = GetChannelSignatureMessage (channelId, topic, msg);
+  const std::string hashed
+      = GetChannelSignatureMessage (channelId, meta, topic, msg);
   EXPECT_CALL (mockXayaServer, verifymessage ("", hashed, EncodeBase64 (sgn)))
       .WillOnce (Return (res));
 }

--- a/gamechannel/testgame.hpp
+++ b/gamechannel/testgame.hpp
@@ -128,7 +128,9 @@ protected:
    * and signature (both as binary, they will be hashed / base64-encoded).
    * Returns a valid response for the given address.
    */
-  void ExpectSignature (const uint256& channelId, const std::string& topic,
+  void ExpectSignature (const uint256& channelId,
+                        const proto::ChannelMetadata& meta,
+                        const std::string& topic,
                         const std::string& msg, const std::string& sgn,
                         const std::string& addr);
 

--- a/ships/board.cpp
+++ b/ships/board.cpp
@@ -37,11 +37,7 @@ CheckHashValue (const xaya::uint256& actual, const std::string& expected)
       return false;
     }
 
-  const auto* bytes = reinterpret_cast<const unsigned char*> (expected.data ());
-  xaya::uint256 expectedValue;
-  expectedValue.FromBlob (bytes);
-
-  return actual == expectedValue;
+  return actual.GetBinaryString () == expected;
 }
 
 } // anonymous namespace

--- a/ships/board_tests.cpp
+++ b/ships/board_tests.cpp
@@ -107,13 +107,18 @@ protected:
 
   BoardTests ()
   {
-    auto* p = meta.add_participants ();
-    p->set_name ("alice");
-    p->set_address ("addr 0");
-
-    p = meta.add_participants ();
-    p->set_name ("bob");
-    p->set_address ("addr 1");
+    CHECK (TextFormat::ParseFromString (R"(
+      participants:
+        {
+          name: "alice"
+          address: "addr 0"
+        }
+      participants:
+        {
+          name: "bob"
+          address: "addr 1"
+        }
+    )", &meta));
   }
 
   /**
@@ -575,7 +580,8 @@ protected:
     res["address"] = addr;
 
     const std::string hashed
-        = xaya::GetChannelSignatureMessage (channelId, "winnerstatement", data);
+        = xaya::GetChannelSignatureMessage (channelId, meta,
+                                            "winnerstatement", data);
     EXPECT_CALL (mockXayaServer, verifymessage ("", hashed,
                                                 xaya::EncodeBase64 (sgn)))
         .WillOnce (Return (res));

--- a/ships/gamestatejson_tests.cpp
+++ b/ships/gamestatejson_tests.cpp
@@ -96,9 +96,20 @@ TEST_F (GameStateJsonTests, OneParticipantChannel)
     {
       "meta":
         {
+          "reinit": "",
           "participants": [{"name": "only me", "address": "addr"}]
         },
       "state":
+        {
+          "data":
+            {
+              "proto": "",
+              "phase": "single participant"
+            },
+          "whoseturn": null,
+          "turncount": 0
+        },
+      "reinit":
         {
           "data":
             {
@@ -112,7 +123,10 @@ TEST_F (GameStateJsonTests, OneParticipantChannel)
   )");
   expected["channels"][id.ToHex ()]["id"] = id.ToHex ();
 
-  EXPECT_EQ (gsj.GetFullJson (), expected);
+  auto actual = gsj.GetFullJson ();
+  actual["channels"][id.ToHex ()]["meta"].removeMember ("proto");
+  actual["channels"][id.ToHex ()]["state"].removeMember ("proof");
+  EXPECT_EQ (actual, expected);
 }
 
 TEST_F (GameStateJsonTests, TwoParticipantChannel)

--- a/ships/gamestatejson_tests.cpp
+++ b/ships/gamestatejson_tests.cpp
@@ -75,13 +75,15 @@ TEST_F (GameStateJsonTests, OneParticipantChannel)
 {
   const auto id = xaya::SHA256::Hash ("channel");
   auto h = tbl.CreateNew (id);
+  xaya::proto::ChannelMetadata meta;
   CHECK (TextFormat::ParseFromString (R"(
     participants:
       {
         name: "only me"
         address: "addr"
       }
-  )", &h->MutableMetadata ()));
+  )", &meta));
+  h->Reinitialise (meta, "");
   h.reset ();
 
   auto expected = ParseJson (R"(
@@ -117,6 +119,7 @@ TEST_F (GameStateJsonTests, TwoParticipantChannel)
 {
   const auto id = xaya::SHA256::Hash ("channel");
   auto h = tbl.CreateNew (id);
+  xaya::proto::ChannelMetadata meta;
   CHECK (TextFormat::ParseFromString (R"(
     participants:
       {
@@ -128,14 +131,15 @@ TEST_F (GameStateJsonTests, TwoParticipantChannel)
         name: "bar"
         address: "addr 2"
       }
-  )", &h->MutableMetadata ()));
+  )", &meta));
 
   proto::BoardState state;
   state.set_turn (0);
 
   std::string serialised;
   CHECK (state.SerializeToString (&serialised));
-  h->SetState (serialised);
+
+  h->Reinitialise (meta, serialised);
   h.reset ();
 
   const auto actual = gsj.GetFullJson ();

--- a/ships/gametest/channel_management.py
+++ b/ships/gametest/channel_management.py
@@ -36,16 +36,16 @@ class ChannelManagementTest (ShipsTest):
 
     assert id1 in channels
     ch1 = channels[id1]
-    self.assertEqual (ch1["meta"], {
-      "participants": [{"name": "foo", "address": addr1}],
-    })
+    self.assertEqual (ch1["meta"]["participants"], [
+      {"name": "foo", "address": addr1}
+    ])
     self.assertEqual (ch1["state"]["data"]["phase"], "single participant")
 
     assert id2 in channels
     ch2 = channels[id2]
-    self.assertEqual (ch2["meta"], {
-      "participants": [{"name": "bar", "address": addr2}],
-    })
+    self.assertEqual (ch2["meta"]["participants"], [
+      {"name": "bar", "address": addr2}
+    ])
     self.assertEqual (ch2["state"]["data"]["phase"], "single participant")
 
     # Perform an invalid join and abort on the channels. This should not affect
@@ -70,13 +70,10 @@ class ChannelManagementTest (ShipsTest):
 
     assert id1 in channels
     ch1 = channels[id1]
-    self.assertEqual (ch1["meta"], {
-      "participants":
-        [
-          {"name": "foo", "address": addr1},
-          {"name": "baz", "address": addr3},
-        ],
-    })
+    self.assertEqual (ch1["meta"]["participants"], [
+      {"name": "foo", "address": addr1},
+      {"name": "baz", "address": addr3},
+    ])
     self.assertEqual (ch1["state"]["data"]["phase"], "first commitment")
 
     assert id2 not in channels

--- a/ships/gametest/disputes.py
+++ b/ships/gametest/disputes.py
@@ -36,8 +36,15 @@ class DisputeTest (ShipsTest):
     self.generate (1)
     self.expectChannelState (cid, "first commitment", disputeHeight)
 
+    # Also filing a new dispute without more turns won't work in
+    # shifting forward the height.
+    self.mainLogger.info ("Trying to dispute again without more moves...")
+    self.sendMove ("xyz", {"d": {"id": cid, "state": state}})
+    self.generate (1)
+    self.expectChannelState (cid, "first commitment", disputeHeight)
+
     # Successfully resolve now, right at the expiry height.
-    self.generate (8)
+    self.generate (7)
     state = self.getStateProof (cid, """
       turn: 1
       position_hashes: "foo"

--- a/ships/logic.cpp
+++ b/ships/logic.cpp
@@ -110,7 +110,7 @@ ShipsLogic::UpdateState (sqlite3* db, const Json::Value& blockData)
         }
 
       HandleCreateChannel (data["c"], name, txid);
-      HandleJoinChannel (data["j"], name);
+      HandleJoinChannel (data["j"], name, txid);
       HandleAbortChannel (data["a"], name);
       HandleCloseChannel (data["w"]);
       HandleDisputeResolution (data["d"], height, true);
@@ -194,7 +194,8 @@ RetrieveChannelFromMove (const Json::Value& obj, xaya::ChannelsTable& tbl)
 } // anonymous namespace
 
 void
-ShipsLogic::HandleJoinChannel (const Json::Value& obj, const std::string& name)
+ShipsLogic::HandleJoinChannel (const Json::Value& obj, const std::string& name,
+                               const xaya::uint256& txid)
 {
   if (!obj.isObject ())
     return;
@@ -234,6 +235,7 @@ ShipsLogic::HandleJoinChannel (const Json::Value& obj, const std::string& name)
       << " with address " << addr;
 
   xaya::proto::ChannelMetadata newMeta = meta;
+  xaya::UpdateMetadataReinit (txid, newMeta);
   auto* p = newMeta.add_participants ();
   p->set_name (name);
   p->set_address (addr);

--- a/ships/logic.hpp
+++ b/ships/logic.hpp
@@ -48,7 +48,8 @@ private:
   /**
    * Tries to process a "join channel" move.
    */
-  void HandleJoinChannel (const Json::Value& obj, const std::string& name);
+  void HandleJoinChannel (const Json::Value& obj, const std::string& name,
+                          const xaya::uint256& txid);
 
   /**
    * Tries to process an "abort channel" move.

--- a/ships/logic_tests.cpp
+++ b/ships/logic_tests.cpp
@@ -700,6 +700,7 @@ TEST_F (CloseChannelTests, WrongNumberOfParticipants)
   auto h = ExpectChannel (channelId);
   xaya::proto::ChannelMetadata meta = h->GetMetadata ();
   meta.mutable_participants ()->RemoveLast ();
+  meta.set_reinit ("init 2");
   h->Reinitialise (meta, "");
   h.reset ();
 
@@ -893,6 +894,7 @@ TEST_F (DisputeResolutionTests, WrongNumberOfParticipants)
   auto h = ExpectChannel (channelId);
   xaya::proto::ChannelMetadata meta = h->GetMetadata ();
   meta.mutable_participants ()->RemoveLast ();
+  meta.set_reinit ("init 2");
   h->Reinitialise (meta, h->GetLatestState ());
   h.reset ();
 

--- a/ships/logic_tests.cpp
+++ b/ships/logic_tests.cpp
@@ -160,6 +160,21 @@ Move (const std::string& name, const xaya::uint256& txid,
   return res;
 }
 
+/**
+ * Returns a serialised state for the given text proto.
+ */
+xaya::BoardState
+SerialisedState (const std::string& str)
+{
+  proto::BoardState state;
+  CHECK (TextFormat::ParseFromString (str, &state));
+
+  xaya::BoardState res;
+  CHECK (state.SerializeToString (&res));
+
+  return res;
+}
+
 TEST_F (StateUpdateTests, MoveNotAnObject)
 {
   const auto txid = xaya::SHA256::Hash ("foo");
@@ -239,7 +254,7 @@ TEST_F (CreateChannelTests, CreationSuccessful)
   ASSERT_EQ (h->GetMetadata ().participants_size (), 1);
   EXPECT_EQ (h->GetMetadata ().participants (0).name (), "bar");
   EXPECT_EQ (h->GetMetadata ().participants (0).address (), "address 1");
-  EXPECT_EQ (h->GetState (), "");
+  EXPECT_EQ (h->GetLatestState (), "");
   EXPECT_FALSE (h->HasDispute ());
 
   h = ExpectChannel (xaya::SHA256::Hash ("baz"));
@@ -275,7 +290,11 @@ using JoinChannelTests = StateUpdateTests;
 TEST_F (JoinChannelTests, Malformed)
 {
   const auto existing = xaya::SHA256::Hash ("foo");
-  tbl.CreateNew (existing)->MutableMetadata ().add_participants ();
+  auto h = tbl.CreateNew (existing);
+  xaya::proto::ChannelMetadata meta;
+  meta.add_participants ();
+  h->Reinitialise (meta, "");
+  h.reset ();
 
   const auto txid = xaya::SHA256::Hash ("bar");
 
@@ -299,7 +318,11 @@ TEST_F (JoinChannelTests, Malformed)
 TEST_F (JoinChannelTests, NonExistantChannel)
 {
   const auto existing = xaya::SHA256::Hash ("foo");
-  tbl.CreateNew (existing)->MutableMetadata ().add_participants ();
+  auto h = tbl.CreateNew (existing);
+  xaya::proto::ChannelMetadata meta;
+  meta.add_participants ();
+  h->Reinitialise (meta, "");
+  h.reset ();
 
   const auto txid = xaya::SHA256::Hash ("bar");
   Json::Value data (Json::objectValue);
@@ -315,8 +338,10 @@ TEST_F (JoinChannelTests, AlreadyTwoParticipants)
 {
   const auto existing = xaya::SHA256::Hash ("foo");
   auto h = tbl.CreateNew (existing);
-  h->MutableMetadata ().add_participants ()->set_name ("foo");
-  h->MutableMetadata ().add_participants ()->set_name ("bar");
+  xaya::proto::ChannelMetadata meta;
+  meta.add_participants ()->set_name ("foo");
+  meta.add_participants ()->set_name ("bar");
+  h->Reinitialise (meta, SerialisedState ("turn: 0"));
   h.reset ();
 
   const auto txid = xaya::SHA256::Hash ("bar");
@@ -336,7 +361,9 @@ TEST_F (JoinChannelTests, SameNameInChannel)
 {
   const auto existing = xaya::SHA256::Hash ("foo");
   auto h = tbl.CreateNew (existing);
-  h->MutableMetadata ().add_participants ()->set_name ("foo");
+  xaya::proto::ChannelMetadata meta;
+  meta.add_participants ()->set_name ("foo");
+  h->Reinitialise (meta, "");
   h.reset ();
 
   const auto txid = xaya::SHA256::Hash ("bar");
@@ -375,7 +402,7 @@ TEST_F (JoinChannelTests, SuccessfulJoin)
   EXPECT_FALSE (h->HasDispute ());
 
   proto::BoardState state;
-  CHECK (state.ParseFromString (h->GetState ()));
+  CHECK (state.ParseFromString (h->GetLatestState ()));
   EXPECT_TRUE (state.has_turn ());
   EXPECT_EQ (state.turn (), 0);
 }
@@ -387,7 +414,11 @@ using AbortChannelTests = StateUpdateTests;
 TEST_F (AbortChannelTests, Malformed)
 {
   const auto existing = xaya::SHA256::Hash ("foo");
-  tbl.CreateNew (existing)->MutableMetadata ().add_participants ();
+  auto h = tbl.CreateNew (existing);
+  xaya::proto::ChannelMetadata meta;
+  meta.add_participants ();
+  h->Reinitialise (meta, "");
+  h.reset ();
 
   const auto txid = xaya::SHA256::Hash ("bar");
 
@@ -410,7 +441,11 @@ TEST_F (AbortChannelTests, Malformed)
 TEST_F (AbortChannelTests, NonExistantChannel)
 {
   const auto existing = xaya::SHA256::Hash ("foo");
-  tbl.CreateNew (existing)->MutableMetadata ().add_participants ();
+  auto h = tbl.CreateNew (existing);
+  xaya::proto::ChannelMetadata meta;
+  meta.add_participants ();
+  h->Reinitialise (meta, "");
+  h.reset ();
 
   const auto txid = xaya::SHA256::Hash ("bar");
   Json::Value data (Json::objectValue);
@@ -426,8 +461,10 @@ TEST_F (AbortChannelTests, AlreadyTwoParticipants)
 {
   const auto existing = xaya::SHA256::Hash ("foo");
   auto h = tbl.CreateNew (existing);
-  h->MutableMetadata ().add_participants ()->set_name ("foo");
-  h->MutableMetadata ().add_participants ()->set_name ("bar");
+  xaya::proto::ChannelMetadata meta;
+  meta.add_participants ()->set_name ("foo");
+  meta.add_participants ()->set_name ("bar");
+  h->Reinitialise (meta, SerialisedState ("turn: 0"));
   h.reset ();
 
   const auto txid = xaya::SHA256::Hash ("bar");
@@ -444,7 +481,9 @@ TEST_F (AbortChannelTests, DifferentName)
 {
   const auto existing = xaya::SHA256::Hash ("foo");
   auto h = tbl.CreateNew (existing);
-  h->MutableMetadata ().add_participants ()->set_name ("foo");
+  xaya::proto::ChannelMetadata meta;
+  meta.add_participants ()->set_name ("foo");
+  h->Reinitialise (meta, "");
   h.reset ();
 
   const auto txid = xaya::SHA256::Hash ("bar");
@@ -460,7 +499,11 @@ TEST_F (AbortChannelTests, DifferentName)
 TEST_F (AbortChannelTests, SuccessfulAbort)
 {
   const auto existing = xaya::SHA256::Hash ("existing channel");
-  tbl.CreateNew (existing);
+  auto h = tbl.CreateNew (existing);
+  xaya::proto::ChannelMetadata meta;
+  meta.add_participants ();
+  h->Reinitialise (meta, "");
+  h.reset ();
 
   const auto id1 = xaya::SHA256::Hash ("foo");
   const auto id2 = xaya::SHA256::Hash ("bar");
@@ -499,22 +542,26 @@ protected:
 
   CloseChannelTests ()
   {
+    xaya::proto::ChannelMetadata meta;
+    CHECK (TextFormat::ParseFromString (R"(
+      participants:
+        {
+          name: "name 0"
+          address: "addr 0"
+        }
+      participants:
+        {
+          name: "name 1"
+          address: "addr 1"
+        }
+    )", &meta));
+
     auto h = tbl.CreateNew (channelId);
-    auto* p = h->MutableMetadata ().add_participants ();
-    p->set_name ("name 0");
-    p->set_address ("addr 0");
-    p = h->MutableMetadata ().add_participants ();
-    p->set_name ("name 1");
-    p->set_address ("addr 1");
+    h->Reinitialise (meta, SerialisedState ("turn: 0"));
     h.reset ();
 
     h = tbl.CreateNew (otherId);
-    p = h->MutableMetadata ().add_participants ();
-    p->set_name ("name 0");
-    p->set_address ("addr 0");
-    p = h->MutableMetadata ().add_participants ();
-    p->set_name ("name 1");
-    p->set_address ("addr 1");
+    h->Reinitialise (meta, SerialisedState ("turn: 0"));
     h.reset ();
   }
 
@@ -651,7 +698,9 @@ TEST_F (CloseChannelTests, NonExistantChannel)
 TEST_F (CloseChannelTests, WrongNumberOfParticipants)
 {
   auto h = ExpectChannel (channelId);
-  h->MutableMetadata ().mutable_participants ()->RemoveLast ();
+  xaya::proto::ChannelMetadata meta = h->GetMetadata ();
+  meta.mutable_participants ()->RemoveLast ();
+  h->Reinitialise (meta, "");
   h.reset ();
 
   auto mv = CloseMove (xaya::proto::SignedData ());
@@ -710,18 +759,22 @@ protected:
   DisputeResolutionTests ()
   {
     auto h = tbl.CreateNew (channelId);
-    auto* p = h->MutableMetadata ().add_participants ();
-    p->set_name ("name 0");
-    p->set_address ("addr 0");
-    p = h->MutableMetadata ().add_participants ();
-    p->set_name ("name 1");
-    p->set_address ("addr 1");
 
-    proto::BoardState state;
-    state.set_turn (0);
-    std::string serialisedState;
-    CHECK (state.SerializeToString (&serialisedState));
-    h->SetState (serialisedState);
+    xaya::proto::ChannelMetadata meta;
+    CHECK (TextFormat::ParseFromString (R"(
+      participants:
+        {
+          name: "name 0"
+          address: "addr 0"
+        }
+      participants:
+        {
+          name: "name 1"
+          address: "addr 1"
+        }
+    )", &meta));
+
+    h->Reinitialise (meta, SerialisedState ("turn: 0"));
     h.reset ();
 
     Json::Value signatureOk(Json::objectValue);
@@ -752,12 +805,9 @@ protected:
   BuildMove (const std::string& key, const std::string& stateStr,
              const std::vector<std::string>& signatures)
   {
-    proto::BoardState state;
-    CHECK (TextFormat::ParseFromString (stateStr, &state));
-
     xaya::proto::StateProof proof;
     auto* is = proof.mutable_initial_state ();
-    CHECK (state.SerializeToString (is->mutable_data ()));
+    *is->mutable_data () = SerialisedState (stateStr);
     for (const auto& sgn : signatures)
       is->add_signatures (sgn);
 
@@ -841,7 +891,9 @@ TEST_F (DisputeResolutionTests, NonExistantChannel)
 TEST_F (DisputeResolutionTests, WrongNumberOfParticipants)
 {
   auto h = ExpectChannel (channelId);
-  h->MutableMetadata ().mutable_participants ()->RemoveLast ();
+  xaya::proto::ChannelMetadata meta = h->GetMetadata ();
+  meta.mutable_participants ()->RemoveLast ();
+  h->Reinitialise (meta, h->GetLatestState ());
   h.reset ();
 
   UpdateState (10, {BuildMove ("d", "turn: 1 winner: 0", {"sgn 0", "sgn 1"})});

--- a/ships/logic_tests.cpp
+++ b/ships/logic_tests.cpp
@@ -528,6 +528,8 @@ class CloseChannelTests : public StateUpdateTests
 
 protected:
 
+  xaya::proto::ChannelMetadata meta;
+
   /**
    * ID of the channel closed in tests (or not).  This channel is set up
    * with players "name 0" and "name 1".
@@ -542,7 +544,6 @@ protected:
 
   CloseChannelTests ()
   {
-    xaya::proto::ChannelMetadata meta;
     CHECK (TextFormat::ParseFromString (R"(
       participants:
         {
@@ -582,7 +583,8 @@ protected:
     CHECK (stmt.SerializeToString (&data));
 
     const std::string hashed
-        = xaya::GetChannelSignatureMessage (channelId, "winnerstatement", data);
+        = xaya::GetChannelSignatureMessage (channelId, meta,
+                                            "winnerstatement", data);
     EXPECT_CALL (mockXayaServer, verifymessage ("", hashed,
                                                 xaya::EncodeBase64 (sgn)))
         .WillOnce (Return (res));

--- a/xayagame/lmdbstorage.cpp
+++ b/xayagame/lmdbstorage.cpp
@@ -158,8 +158,7 @@ std::string
 KeyForUndoData (const uint256& hash)
 {
   std::string key(1, KEY_PREFIX_UNDO);
-  key.insert (1, reinterpret_cast<const char*> (hash.GetBlob ()),
-              uint256::NUM_BYTES);
+  key += hash.GetBinaryString ();
 
   return key;
 }

--- a/xayautil/uint256.cpp
+++ b/xayautil/uint256.cpp
@@ -79,6 +79,12 @@ uint256::FromBlob (const unsigned char* blob)
   std::copy (blob, blob + NUM_BYTES, data.data ());
 }
 
+std::string
+uint256::GetBinaryString () const
+{
+  return std::string (reinterpret_cast<const char*> (GetBlob ()), NUM_BYTES);
+}
+
 bool
 uint256::IsNull () const
 {

--- a/xayautil/uint256.hpp
+++ b/xayautil/uint256.hpp
@@ -68,6 +68,12 @@ public:
   void FromBlob (const unsigned char* blob);
 
   /**
+   * Returns a binary string representing this as raw bytes (i.e. GetBlob()
+   * as std::string).
+   */
+  std::string GetBinaryString () const;
+
+  /**
    * Checks if this number is all-zeros, which is used as "null" value.
    */
   bool IsNull () const;

--- a/xayautil/uint256_tests.cpp
+++ b/xayautil/uint256_tests.cpp
@@ -80,6 +80,19 @@ TEST (Uint256Tests, FromBlob)
   EXPECT_TRUE (obj == copy);
 }
 
+TEST (Uint256Tests, GetBinaryString)
+{
+  uint256 obj;
+  ASSERT_TRUE (obj.FromHex ("42" + std::string (60, '0') + "ff"));
+
+  const std::string str = obj.GetBinaryString ();
+  ASSERT_EQ (str.size (), 32);
+  EXPECT_EQ (str[0], static_cast<char> (0x42));
+  for (size_t i = 1; i < 31; ++i)
+    EXPECT_EQ (str[i], '\0');
+  EXPECT_EQ (str[31], static_cast<char> (0xff));
+}
+
 TEST (Uint256Tests, IsNull)
 {
   uint256 obj;


### PR DESCRIPTION
This implements the final design for #54:  Channels store not only a "latest" state, but also the full state proof for that latest state and the initial state of the last "reinitsialisation" on chain.  While this is a bit less efficient in some situations, it avoids a couple potential issues with respect to replay attacks, potential invalidation of state proofs (and cheating by it) and it allows for better handling in situations where e.g. some changes to a channel are reorged away.