### PR TITLE
Create ChannelManager class for game channels

### DIFF
--- a/gamechannel/Makefile.am
+++ b/gamechannel/Makefile.am
@@ -43,6 +43,7 @@ gamechannel_HEADERS = \
   channelgame.hpp \
   database.hpp \
   gamestatejson.hpp \
+  movesender.hpp \
   protoboard.hpp protoboard.tpp \
   rollingstate.hpp \
   schema.hpp \

--- a/gamechannel/Makefile.am
+++ b/gamechannel/Makefile.am
@@ -31,6 +31,7 @@ libgamechannel_la_LIBADD = \
 libgamechannel_la_SOURCES = \
   boardrules.cpp \
   channelgame.cpp \
+  channelmanager.cpp \
   database.cpp \
   gamestatejson.cpp \
   rollingstate.cpp \
@@ -41,6 +42,7 @@ libgamechannel_la_SOURCES = \
 gamechannel_HEADERS = \
   boardrules.hpp \
   channelgame.hpp \
+  channelmanager.hpp \
   database.hpp \
   gamestatejson.hpp \
   movesender.hpp \
@@ -76,6 +78,7 @@ tests_LDADD = \
   $(GLOG_LIBS) $(GTEST_LIBS) $(SQLITE3_LIBS) $(PROTOBUF_LIBS)
 tests_SOURCES = \
   channelgame_tests.cpp \
+  channelmanager_tests.cpp \
   database_tests.cpp \
   gamestatejson_tests.cpp \
   protoboard_tests.cpp \

--- a/gamechannel/channelmanager.cpp
+++ b/gamechannel/channelmanager.cpp
@@ -1,0 +1,178 @@
+// Copyright (C) 2019 The Xaya developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "channelmanager.hpp"
+
+#include "stateproof.hpp"
+
+#include <glog/logging.h>
+
+namespace xaya
+{
+
+ChannelManager::ChannelManager (const BoardRules& r, XayaRpcClient& c,
+                                const uint256& id, const std::string& name)
+  : rules(r), rpc(c), channelId(id), playerName(name),
+    boardStates(rules, rpc, channelId)
+{}
+
+void
+ChannelManager::SetOffChainBroadcast (OffChainBroadcast& s)
+{
+  CHECK (offChainSender == nullptr);
+  offChainSender = &s;
+}
+
+void
+ChannelManager::SetMoveSender (MoveSender& s)
+{
+  CHECK (onChainSender == nullptr);
+  onChainSender = &s;
+}
+
+void
+ChannelManager::TryResolveDispute ()
+{
+  VLOG (1)
+      << "Trying to resolve a potential dispute for channel "
+      << channelId.ToHex ();
+
+  if (!exists)
+    {
+      VLOG (1) << "This channel does not exist on-chain";
+      return;
+    }
+  if (dispute == nullptr)
+    {
+      VLOG (1) << "There is no dispute for the channel";
+      return;
+    }
+  if (dispute->pendingResolution)
+    {
+      VLOG (1) << "There may be a pending resolution already";
+      return;
+    }
+
+  CHECK_NE (dispute->turn, ParsedBoardState::NO_TURN);
+  const auto& meta = boardStates.GetMetadata ();
+  CHECK_GE (dispute->turn, 0);
+  CHECK_LT (dispute->turn, meta.participants_size ());
+  const std::string& disputedPlayer = meta.participants (dispute->turn).name ();
+  if (disputedPlayer != playerName)
+    {
+      VLOG (1)
+          << "Disputed player is " << disputedPlayer
+          << ", we are " << playerName;
+      return;
+    }
+
+  const unsigned latestCnt = boardStates.GetLatestState ().TurnCount ();
+  if (latestCnt <= dispute->count)
+    {
+      VLOG (1)
+          << "We have no better state than the disputed turn count "
+          << dispute->count;
+      return;
+    }
+
+  LOG (INFO)
+      << "Channel " << channelId.ToHex ()
+      << " has a dispute for our turn, we have a better state"
+      << " at turn count " << latestCnt
+      << " (dispute: " << dispute->count << ")";
+  CHECK (onChainSender != nullptr);
+  onChainSender->SendResolution (boardStates.GetStateProof ());
+  dispute->pendingResolution = true;
+}
+
+void
+ChannelManager::ProcessOffChain (const std::string& reinitId,
+                                 const proto::StateProof& proof)
+{
+  std::lock_guard<std::mutex> lock(mut);
+
+  boardStates.UpdateWithMove (reinitId, proof);
+  TryResolveDispute ();
+}
+
+void
+ChannelManager::ProcessOnChainNonExistant ()
+{
+  LOG_IF (INFO, exists)
+      << "Channel " << channelId.ToHex () << " no longer exists on-chain";
+  std::lock_guard<std::mutex> lock(mut);
+
+  exists = false;
+}
+
+void
+ChannelManager::ProcessOnChain (const proto::ChannelMetadata& meta,
+                                const BoardState& reinitState,
+                                const proto::StateProof& proof,
+                                const unsigned disputeHeight)
+{
+  LOG_IF (INFO, !exists)
+      << "Channel " << channelId.ToHex () << " is now found on-chain";
+  std::lock_guard<std::mutex> lock(mut);
+
+  pendingDispute = false;
+  exists = true;
+  boardStates.UpdateOnChain (meta, reinitState, proof);
+
+  if (disputeHeight == 0)
+    {
+      LOG_IF (INFO, dispute != nullptr)
+          << "Dispute on channel " << channelId.ToHex () << " is resolved";
+      dispute.reset ();
+    }
+  else
+    {
+      if (dispute == nullptr)
+        {
+          LOG (INFO)
+              << "Channel " << channelId.ToHex ()
+              << " has now a dispute for height " << disputeHeight;
+          dispute = std::make_unique<DisputeData> ();
+        }
+
+      dispute->height = disputeHeight;
+      dispute->pendingResolution = false;
+
+      auto p = rules.ParseState (channelId, meta,
+                                 UnverifiedProofEndState (proof));
+      dispute->turn = p->WhoseTurn ();
+      dispute->count = p->TurnCount ();
+    }
+
+  TryResolveDispute ();
+}
+
+void
+ChannelManager::FileDispute ()
+{
+  LOG (INFO) << "Trying to file a dispute for channel " << channelId.ToHex ();
+  std::lock_guard<std::mutex> lock(mut);
+
+  if (!exists)
+    {
+      LOG (WARNING) << "The channel does not exist on chain";
+      return;
+    }
+  if (dispute != nullptr)
+    {
+      LOG (WARNING) << "There is already a dispute for the channel";
+      return;
+    }
+  if (pendingDispute)
+    {
+      LOG (WARNING) << "There may already be a pending dispute";
+      return;
+    }
+
+  CHECK (onChainSender != nullptr);
+  onChainSender->SendDispute (boardStates.GetStateProof ());
+  pendingDispute = true;
+}
+
+} // namespace xaya

--- a/gamechannel/channelmanager.hpp
+++ b/gamechannel/channelmanager.hpp
@@ -15,6 +15,8 @@
 #include <xayagame/rpc-stubs/xayawalletrpcclient.h>
 #include <xayautil/uint256.hpp>
 
+#include <json/json.h>
+
 #include <memory>
 #include <mutex>
 #include <string>
@@ -177,6 +179,12 @@ public:
    * Requests to file a dispute with the current state.
    */
   void FileDispute ();
+
+  /**
+   * Returns the current state of this channel as JSON, suitable to be
+   * sent to frontends.
+   */
+  Json::Value ToJson () const;
 
 };
 

--- a/gamechannel/channelmanager.hpp
+++ b/gamechannel/channelmanager.hpp
@@ -12,6 +12,7 @@
 #include "proto/stateproof.pb.h"
 
 #include <xayagame/rpc-stubs/xayarpcclient.h>
+#include <xayagame/rpc-stubs/xayawalletrpcclient.h>
 #include <xayautil/uint256.hpp>
 
 #include <memory>
@@ -80,6 +81,9 @@ private:
   /** RPC connection to Xaya Core used for verifying signatures.  */
   XayaRpcClient& rpc;
 
+  /** RPC connection to the Xaya wallet used for signing local moves.  */
+  XayaWalletRpcClient& wallet;
+
   /** The ID of the managed channel.  */
   const uint256 channelId;
 
@@ -131,7 +135,8 @@ private:
 
 public:
 
-  explicit ChannelManager (const BoardRules& r, XayaRpcClient& c,
+  explicit ChannelManager (const BoardRules& r,
+                           XayaRpcClient& c, XayaWalletRpcClient& w,
                            const uint256& id, const std::string& name);
 
   ChannelManager () = delete;
@@ -160,6 +165,13 @@ public:
                        const BoardState& reinitState,
                        const proto::StateProof& proof,
                        unsigned disputeHeight);
+
+  /**
+   * Processes a move made locally, i.e. by the player who runs the channel
+   * manager.  This tries to apply the move to the current state, sign the
+   * resulting state, build a new state proof, and then broadcast it.
+   */
+  void ProcessLocalMove (const BoardMove& mv);
 
   /**
    * Requests to file a dispute with the current state.

--- a/gamechannel/channelmanager.hpp
+++ b/gamechannel/channelmanager.hpp
@@ -1,0 +1,173 @@
+// Copyright (C) 2019 The Xaya developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef GAMECHANNEL_CHANNELMANAGER_HPP
+#define GAMECHANNEL_CHANNELMANAGER_HPP
+
+#include "boardrules.hpp"
+#include "movesender.hpp"
+#include "rollingstate.hpp"
+
+#include "proto/stateproof.pb.h"
+
+#include <xayagame/rpc-stubs/xayarpcclient.h>
+#include <xayautil/uint256.hpp>
+
+#include <memory>
+#include <mutex>
+#include <string>
+
+namespace xaya
+{
+
+/**
+ * The main logic for a channel daemon.  This class keeps track of the
+ * state (except for game-specific pieces of data, of course), including
+ * the actual board states known but also information about disputes.
+ * It updates the states as moves and on-chain updates come in, provides
+ * functions to query the state (used by the RPC server) and can request
+ * resolutions if disputes are filed against the player and a newer state
+ * is already known.
+ *
+ * This class performs locking as needed, and its functions (e.g. updates
+ * for on-chain and off-chain changes) may be freely called from different
+ * threads and in parallel.
+ */
+class ChannelManager
+{
+
+private:
+
+  /**
+   * Data stored about a potential dispute on the current channel.
+   */
+  struct DisputeData
+  {
+
+    /** The block height at which the dispute is filed.  */
+    unsigned height;
+
+    /** The player whose turn it is at the dispute.  */
+    int turn;
+
+    /** The turn count at which the disputed state is.  */
+    unsigned count;
+
+    /**
+     * True if we already tried to send a resolution for the last known
+     * on-chain block.
+     */
+    bool pendingResolution;
+
+    DisputeData () = default;
+    DisputeData (const DisputeData&) = default;
+    DisputeData& operator= (const DisputeData&) = default;
+
+  };
+
+  /**
+   * Mutex protecting the state in this class.  This is needed since there
+   * may be multiple threads calling functions on the ChannelManager (e.g.
+   * one thread listing to the GSP's waitforchange and another on the real-time
+   * broadcast network).
+   */
+  mutable std::mutex mut;
+
+  /** The board rules of the game being played.  */
+  const BoardRules& rules;
+
+  /** RPC connection to Xaya Core used for verifying signatures.  */
+  XayaRpcClient& rpc;
+
+  /** The ID of the managed channel.  */
+  const uint256 channelId;
+
+  /**
+   * The Xaya name that corresponds to the player that is using the
+   * current channel daemon.
+   */
+  const std::string playerName;
+
+  /** Data about the board states we know.  */
+  RollingState boardStates;
+
+  /**
+   * Broadcaster for off-chain moves.  This must be initialised before any
+   * functions are called that would trigger a broadcast.
+   */
+  OffChainBroadcast* offChainSender = nullptr;
+
+  /**
+   * Instance for sending on-chain moves (disputes / resolutions).  This must
+   * be set before any functions may be called that trigger such moves.
+   */
+  MoveSender* onChainSender = nullptr;
+
+  /**
+   * If set to false, it means that there is no on-chain data about the
+   * channel ID.  This may be the case because the channel creation has not
+   * been confirmed yet, or perhaps because the channel is already closed.
+   */
+  bool exists = false;
+
+  /** Data about an open dispute, if any.  */
+  std::unique_ptr<DisputeData> dispute;
+
+  /**
+   * Set to true if we already tried to file a pending dispute for the last
+   * known block height.
+   */
+  bool pendingDispute = false;
+
+  /**
+   * Tries to resolve the current dispute, if there is any.  This can be called
+   * whenever a change may have happened that affects this, like a new state
+   * being known (e.g. off-chain / local move) or an on-chain update.
+   */
+  void TryResolveDispute ();
+
+  friend class ChannelManagerTests;
+
+public:
+
+  explicit ChannelManager (const BoardRules& r, XayaRpcClient& c,
+                           const uint256& id, const std::string& name);
+
+  ChannelManager () = delete;
+  ChannelManager (const ChannelManager&) = delete;
+  void operator= (const ChannelManager&) = delete;
+
+  void SetOffChainBroadcast (OffChainBroadcast& s);
+  void SetMoveSender (MoveSender& s);
+
+  /**
+   * Processes a (potentially) new move retrieved through the off-chain
+   * broadcasting network.
+   */
+  void ProcessOffChain (const std::string& reinitId,
+                        const proto::StateProof& proof);
+
+  /**
+   * Processes an on-chain update that did not contain any data for our channel.
+   */
+  void ProcessOnChainNonExistant ();
+
+  /**
+   * Processes a (potentially) new on-chain state for the channel.
+   */
+  void ProcessOnChain (const proto::ChannelMetadata& meta,
+                       const BoardState& reinitState,
+                       const proto::StateProof& proof,
+                       unsigned disputeHeight);
+
+  /**
+   * Requests to file a dispute with the current state.
+   */
+  void FileDispute ();
+
+};
+
+} // namespace xaya
+
+#endif // GAMECHANNEL_CHANNELMANAGER_HPP

--- a/gamechannel/channelmanager_tests.cpp
+++ b/gamechannel/channelmanager_tests.cpp
@@ -1,0 +1,331 @@
+// Copyright (C) 2019 The Xaya developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "channelmanager.hpp"
+
+#include "stateproof.hpp"
+#include "testgame.hpp"
+
+#include <xayautil/hash.hpp>
+
+#include <google/protobuf/text_format.h>
+#include <google/protobuf/util/message_differencer.h>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <glog/logging.h>
+
+using google::protobuf::TextFormat;
+using google::protobuf::util::MessageDifferencer;
+using testing::_;
+using testing::Truly;
+
+namespace xaya
+{
+
+namespace
+{
+
+/**
+ * Constructs a state proof for the given state, signed by both players
+ * (and thus valid).
+ */
+proto::StateProof
+ValidProof (const std::string& state)
+{
+  proto::StateProof res;
+  auto* is = res.mutable_initial_state ();
+  is->set_data (state);
+  is->add_signatures ("sgn");
+  is->add_signatures ("other sgn");
+
+  return res;
+}
+
+class MockMoveSender : public MoveSender
+{
+
+public:
+
+  MockMoveSender ()
+  {
+    /* By default, we do not expect any calls.  Tests should explicitly
+       overwrite these expectations as needed.  */
+    EXPECT_CALL (*this, SendDispute (_)).Times (0);
+    EXPECT_CALL (*this, SendResolution (_)).Times (0);
+  }
+
+  MOCK_METHOD1 (SendDispute, void (const proto::StateProof& proof));
+  MOCK_METHOD1 (SendResolution, void (const proto::StateProof& proof));
+
+};
+
+} // anonymous namespace
+
+class ChannelManagerTests : public TestGameFixture
+{
+
+protected:
+
+  const uint256 channelId = SHA256::Hash ("channel id");
+  proto::ChannelMetadata meta;
+
+  ChannelManager cm;
+  MockMoveSender onChain;
+
+  ChannelManagerTests ()
+    : cm(game.rules, rpcClient, channelId, "player")
+  {
+    cm.SetMoveSender (onChain);
+
+    CHECK (TextFormat::ParseFromString (R"(
+      participants:
+        {
+          name: "player"
+          address: "my addr"
+        }
+      participants:
+        {
+          name: "other"
+          address: "not my addr"
+        }
+    )", &meta));
+
+    ValidSignature ("sgn", "my addr");
+    ValidSignature ("other sgn", "not my addr");
+  }
+
+  /**
+   * Extracts the latest state from boardStates.
+   */
+  BoardState
+  GetLatestState () const
+  {
+    return UnverifiedProofEndState (cm.boardStates.GetStateProof ());
+  }
+
+  /**
+   * Exposes the boardStates member of our ChannelManager to subtests.
+   */
+  const RollingState&
+  GetBoardStates () const
+  {
+    return cm.boardStates;
+  }
+
+  /**
+   * Exposes the exists member to subtests.
+   */
+  bool
+  GetExists () const
+  {
+    return cm.exists;
+  }
+
+  /**
+   * Exposes the dispute member to subtests.
+   */
+  const ChannelManager::DisputeData*
+  GetDispute () const
+  {
+    return cm.dispute.get ();
+  }
+
+  /**
+   * Expects exactly n calls to SendResolution to be made, with the state
+   * proof from GetBoardStates().
+   */
+  void
+  ExpectResolutions (const int n)
+  {
+    auto isOk = [this] (const proto::StateProof& p)
+      {
+        const auto& expected = GetBoardStates ().GetStateProof ();
+        return MessageDifferencer::Equals (p, expected);
+      };
+    EXPECT_CALL (onChain, SendResolution (Truly (isOk))).Times (n);
+  }
+
+};
+
+namespace
+{
+
+TEST_F (ChannelManagerTests, ProcessOnChainNonExistant)
+{
+  cm.ProcessOnChain (meta, "0 0", ValidProof ("10 5"), 0);
+  EXPECT_TRUE (GetExists ());
+
+  cm.ProcessOnChainNonExistant ();
+  EXPECT_FALSE (GetExists ());
+}
+
+/* ************************************************************************** */
+
+using ProcessOnChainTests = ChannelManagerTests;
+
+TEST_F (ProcessOnChainTests, Basic)
+{
+  cm.ProcessOnChain (meta, "0 0", ValidProof ("10 5"), 0);
+  EXPECT_TRUE (GetExists ());
+  EXPECT_EQ (GetLatestState (), "10 5");
+  EXPECT_EQ (GetDispute (), nullptr);
+}
+
+TEST_F (ProcessOnChainTests, Dispute)
+{
+  cm.ProcessOnChain (meta, "0 0", ValidProof ("11 5"), 10);
+  EXPECT_NE (GetDispute (), nullptr);
+  EXPECT_EQ (GetDispute ()->height, 10);
+  EXPECT_EQ (GetDispute ()->turn, 1);
+  EXPECT_EQ (GetDispute ()->count, 5);
+  EXPECT_EQ (GetDispute ()->pendingResolution, false);
+
+  cm.ProcessOnChain (meta, "0 0", ValidProof ("12 6"), 0);
+  EXPECT_EQ (GetDispute (), nullptr);
+}
+
+TEST_F (ProcessOnChainTests, TriggersResolutionn)
+{
+  ExpectResolutions (1);
+  cm.ProcessOnChain (meta, "0 0", ValidProof ("10 5"), 0);
+  cm.ProcessOffChain ("", ValidProof ("12 6"));
+  cm.ProcessOnChain (meta, "0 0", ValidProof ("10 5"), 1);
+}
+
+/* ************************************************************************** */
+
+using ProcessOffChainTests = ChannelManagerTests;
+
+TEST_F (ProcessOffChainTests, UpdatesState)
+{
+  cm.ProcessOnChain (meta, "0 0", ValidProof ("10 5"), 0);
+  cm.ProcessOffChain ("", ValidProof ("12 6"));
+  EXPECT_EQ (GetLatestState (), "12 6");
+}
+
+TEST_F (ProcessOffChainTests, TriggersResolutionn)
+{
+  ExpectResolutions (1);
+  cm.ProcessOnChain (meta, "0 0", ValidProof ("10 5"), 1);
+  cm.ProcessOffChain ("", ValidProof ("12 6"));
+}
+
+TEST_F (ProcessOffChainTests, WhenNotExists)
+{
+  cm.ProcessOnChain (meta, "0 0", ValidProof ("10 5"), 0);
+  cm.ProcessOnChainNonExistant ();
+  cm.ProcessOffChain ("", ValidProof ("20 10"));
+  cm.ProcessOnChain (meta, "0 0", ValidProof ("15 7"), 0);
+  EXPECT_EQ (GetLatestState (), "20 10");
+}
+
+/* ************************************************************************** */
+
+using ResolveDisputeTests = ChannelManagerTests;
+
+TEST_F (ResolveDisputeTests, SendsResolution)
+{
+  ExpectResolutions (1);
+  cm.ProcessOnChain (meta, "0 0", ValidProof ("10 5"), 1);
+  cm.ProcessOffChain ("", ValidProof ("12 6"));
+}
+
+TEST_F (ResolveDisputeTests, ChannelDoesNotExist)
+{
+  ExpectResolutions (0);
+  cm.ProcessOnChain (meta, "0 0", ValidProof ("10 5"), 1);
+  cm.ProcessOnChainNonExistant ();
+  cm.ProcessOffChain ("", ValidProof ("12 6"));
+}
+
+TEST_F (ResolveDisputeTests, AlreadyPending)
+{
+  ExpectResolutions (1);
+  cm.ProcessOnChain (meta, "0 0", ValidProof ("10 5"), 1);
+  cm.ProcessOffChain ("", ValidProof ("12 6"));
+  cm.ProcessOffChain ("", ValidProof ("14 8"));
+}
+
+TEST_F (ResolveDisputeTests, OtherPlayer)
+{
+  ExpectResolutions (0);
+  cm.ProcessOnChain (meta, "0 0", ValidProof ("11 5"), 1);
+  cm.ProcessOffChain ("", ValidProof ("12 6"));
+}
+
+TEST_F (ResolveDisputeTests, NoBetterTurn)
+{
+  ExpectResolutions (0);
+  cm.ProcessOnChain (meta, "0 0", ValidProof ("10 5"), 1);
+  cm.ProcessOffChain ("", ValidProof ("12 5"));
+}
+
+/* ************************************************************************** */
+
+class FileDisputeTests : public ChannelManagerTests
+{
+
+protected:
+
+  /**
+   * Expects exactly n calls to SendDispute to be made, with the state
+   * proof from GetBoardStates().
+   */
+  void
+  ExpectDisputes (const int n)
+  {
+    auto isOk = [this] (const proto::StateProof& p)
+      {
+        const auto& expected = GetBoardStates ().GetStateProof ();
+        return MessageDifferencer::Equals (p, expected);
+      };
+    EXPECT_CALL (onChain, SendDispute (Truly (isOk))).Times (n);
+  }
+
+};
+
+TEST_F (FileDisputeTests, Successful)
+{
+  ExpectDisputes (1);
+  cm.ProcessOnChain (meta, "0 0", ValidProof ("10 5"), 0);
+  cm.FileDispute ();
+}
+
+TEST_F (FileDisputeTests, ChannelDoesNotExist)
+{
+  ExpectDisputes (0);
+  cm.ProcessOnChainNonExistant ();
+  cm.FileDispute ();
+}
+
+TEST_F (FileDisputeTests, HasOtherDispute)
+{
+  ExpectDisputes (0);
+  cm.ProcessOnChain (meta, "0 0", ValidProof ("10 5"), 10);
+  cm.FileDispute ();
+}
+
+TEST_F (FileDisputeTests, AlreadyPending)
+{
+  ExpectDisputes (1);
+  cm.ProcessOnChain (meta, "0 0", ValidProof ("10 5"), 0);
+  cm.FileDispute ();
+  cm.FileDispute ();
+}
+
+TEST_F (FileDisputeTests, RetryAfterBlock)
+{
+  ExpectDisputes (2);
+  cm.ProcessOnChain (meta, "0 0", ValidProof ("10 5"), 0);
+  cm.FileDispute ();
+  cm.ProcessOnChain (meta, "0 0", ValidProof ("10 5"), 0);
+  cm.FileDispute ();
+}
+
+/* ************************************************************************** */
+
+} // anonymous namespace
+} // namespace xaya

--- a/gamechannel/gamestatejson.hpp
+++ b/gamechannel/gamestatejson.hpp
@@ -7,11 +7,26 @@
 
 #include "boardrules.hpp"
 #include "database.hpp"
+#include "proto/metadata.pb.h"
+
+#include <xayautil/uint256.hpp>
 
 #include <json/json.h>
 
 namespace xaya
 {
+
+/**
+ * Encodes a metadata proto into JSON.
+ */
+Json::Value ChannelMetadataToJson (const proto::ChannelMetadata& meta);
+
+/**
+ * Encodes a given state as JSON.
+ */
+Json::Value BoardStateToJson (const BoardRules& r, const uint256& channelId,
+                              const proto::ChannelMetadata& meta,
+                              const BoardState& state);
 
 /**
  * Converts the game-state data for a given channel into JSON format.

--- a/gamechannel/gamestatejson_tests.cpp
+++ b/gamechannel/gamestatejson_tests.cpp
@@ -27,17 +27,6 @@ namespace xaya
 namespace
 {
 
-Json::Value
-ParseJson (const std::string& str)
-{
-  std::istringstream in(str);
-  Json::Value res;
-  in >> res;
-  CHECK (in);
-
-  return res;
-}
-
 /**
  * Checks if the given actual game-state JSON for a channel matches the
  * expected one, taking into account potential differences in protocol buffer

--- a/gamechannel/movesender.hpp
+++ b/gamechannel/movesender.hpp
@@ -1,0 +1,77 @@
+// Copyright (C) 2019 The Xaya developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef GAMECHANNEL_MOVESENDER_HPP
+#define GAMECHANNEL_MOVESENDER_HPP
+
+#include "proto/stateproof.pb.h"
+
+#include <string>
+
+namespace xaya
+{
+
+/**
+ * Interface for a class that allows broadcasting moves / state-proofs
+ * off-chain to the channel participants.  This is implemented by the
+ * real-time implementations and mocked for testing.
+ *
+ * Functions of the interface may be called by different threads, but it is
+ * guaranteed that only one thread at a time is accessing the instance.
+ */
+class OffChainBroadcast
+{
+
+protected:
+
+  OffChainBroadcast () = default;
+
+public:
+
+  virtual ~OffChainBroadcast () = default;
+
+  /**
+   * Sends a new state (presumably after the player made a move) to all
+   * channel participants.
+   */
+  virtual void SendNewState (const std::string& reinitId,
+                             const proto::StateProof& proof) = 0;
+
+};
+
+/**
+ * Interface for sending on-chain moves (resolutions / disputes).  This is
+ * used by the ChannelManager.  The main implementation for this interface
+ * uses a Xaya Core RPC connection with name_update, but it is also mocked
+ * for unit tests.
+ *
+ * Functions of the interface may be called by different threads, but it is
+ * guaranteed that only one thread at a time is accessing the instance.
+ */
+class MoveSender
+{
+
+protected:
+
+  MoveSender () = default;
+
+public:
+
+  virtual ~MoveSender () = default;
+
+  /**
+   * Sends a dispute based on the given state proof.
+   */
+  virtual void SendDispute (const proto::StateProof& proof) = 0;
+
+  /**
+   * Sends a resolution based on the given state proof.
+   */
+  virtual void SendResolution (const proto::StateProof& proof) = 0;
+
+};
+
+} // namespace xaya
+
+#endif // GAMECHANNEL_MOVESENDER_HPP

--- a/gamechannel/rollingstate.cpp
+++ b/gamechannel/rollingstate.cpp
@@ -42,6 +42,15 @@ RollingState::GetReinitId () const
   return reinitId;
 }
 
+const proto::ChannelMetadata&
+RollingState::GetMetadata () const
+{
+  CHECK (!reinits.empty ()) << "RollingState has not been initialised yet";
+  const auto mit = reinits.find (reinitId);
+  CHECK (mit != reinits.end ());
+  return mit->second.meta;
+}
+
 void
 RollingState::UpdateOnChain (const proto::ChannelMetadata& meta,
                              const BoardState& reinitState,

--- a/gamechannel/rollingstate.hpp
+++ b/gamechannel/rollingstate.hpp
@@ -65,7 +65,7 @@ private:
   };
 
   /** Board rules to use for our game.  */
-  BoardRules& rules;
+  const BoardRules& rules;
 
   /** RPC client for signature verification.  */
   XayaRpcClient& rpc;
@@ -85,7 +85,8 @@ private:
 
 public:
 
-  explicit RollingState (BoardRules& r, XayaRpcClient& c, const uint256& id)
+  explicit RollingState (const BoardRules& r, XayaRpcClient& c,
+                         const uint256& id)
     : rules(r), rpc(c), channelId(id)
   {}
 
@@ -108,6 +109,12 @@ public:
    * latest state (as returned by GetLatestState and GetStateProof) is.
    */
   const std::string& GetReinitId () const;
+
+  /**
+   * Returns the channel metadata corresponding to the currently best
+   * reinitId.
+   */
+  const proto::ChannelMetadata& GetMetadata () const;
 
   /**
    * Updates the state for a newly received on-chain update.  This assumes

--- a/gamechannel/stateproof.hpp
+++ b/gamechannel/stateproof.hpp
@@ -11,6 +11,7 @@
 #include "proto/stateproof.pb.h"
 
 #include <xayagame/rpc-stubs/xayarpcclient.h>
+#include <xayagame/rpc-stubs/xayawalletrpcclient.h>
 #include <xayautil/uint256.hpp>
 
 namespace xaya
@@ -48,6 +49,25 @@ bool VerifyStateProof (XayaRpcClient& rpc, const BoardRules& rules,
  * efficient than VerifyStateProof.
  */
 const BoardState& UnverifiedProofEndState (const proto::StateProof& proof);
+
+/**
+ * Tries to apply the given move onto the latest state of the given proof,
+ * updating the proof for the new state if possible (signing it through
+ * the given wallet connection).
+ *
+ * The state proof must be known to be valid already (e.g. because it is
+ * the on-chain state from the GSP, or because it has been validated previously
+ * already).
+ *
+ * Returns true if the state proof was extended successfully.
+ */
+bool ExtendStateProof (XayaRpcClient& rpc, XayaWalletRpcClient& wallet,
+                       const BoardRules& rules,
+                       const uint256& channelId,
+                       const proto::ChannelMetadata& meta,
+                       const proto::StateProof& oldProof,
+                       const BoardMove& mv,
+                       proto::StateProof& newProof);
 
 } // namespace xaya
 

--- a/gamechannel/testgame.cpp
+++ b/gamechannel/testgame.cpp
@@ -171,8 +171,12 @@ TestGame::GetBoardRules () const
 TestGameFixture::TestGameFixture ()
   : httpServer(MockXayaRpcServer::HTTP_PORT),
     httpClient(MockXayaRpcServer::HTTP_URL),
+    httpServerWallet(MockXayaWalletRpcServer::HTTP_PORT),
+    httpClientWallet(MockXayaWalletRpcServer::HTTP_URL),
     mockXayaServer(httpServer),
-    rpcClient(httpClient)
+    rpcClient(httpClient),
+    mockXayaWallet(httpServerWallet),
+    rpcWallet(httpClientWallet)
 {
   game.Initialise (":memory:");
   game.InitialiseGameContext (Chain::MAIN, "add", &rpcClient);
@@ -180,11 +184,13 @@ TestGameFixture::TestGameFixture ()
   /* The initialisation above already sets up the database schema.  */
 
   mockXayaServer.StartListening ();
+  mockXayaWallet.StartListening ();
 }
 
 TestGameFixture::~TestGameFixture ()
 {
   mockXayaServer.StopListening ();
+  mockXayaWallet.StopListening ();
 }
 
 sqlite3*

--- a/gamechannel/testgame.hpp
+++ b/gamechannel/testgame.hpp
@@ -10,6 +10,7 @@
 
 #include <xayagame/testutils.hpp>
 #include <xayagame/rpc-stubs/xayarpcclient.h>
+#include <xayagame/rpc-stubs/xayawalletrpcclient.h>
 #include <xayautil/uint256.hpp>
 
 #include <jsonrpccpp/client/connectors/httpclient.h>
@@ -93,10 +94,16 @@ private:
   jsonrpc::HttpServer httpServer;
   jsonrpc::HttpClient httpClient;
 
+  jsonrpc::HttpServer httpServerWallet;
+  jsonrpc::HttpClient httpClientWallet;
+
 protected:
 
   MockXayaRpcServer mockXayaServer;
   XayaRpcClient rpcClient;
+
+  MockXayaWalletRpcServer mockXayaWallet;
+  XayaWalletRpcClient rpcWallet;
 
   TestGame game;
 


### PR DESCRIPTION
This creates the `ChannelManager` class, which handles the main tasks of a channel daemon (as described in #57).  This is very similar to `Game` for on-chain GSPs, although the structure is a bit different (external updates will be fed into the `ChannelManager` through separate objects and are not contained in the class already like the ZMQ subscriber is in `Game`).