### PR TITLE
Pass known block to waitforchange

### DIFF
--- a/mover/gametest/waitforchange.py
+++ b/mover/gametest/waitforchange.py
@@ -37,7 +37,11 @@ class ForChangeWaiter (threading.Thread):
 
   def run (self):
     rpc = self.node.createRpc ()
-    self.result = rpc.waitforchange ()
+    state = rpc.getcurrentstate ()
+    oldBlock = ""
+    if "blockhash" in state:
+      oldBlock = state["blockhash"]
+    self.result = rpc.waitforchange (oldBlock)
 
   def shouldBeRunning (self):
     sleepSome ()
@@ -63,7 +67,7 @@ class WaitForChangeTest (MoverTest):
     # best block and null is returned from the RPC.
 
   def test_attach (self):
-    self.log.info ("Testing block attaches...")
+    self.mainLogger.info ("Block attaches...")
 
     waiter = ForChangeWaiter (self.gamenode)
     waiter.shouldBeRunning ()
@@ -72,7 +76,7 @@ class WaitForChangeTest (MoverTest):
     waiter.shouldBeDone (self.rpc.xaya.getbestblockhash ())
 
   def test_detach (self):
-    self.log.info ("Testing block detaches...")
+    self.mainLogger.info ("Block detaches...")
 
     self.generate (1)
     blk = self.rpc.xaya.getbestblockhash ()
@@ -84,7 +88,7 @@ class WaitForChangeTest (MoverTest):
     waiter.shouldBeDone (self.rpc.xaya.getbestblockhash ())
 
   def test_stopped (self):
-    self.log.info ("Testing stopping the daemon while a waiter is active...")
+    self.mainLogger.info ("Stopping the daemon while a waiter is active...")
 
     waiter = ForChangeWaiter (self.gamenode)
     waiter.shouldBeRunning ()

--- a/xayagame/game.hpp
+++ b/xayagame/game.hpp
@@ -344,9 +344,15 @@ public:
    * RPC methods, e.g. for front-ends.  Note that this function may return
    * spuriously in situations when there is no new state.
    *
-   * If a non-null pointer is passed in, then the new current block is
-   * returned in it.  This is set to null if there is not yet any known
-   * state associated to a block (during initial sync).
+   * When oldBlock is non-null and does not match the best block at the time
+   * of entering WaitForChange, then the function returns immediately.  This
+   * can be used to prevent race conditions where a new state came in between
+   * the last return from WaitForChange and when a client finishes processing
+   * that change and calls again.
+   *
+   * The new new best block is returned after the detected change.  This is set
+   * to null if there is not yet any known state associated to a block
+   * (during initial sync).
    *
    * After this function returns, clients will likely want to check if the
    * new current state matches what they already have.  If not, they should
@@ -356,7 +362,7 @@ public:
    * Otherwise, it will simply return immediately, as there are no changes
    * expected anyway.
    */
-  void WaitForChange (uint256* currentBlock = nullptr) const;
+  void WaitForChange (const uint256& oldBlock, uint256& newBlock) const;
 
   /**
    * Starts the ZMQ subscriber and other logic.  Must not be called before

--- a/xayagame/gamerpcserver.cpp
+++ b/xayagame/gamerpcserver.cpp
@@ -24,19 +24,33 @@ GameRpcServer::getcurrentstate ()
 }
 
 Json::Value
-GameRpcServer::waitforchange ()
+GameRpcServer::waitforchange (const std::string& knownBlock)
 {
-  LOG (INFO) << "RPC method called: waitforchange";
+  LOG (INFO) << "RPC method called: waitforchange " << knownBlock;
+  return DefaultWaitForChange (game, knownBlock);
+}
 
-  uint256 block;
-  game.WaitForChange (&block);
+Json::Value
+GameRpcServer::DefaultWaitForChange (const Game& g,
+                                     const std::string& knownBlock)
+{
+  LOG (INFO) << "RPC method called: waitforchange " << knownBlock;
+
+  uint256 oldBlock;
+  oldBlock.SetNull ();
+  if (!knownBlock.empty () && !oldBlock.FromHex (knownBlock))
+    LOG (ERROR)
+        << "Invalid block hash passed as known block: " << knownBlock;
+
+  uint256 newBlock;
+  g.WaitForChange (oldBlock, newBlock);
 
   /* If there is no best block so far, return JSON null.  */
-  if (block.IsNull ())
+  if (newBlock.IsNull ())
     return Json::Value ();
 
   /* Otherwise, return the block hash.  */
-  return block.ToHex ();
+  return newBlock.ToHex ();
 }
 
 } // namespace xaya

--- a/xayagame/gamerpcserver.hpp
+++ b/xayagame/gamerpcserver.hpp
@@ -40,10 +40,16 @@ public:
   {}
 
   virtual void stop () override;
-
   virtual Json::Value getcurrentstate () override;
+  virtual Json::Value waitforchange (const std::string& knownBlock) override;
 
-  virtual Json::Value waitforchange () override;
+  /**
+   * Implements the standard waitforchange RPC method independent of a
+   * particular server instance.  This can be used by customised RPC servers
+   * of games that have more methods, so that the code can still be reused.
+   */
+  static Json::Value DefaultWaitForChange (const Game& g,
+                                           const std::string& knownBlock);
 
 };
 

--- a/xayagame/rpc-stubs/game.json
+++ b/xayagame/rpc-stubs/game.json
@@ -10,7 +10,7 @@
   },
   {
     "name": "waitforchange",
-    "params": {},
+    "params": [ "known block" ],
     "returns": {}
   }
 ]


### PR DESCRIPTION
This adds an argument to `waitforchange`, where the caller may pass the best known block to them.  Then, if the current state already is different from that, waitforchange will return immediately.

By making use of this feature, callers can avoid a potential race condition:  If they call `waitforchange` but then a change happens between the client processing the result and calling `waitforchange` again, previously the call would block until *another* change was made.  With this feature, clients can make sure they always get notified as soon as possible of any changes.

By passing an empty string for the new argument, callers can revert back to the old behaviour.