### PR TITLE
Implement gsp-to-channel update logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,5 +29,7 @@ Makefile.in
 *.pb.cc
 *_pb2.py
 
+*/rpc-stubs/*.h
+
 .dirstamp
 tests

--- a/gamechannel/Makefile.am
+++ b/gamechannel/Makefile.am
@@ -1,8 +1,13 @@
 lib_LTLIBRARIES = libgamechannel.la
 gamechanneldir = $(includedir)/gamechannel
+rpcstubdir = $(gamechanneldir)/rpc-stubs
 protodir = $(gamechanneldir)/proto
 pydir = $(pythondir)/gamechannel
 pyprotodir = $(pydir)/proto
+
+RPC_STUBS = \
+  rpc-stubs/channelgsprpcclient.h \
+  rpc-stubs/channelgsprpcserverstub.h
 
 PROTOS = \
   proto/metadata.proto \
@@ -14,10 +19,11 @@ PROTOSOURCES = $(PROTOS:.proto=.pb.cc)
 PROTOPY = $(PROTOS:.proto=_pb2.py)
 
 EXTRA_DIST = $(PROTOS) \
+  rpc-stubs/gsp.json \
   schema.sql schema_head.cpp schema_tail.cpp
 
-BUILT_SOURCES = $(PROTOHEADERS) $(PROTOPY)
-CLEANFILES = $(PROTOHEADERS) $(PROTOSOURCES) $(PROTOPY) schema.cpp
+BUILT_SOURCES = $(RPC_STUBS) $(PROTOHEADERS) $(PROTOPY)
+CLEANFILES = $(RPC_STUBS) $(PROTOHEADERS) $(PROTOSOURCES) $(PROTOPY) schema.cpp
 
 libgamechannel_la_CXXFLAGS = \
   -I$(top_srcdir) \
@@ -34,6 +40,7 @@ libgamechannel_la_SOURCES = \
   channelmanager.cpp \
   database.cpp \
   gamestatejson.cpp \
+  gsprpc.cpp \
   rollingstate.cpp \
   schema.cpp \
   signatures.cpp \
@@ -45,12 +52,14 @@ gamechannel_HEADERS = \
   channelmanager.hpp \
   database.hpp \
   gamestatejson.hpp \
+  gsprpc.hpp \
   movesender.hpp \
   protoboard.hpp protoboard.tpp \
   rollingstate.hpp \
   schema.hpp \
   signatures.hpp \
   stateproof.hpp
+rpcstub_HEADERS = $(RPC_STUBS)
 proto_HEADERS = $(PROTOHEADERS)
 
 PYTHONTESTS = \
@@ -94,6 +103,13 @@ check_HEADERS = \
 
 schema.cpp: schema_head.cpp schema.sql schema_tail.cpp
 	cat $^ >$@
+
+rpc-stubs/channelgsprpcclient.h: $(srcdir)/rpc-stubs/gsp.json
+	jsonrpcstub "$<" --cpp-client=ChannelGspRpcClient --cpp-client-file="$@"
+rpc-stubs/channelgsprpcserverstub.h: $(srcdir)/rpc-stubs/gsp.json
+	jsonrpcstub "$<" \
+	  --cpp-server=ChannelGspRpcServerStub \
+	  --cpp-server-file="$@"
 
 proto/%.pb.h proto/%.pb.cc: $(top_srcdir)/gamechannel/proto/%.proto
 	protoc -I$(top_srcdir) --cpp_out=$(top_builddir) "$<"

--- a/gamechannel/Makefile.am
+++ b/gamechannel/Makefile.am
@@ -38,6 +38,7 @@ libgamechannel_la_SOURCES = \
   boardrules.cpp \
   channelgame.cpp \
   channelmanager.cpp \
+  chaintochannel.cpp \
   database.cpp \
   gamestatejson.cpp \
   gsprpc.cpp \
@@ -50,6 +51,7 @@ gamechannel_HEADERS = \
   boardrules.hpp \
   channelgame.hpp \
   channelmanager.hpp \
+  chaintochannel.hpp \
   database.hpp \
   gamestatejson.hpp \
   gsprpc.hpp \
@@ -88,6 +90,7 @@ tests_LDADD = \
 tests_SOURCES = \
   channelgame_tests.cpp \
   channelmanager_tests.cpp \
+  chaintochannel_tests.cpp \
   database_tests.cpp \
   gamestatejson_tests.cpp \
   protoboard_tests.cpp \

--- a/gamechannel/chaintochannel.cpp
+++ b/gamechannel/chaintochannel.cpp
@@ -1,0 +1,182 @@
+// Copyright (C) 2018 The Xaya developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "chaintochannel.hpp"
+
+#include "proto/metadata.pb.h"
+#include "proto/stateproof.pb.h"
+
+#include <xayautil/base64.hpp>
+
+#include <jsonrpccpp/common/errors.h>
+#include <jsonrpccpp/common/exception.h>
+
+#include <glog/logging.h>
+
+namespace xaya
+{
+
+ChainToChannelFeeder::ChainToChannelFeeder (jsonrpc::IClientConnector& conn,
+                                            ChannelManager& cm)
+  : rpc(conn), manager(cm)
+{
+  lastBlock.SetNull ();
+}
+
+ChainToChannelFeeder::~ChainToChannelFeeder ()
+{
+  Stop ();
+  CHECK (loop == nullptr);
+}
+
+namespace
+{
+
+/**
+ * Decodes a JSON value (which must be a base64-encoded string) into a
+ * protocol buffer instance of the given type.
+ */
+template <typename Proto>
+  Proto
+  DecodeProto (const Json::Value& val)
+{
+  CHECK (val.isString ());
+
+  std::string bytes;
+  CHECK (DecodeBase64 (val.asString (), bytes));
+
+  Proto res;
+  CHECK (res.ParseFromString (bytes));
+
+  return res;
+}
+
+} // anonymous namespace
+
+void
+ChainToChannelFeeder::UpdateOnce ()
+{
+  const std::string channelIdHex = manager.GetChannelId ().ToHex ();
+  const auto data = rpc.getchannel (channelIdHex);
+
+  if (data["state"] != "up-to-date")
+    {
+      LOG (WARNING)
+          << "Channel GSP is in state " << data["state"]
+          << ", not updating channel";
+      return;
+    }
+
+  const auto& newBlockVal = data["blockhash"];
+  if (newBlockVal.isNull ())
+    {
+      /* This will typically not happen, since we already check the return
+         value of waitforchange.  But there are two situations where we could
+         get here:  On the initial update, and (very unlikely) if the
+         existing state gets detached between the waitforchange call and when
+         we call getchannel.  */
+      LOG (WARNING) << "GSP has no current state yet";
+      return;
+    }
+
+  CHECK (newBlockVal.isString ());
+  CHECK (lastBlock.FromHex (newBlockVal.asString ()));
+  LOG (INFO) << "New on-chain best block: " << lastBlock.ToHex ();
+
+  const auto& channel = data["channel"];
+  if (channel.isNull ())
+    {
+      LOG (INFO) << "Channel " << channelIdHex << " is not known on-chain";
+      manager.ProcessOnChainNonExistant ();
+      return;
+    }
+  CHECK (channel.isObject ());
+
+  CHECK_EQ (channel["id"].asString (), channelIdHex);
+  const auto meta
+      = DecodeProto<proto::ChannelMetadata> (channel["meta"]["proto"]);
+  const auto proof = DecodeProto<proto::StateProof> (channel["state"]["proof"]);
+
+  BoardState reinitState;
+  CHECK (DecodeBase64 (channel["reinit"]["base64"].asString (), reinitState));
+
+  unsigned disputeHeight = 0;
+  const auto& disputeVal = channel["disputeheight"];
+  if (!disputeVal.isNull ())
+    {
+      CHECK (disputeVal.isUInt ());
+      disputeHeight = disputeVal.asUInt ();
+    }
+
+  manager.ProcessOnChain (meta, reinitState, proof, disputeHeight);
+  LOG (INFO) << "Updated channel from on-chain state: " << channelIdHex;
+}
+
+void
+ChainToChannelFeeder::RunLoop ()
+{
+  UpdateOnce ();
+
+  while (!stopLoop)
+    {
+      const std::string lastBlockHex = lastBlock.ToHex ();
+
+      std::string newBlockHex;
+      try
+        {
+          newBlockHex = rpc.waitforchange (lastBlockHex);
+        }
+      catch (const jsonrpc::JsonRpcException& exc)
+        {
+          /* Especially timeouts are fine, we should just ignore them.
+             A relatively small timeout is needed in order to not block
+             too long when waiting for shutting down the loop.  */
+          VLOG (1) << "Error calling waitforchange: " << exc.what ();
+          CHECK_EQ (exc.GetCode (), jsonrpc::Errors::ERROR_CLIENT_CONNECTOR);
+          continue;
+        }
+
+      if (newBlockHex.empty ())
+        {
+          VLOG (1) << "GSP does not have any state yet";
+          continue;
+        }
+
+      if (newBlockHex == lastBlockHex)
+        {
+          VLOG (1) << "We are already at newest block";
+          continue;
+        }
+
+      UpdateOnce ();
+    }
+}
+
+void
+ChainToChannelFeeder::Start ()
+{
+  LOG (INFO) << "Starting chain-to-channel feeder loop...";
+  CHECK (loop == nullptr) << "Feeder loop is already running";
+
+  stopLoop = false;
+  loop = std::make_unique<std::thread> ([this] ()
+    {
+      RunLoop ();
+    });
+}
+
+void
+ChainToChannelFeeder::Stop ()
+{
+  if (loop == nullptr)
+    return;
+
+  LOG (INFO) << "Stopping chain-to-channel feeder loop...";
+
+  stopLoop = true;
+  loop->join ();
+  loop.reset ();
+}
+
+} // namespace xaya

--- a/gamechannel/chaintochannel.hpp
+++ b/gamechannel/chaintochannel.hpp
@@ -1,0 +1,94 @@
+// Copyright (C) 2018 The Xaya developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef GAMECHANNEL_CHAINTOCHANNEL_HPP
+#define GAMECHANNEL_CHAINTOCHANNEL_HPP
+
+#include "channelmanager.hpp"
+
+#include "rpc-stubs/channelgsprpcclient.h"
+
+#include <jsonrpccpp/client/client.h>
+
+#include <memory>
+#include <atomic>
+#include <thread>
+
+namespace xaya
+{
+
+/**
+ * Instances of this class connect to a channel-game GSP by RPC and feed
+ * updates received for a particular channel to a local ChannelManager.
+ * This is done through a separate thread that just calls waitforchange
+ * and getchannel in a loop.
+ */
+class ChainToChannelFeeder
+{
+
+private:
+
+  /**
+   * The RPC connection to the GSP.  This is opened in the constructor based
+   * on a passed-in IClientConnector.
+   */
+  ChannelGspRpcClient rpc;
+
+  /** The ChannelManager that is updated.  */
+  ChannelManager& manager;
+
+  /** The running thread (if any).  */
+  std::unique_ptr<std::thread> loop;
+
+  /** Atomic flag telling the running thread to stop.  */
+  std::atomic<bool> stopLoop;
+
+  /**
+   * The last block hash to which we updated the channel manager.  This is
+   * only accessed from the loop thread (and the constructor).
+   */
+  uint256 lastBlock;
+
+  /**
+   * Queries the GSP for the current state and updates the ChannelManager
+   * and lastBlock from the result.
+   */
+  void UpdateOnce ();
+
+  /**
+   * Runs the main loop.  This is the function executed by the loop
+   * thread when started.
+   */
+  void RunLoop ();
+
+public:
+
+  explicit ChainToChannelFeeder (jsonrpc::IClientConnector& conn,
+                                 ChannelManager& cm);
+
+  ~ChainToChannelFeeder ();
+
+  ChainToChannelFeeder () = delete;
+  ChainToChannelFeeder (const ChainToChannelFeeder&) = delete;
+  void operator= (const ChainToChannelFeeder&) = delete;
+
+  /**
+   * Starts the main loop in a separate thread.
+   */
+  void Start ();
+
+  /**
+   * Stops the main loop.  This is automatically called in the destructor
+   * if the loop is still running then.
+   *
+   * Note that this has to wait for the current waitforchange call to return,
+   * which may require it to time out.
+   */
+  void Stop ();
+
+};
+
+} // namespace xaya
+
+#endif // GAMECHANNEL_CHAINTOCHANNEL_HPP

--- a/gamechannel/chaintochannel_tests.cpp
+++ b/gamechannel/chaintochannel_tests.cpp
@@ -1,0 +1,467 @@
+// Copyright (C) 2019 The Xaya developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "chaintochannel.hpp"
+
+#include "database.hpp"
+#include "gamestatejson.hpp"
+#include "stateproof.hpp"
+#include "testgame.hpp"
+
+#include "rpc-stubs/channelgsprpcserverstub.h"
+
+#include <xayautil/hash.hpp>
+
+#include <jsonrpccpp/common/exception.h>
+#include <jsonrpccpp/client/connectors/httpclient.h>
+#include <jsonrpccpp/server.h>
+#include <jsonrpccpp/server/connectors/httpserver.h>
+
+#include <google/protobuf/text_format.h>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <glog/logging.h>
+
+#include <chrono>
+#include <condition_variable>
+#include <mutex>
+#include <thread>
+
+using google::protobuf::TextFormat;
+
+namespace xaya
+{
+
+namespace
+{
+
+/** Timeout (in milliseconds) for the test GSP connection.  */
+constexpr int RPC_TIMEOUT_MS = 50;
+
+/**
+ * Constructs a state proof for the given state, signed by both players
+ * (and thus valid).
+ */
+proto::StateProof
+ValidProof (const std::string& state)
+{
+  proto::StateProof res;
+  auto* is = res.mutable_initial_state ();
+  is->set_data (state);
+  is->add_signatures ("sgn");
+  is->add_signatures ("other sgn");
+
+  return res;
+}
+
+/**
+ * GSP RPC server for use in the tests.  It allows to set a current
+ * state that is returned from getchannel, and it allows signalling
+ * waitforchange waiters.
+ *
+ * It knows the test channel's ID and loads data for it from the
+ * underlying SQLite database as needed.  So to change the data
+ * returned for getchannel, update the database.
+ */
+class TestGspServer : public ChannelGspRpcServerStub
+{
+
+private:
+
+  const uint256& channelId;
+  const proto::ChannelMetadata& meta;
+
+  TestGame& game;
+  ChannelsTable tbl;
+
+  std::string gspState;
+  uint256 bestBlockHash;
+
+  /* Mutex and condition variable for the faked waitforchange.  */
+  std::mutex mut;
+  std::condition_variable cv;
+
+public:
+
+  explicit TestGspServer (const uint256& id, const proto::ChannelMetadata& m,
+                          TestGame& g,
+                          jsonrpc::AbstractServerConnector& conn)
+    : ChannelGspRpcServerStub(conn), channelId(id), meta(m),
+      game(g), tbl(game)
+  {
+    EXPECT_CALL (*this, stop ()).Times (0);
+    EXPECT_CALL (*this, getcurrentstate ()).Times (0);
+  }
+
+  /**
+   * Marks the current state as having no game state in the GSP yet.
+   */
+  void
+  SetNoState (const std::string& state)
+  {
+    std::lock_guard<std::mutex> lock(mut);
+    gspState = state;
+    bestBlockHash.SetNull ();
+  }
+
+  /**
+   * Sets the current state to be returned (but does not signal
+   * waiting threads).  The block hash is computed by hashing the
+   * given string for convenience.
+   */
+  void
+  SetState (const std::string& bestBlkPreimage,
+            const std::string& state,
+            const BoardState& reinitState,
+            const proto::StateProof& proof,
+            const unsigned disputeHeight)
+  {
+    std::lock_guard<std::mutex> lock(mut);
+
+    gspState = state;
+    bestBlockHash = SHA256::Hash (bestBlkPreimage);
+
+    tbl.DeleteById (channelId);
+
+    auto h = tbl.CreateNew (channelId);
+    h->Reinitialise (meta, reinitState);
+    h->SetStateProof (proof);
+    if (disputeHeight != 0)
+      h->SetDisputeHeight (disputeHeight);
+  }
+
+  /**
+   * Sets the current state to be that the test channel does not exist.
+   */
+  void
+  SetChannelNotOnChain (const std::string& bestBlkPreimage,
+                        const std::string& state)
+  {
+    std::lock_guard<std::mutex> lock(mut);
+
+    gspState = state;
+    bestBlockHash = SHA256::Hash (bestBlkPreimage);
+
+    tbl.DeleteById (channelId);
+  }
+
+  /**
+   * Notifies all waiting threads of a change.
+   */
+  void
+  NotifyChange ()
+  {
+    std::lock_guard<std::mutex> lock(mut);
+    cv.notify_all ();
+  }
+
+  Json::Value
+  getchannel (const std::string& channelIdHex) override
+  {
+    LOG (INFO) << "RPC call: getchannel " << channelIdHex;
+    std::lock_guard<std::mutex> lock(mut);
+
+    Json::Value res(Json::objectValue);
+    res["state"] = gspState;
+    if (bestBlockHash.IsNull ())
+      return res;
+    res["blockhash"] = bestBlockHash.ToHex ();
+
+    uint256 reqId;
+    CHECK (reqId.FromHex (channelIdHex));
+
+    auto h = tbl.GetById (reqId);
+    if (h == nullptr)
+      res["channel"] = Json::Value ();
+    else
+      res["channel"] = ChannelToGameStateJson (*h, game.rules);
+
+    return res;
+  }
+
+  std::string
+  waitforchange (const std::string& knownBlock) override
+  {
+    LOG (INFO) << "RPC call: waitforchange " << knownBlock;
+    std::unique_lock<std::mutex> lock(mut);
+
+    cv.wait (lock);
+
+    if (bestBlockHash.IsNull ())
+      return "";
+
+    return bestBlockHash.ToHex ();
+  }
+
+  MOCK_METHOD0 (stop, void ());
+  MOCK_METHOD0 (getcurrentstate, Json::Value ());
+
+};
+
+} // anonymous namespace
+
+class ChainToChannelFeederTests : public TestGameFixture
+{
+
+private:
+
+  const uint256 channelId = SHA256::Hash ("channel id");
+
+  jsonrpc::HttpServer httpServerGsp;
+  jsonrpc::HttpClient httpClientGsp;
+
+protected:
+
+  proto::ChannelMetadata meta;
+
+  ChannelManager cm;
+  ChainToChannelFeeder feeder;
+  TestGspServer gspServer;
+
+  ChainToChannelFeederTests ()
+    : httpServerGsp(32200),
+      httpClientGsp("http://localhost:32200"),
+      cm(game.rules, rpcClient, rpcWallet, channelId, "player"),
+      feeder(httpClientGsp, cm),
+      gspServer(channelId, meta, game, httpServerGsp)
+  {
+    httpClientGsp.SetTimeout (RPC_TIMEOUT_MS);
+
+    CHECK (TextFormat::ParseFromString (R"(
+      reinit: "reinit id"
+      participants:
+        {
+          name: "player"
+          address: "my addr"
+        }
+      participants:
+        {
+          name: "other"
+          address: "not my addr"
+        }
+    )", &meta));
+
+    ValidSignature ("sgn", "my addr");
+    ValidSignature ("other sgn", "not my addr");
+
+    gspServer.StartListening ();
+  }
+
+  ~ChainToChannelFeederTests ()
+  {
+    /* Shut down the waiting loop gracefully and wake up any waiting
+       threads so we can stop.  */
+    feeder.Stop ();
+    gspServer.NotifyChange ();
+
+    cm.StopUpdates ();
+    gspServer.StopListening ();
+  }
+
+  /**
+   * Extracts the latest state from boardStates.
+   */
+  BoardState
+  GetLatestState () const
+  {
+    return UnverifiedProofEndState (cm.boardStates.GetStateProof ());
+  }
+
+  /**
+   * Exposes the boardStates member of our ChannelManager to subtests.
+   */
+  const RollingState&
+  GetBoardStates () const
+  {
+    return cm.boardStates;
+  }
+
+  /**
+   * Exposes the exists member to subtests.
+   */
+  bool
+  GetExists () const
+  {
+    return cm.exists;
+  }
+
+  /**
+   * Exposes the dispute height to subtests.  Returns 0 if there is no dispute.
+   */
+  unsigned
+  GetDisputeHeight () const
+  {
+    if (cm.dispute == nullptr)
+      return 0;
+    return cm.dispute->height;
+  }
+
+};
+
+namespace
+{
+
+/* ************************************************************************** */
+
+using UpdateDataTests = ChainToChannelFeederTests;
+
+TEST_F (UpdateDataTests, NotUpToDate)
+{
+  cm.ProcessOnChain (meta, "0 0", ValidProof ("10 5"), 0);
+  gspServer.SetState ("blk", "catching-up", "0 0", ValidProof ("20 6"), 0);
+  feeder.Start ();
+
+  SleepSome ();
+  EXPECT_EQ (GetLatestState (), "10 5");
+}
+
+TEST_F (UpdateDataTests, NoGspState)
+{
+  cm.ProcessOnChain (meta, "0 0", ValidProof ("10 5"), 0);
+  gspServer.SetNoState ("up-to-date");
+  feeder.Start ();
+
+  SleepSome ();
+  EXPECT_EQ (GetLatestState (), "10 5");
+}
+
+TEST_F (UpdateDataTests, ChannelNotOnChain)
+{
+  cm.ProcessOnChain (meta, "0 0", ValidProof ("10 5"), 0);
+  gspServer.SetChannelNotOnChain ("blk", "up-to-date");
+  feeder.Start ();
+
+  SleepSome ();
+  EXPECT_FALSE (GetExists ());
+}
+
+TEST_F (UpdateDataTests, UpdatesProof)
+{
+  cm.ProcessOnChain (meta, "0 0", ValidProof ("10 5"), 0);
+  gspServer.SetState ("blk", "up-to-date", "0 0", ValidProof ("20 6"), 0);
+  feeder.Start ();
+
+  SleepSome ();
+  EXPECT_EQ (GetLatestState (), "20 6");
+}
+
+TEST_F (UpdateDataTests, Reinitialisation)
+{
+  cm.ProcessOnChain (meta, "0 0", ValidProof ("10 5"), 0);
+
+  meta.set_reinit ("other reinit");
+  proto::StateProof reinitBasedProof;
+  CHECK (TextFormat::ParseFromString (R"(
+    initial_state: { data: "42 10" }
+    transitions:
+      {
+        move: "1"
+        new_state:
+          {
+            data: "43 11"
+            signatures: "sgn"
+          }
+      }
+  )", &reinitBasedProof));
+
+  gspServer.SetState ("blk", "up-to-date", "42 10", reinitBasedProof, 0);
+  feeder.Start ();
+
+  SleepSome ();
+  EXPECT_EQ (GetLatestState (), "43 11");
+  EXPECT_EQ (GetBoardStates ().GetReinitId (), "other reinit");
+}
+
+TEST_F (UpdateDataTests, NoDispute)
+{
+  cm.ProcessOnChain (meta, "0 0", ValidProof ("10 5"), 0);
+  gspServer.SetState ("blk", "up-to-date", "0 0", ValidProof ("20 6"), 0);
+  feeder.Start ();
+
+  SleepSome ();
+  EXPECT_EQ (GetDisputeHeight (), 0);
+}
+
+TEST_F (UpdateDataTests, WithDispute)
+{
+  cm.ProcessOnChain (meta, "0 0", ValidProof ("10 5"), 0);
+  gspServer.SetState ("blk", "up-to-date", "0 0", ValidProof ("20 6"), 42);
+  feeder.Start ();
+
+  SleepSome ();
+  EXPECT_EQ (GetDisputeHeight (), 42);
+}
+
+/* ************************************************************************** */
+
+class WaitForChangeLoopTests : public ChainToChannelFeederTests
+{
+
+protected:
+
+  WaitForChangeLoopTests ()
+  {
+    gspServer.SetState ("start", "up-to-date", "0 0", ValidProof ("0 0"), 0);
+    feeder.Start ();
+    SleepSome ();
+  }
+
+};
+
+TEST_F (WaitForChangeLoopTests, UpdateLoopRuns)
+{
+  gspServer.SetState ("blk 1", "up-to-date", "0 0", ValidProof ("10 5"), 0);
+
+  SleepSome ();
+  EXPECT_EQ (GetLatestState (), "0 0");
+
+  gspServer.NotifyChange ();
+  SleepSome ();
+  EXPECT_EQ (GetLatestState (), "10 5");
+
+  gspServer.SetState ("blk 2", "up-to-date", "0 0", ValidProof ("20 6"), 0);
+  gspServer.NotifyChange ();
+  SleepSome ();
+  EXPECT_EQ (GetLatestState (), "20 6");
+}
+
+TEST_F (WaitForChangeLoopTests, NoGspState)
+{
+  gspServer.SetNoState ("up-to-date");
+  gspServer.NotifyChange ();
+  SleepSome ();
+  EXPECT_EQ (GetLatestState (), "0 0");
+}
+
+TEST_F (WaitForChangeLoopTests, NoChangeInBlock)
+{
+  gspServer.SetState ("blk", "up-to-date", "0 0", ValidProof ("10 5"), 0);
+  gspServer.NotifyChange ();
+  SleepSome ();
+  EXPECT_EQ (GetLatestState (), "10 5");
+
+  gspServer.SetState ("blk", "up-to-date", "0 0", ValidProof ("20 6"), 0);
+  gspServer.NotifyChange ();
+  SleepSome ();
+  EXPECT_EQ (GetLatestState (), "10 5");
+}
+
+TEST_F (WaitForChangeLoopTests, TimeoutsGetRepeated)
+{
+  gspServer.SetState ("blk", "up-to-date", "0 0", ValidProof ("10 5"), 0);
+
+  std::this_thread::sleep_for (std::chrono::milliseconds (2 * RPC_TIMEOUT_MS));
+  EXPECT_EQ (GetLatestState (), "0 0");
+
+  gspServer.NotifyChange ();
+  SleepSome ();
+  EXPECT_EQ (GetLatestState (), "10 5");
+}
+
+/* ************************************************************************** */
+
+} // anonymous namespace
+} // namespace xaya

--- a/gamechannel/channelgame.hpp
+++ b/gamechannel/channelgame.hpp
@@ -69,6 +69,7 @@ protected:
   virtual const BoardRules& GetBoardRules () const = 0;
 
   friend class ChannelData;
+  friend class ChannelGspRpcServer;
   friend class ChannelsTable;
 
 public:

--- a/gamechannel/channelmanager.hpp
+++ b/gamechannel/channelmanager.hpp
@@ -174,6 +174,7 @@ private:
   void NotifyStateChange ();
 
   friend class ChannelManagerTests;
+  friend class ChainToChannelFeederTests;
 
 public:
 
@@ -195,6 +196,12 @@ public:
 
   void SetOffChainBroadcast (OffChainBroadcast& s);
   void SetMoveSender (MoveSender& s);
+
+  const uint256&
+  GetChannelId () const
+  {
+    return channelId;
+  }
 
   /**
    * Processes a (potentially) new move retrieved through the off-chain

--- a/gamechannel/gsprpc.cpp
+++ b/gamechannel/gsprpc.cpp
@@ -40,7 +40,7 @@ ChannelGspRpcServer::getchannel (const std::string& channelId)
   return DefaultGetChannel (game, chGame, channelId);
 }
 
-Json::Value
+std::string
 ChannelGspRpcServer::waitforchange (const std::string& knownBlock)
 {
   LOG (INFO) << "RPC method called: waitforchange " << knownBlock;

--- a/gamechannel/gsprpc.cpp
+++ b/gamechannel/gsprpc.cpp
@@ -1,0 +1,84 @@
+// Copyright (C) 2018 The Xaya developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "gsprpc.hpp"
+
+#include "database.hpp"
+#include "gamestatejson.hpp"
+
+#include <xayagame/gamerpcserver.hpp>
+
+#include <glog/logging.h>
+
+#include <jsonrpccpp/common/errors.h>
+#include <jsonrpccpp/common/exception.h>
+
+#include <sqlite3.h>
+
+namespace xaya
+{
+
+void
+ChannelGspRpcServer::stop ()
+{
+  LOG (INFO) << "RPC method called: stop";
+  game.RequestStop ();
+}
+
+Json::Value
+ChannelGspRpcServer::getcurrentstate ()
+{
+  LOG (INFO) << "RPC method called: getcurrentstate";
+  return game.GetCurrentJsonState ();
+}
+
+Json::Value
+ChannelGspRpcServer::getchannel (const std::string& channelId)
+{
+  LOG (INFO) << "RPC method called: getchannel " << channelId;
+  return DefaultGetChannel (game, chGame, channelId);
+}
+
+Json::Value
+ChannelGspRpcServer::waitforchange (const std::string& knownBlock)
+{
+  LOG (INFO) << "RPC method called: waitforchange " << knownBlock;
+  return GameRpcServer::DefaultWaitForChange (game, knownBlock);
+}
+
+Json::Value
+ChannelGspRpcServer::DefaultGetChannel (const Game& g, ChannelGame& chg,
+                                        const std::string& channelId)
+{
+  uint256 id;
+  if (!id.FromHex (channelId))
+    throw jsonrpc::JsonRpcException (jsonrpc::Errors::ERROR_RPC_INVALID_PARAMS,
+                                     "channel ID is not a valid uint256");
+
+  return chg.GetCustomStateData (g, "channel",
+    [&chg, &id] (sqlite3* db)
+      {
+        ChannelsTable tbl(chg);
+        auto h = tbl.GetById (id);
+
+        if (h == nullptr)
+          {
+            LOG (WARNING) << "Channel is not known: " << id.ToHex ();
+            return Json::Value ();
+          }
+
+        return ChannelToGameStateJson (*h, chg.GetBoardRules ());
+      });
+}
+
+std::unique_ptr<RpcServerInterface>
+ChannelGspInstanceFactory::BuildRpcServer (
+    Game& game, jsonrpc::AbstractServerConnector& conn)
+{
+  std::unique_ptr<RpcServerInterface> res;
+  res.reset (new WrappedRpcServer<ChannelGspRpcServer> (game, chGame, conn));
+  return res;
+}
+
+} // namespace xaya

--- a/gamechannel/gsprpc.hpp
+++ b/gamechannel/gsprpc.hpp
@@ -45,7 +45,7 @@ public:
   virtual void stop () override;
   virtual Json::Value getcurrentstate () override;
   virtual Json::Value getchannel (const std::string& channelId) override;
-  virtual Json::Value waitforchange (const std::string& knownBlock) override;
+  virtual std::string waitforchange (const std::string& knownBlock) override;
 
   /**
    * Implements the standard getchannel method.  This can be used by

--- a/gamechannel/gsprpc.hpp
+++ b/gamechannel/gsprpc.hpp
@@ -1,0 +1,88 @@
+// Copyright (C) 2018 The Xaya developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef GAMECHANNEL_GSPRPC_HPP
+#define GAMECHANNEL_GSPRPC_HPP
+
+#include "channelgame.hpp"
+
+#include "rpc-stubs/channelgsprpcserverstub.h"
+
+#include <xayagame/defaultmain.hpp>
+#include <xayagame/game.hpp>
+
+#include <json/json.h>
+#include <jsonrpccpp/server.h>
+
+namespace xaya
+{
+
+/**
+ * Implementation of a simple RPC server for game channel GSPs.  This extends
+ * the GameRpcServer for general GSPs by the "getchannel" method, which extracts
+ * data about a single channel by ID.  This method is used by the channel
+ * daemon to query states.
+ */
+class ChannelGspRpcServer : public ChannelGspRpcServerStub
+{
+
+private:
+
+  /** The game instance whose methods we expose through RPC.  */
+  Game& game;
+
+  /** The ChannelGame that manages the database.  */
+  ChannelGame& chGame;
+
+public:
+
+  explicit ChannelGspRpcServer (Game& g, ChannelGame& chg,
+                                jsonrpc::AbstractServerConnector& conn)
+    : ChannelGspRpcServerStub(conn), game(g), chGame(chg)
+  {}
+
+  virtual void stop () override;
+  virtual Json::Value getcurrentstate () override;
+  virtual Json::Value getchannel (const std::string& channelId) override;
+  virtual Json::Value waitforchange (const std::string& knownBlock) override;
+
+  /**
+   * Implements the standard getchannel method.  This can be used by
+   * games that have an extended RPC server for their GSPs but want to
+   * provide the standard getchannel.
+   */
+  static Json::Value DefaultGetChannel (const Game& g, ChannelGame& chg,
+                                        const std::string& channelId);
+
+};
+
+/**
+ * Customised instance factory for a channel GSP DefaultMain that uses the
+ * ChannelGspRpcServer.
+ */
+class ChannelGspInstanceFactory : public CustomisedInstanceFactory
+{
+
+private:
+
+  /**
+   * Reference to the ChannelGame instance, which is needed for the RPC server
+   * construction.
+   */
+  ChannelGame& chGame;
+
+public:
+
+  explicit ChannelGspInstanceFactory (ChannelGame& chg)
+    : chGame(chg)
+  {}
+
+  std::unique_ptr<RpcServerInterface> BuildRpcServer (
+      Game& game, jsonrpc::AbstractServerConnector& conn) override;
+
+};
+
+} // namespace xaya
+
+#endif // GAMECHANNEL_GSPRPC_HPP

--- a/gamechannel/rpc-stubs/gsp.json
+++ b/gamechannel/rpc-stubs/gsp.json
@@ -1,0 +1,21 @@
+[
+  {
+    "name": "stop",
+    "params": {}
+  },
+  {
+    "name": "getcurrentstate",
+    "params": {},
+    "returns": {}
+  },
+  {
+    "name": "getchannel",
+    "params": [ "channel id" ],
+    "returns": {}
+  },
+  {
+    "name": "waitforchange",
+    "params": [ "known block" ],
+    "returns": {}
+  }
+]

--- a/gamechannel/rpc-stubs/gsp.json
+++ b/gamechannel/rpc-stubs/gsp.json
@@ -16,6 +16,6 @@
   {
     "name": "waitforchange",
     "params": [ "known block" ],
-    "returns": {}
+    "returns": ""
   }
 ]

--- a/ships/gametest/Makefile.am
+++ b/ships/gametest/Makefile.am
@@ -6,6 +6,7 @@ TEST_LIBRARY = shipstest.py
 REGTESTS = \
   channel_management.py \
   disputes.py \
+  getchannel.py \
   reorg.py \
   winner_statement.py
 

--- a/ships/gametest/getchannel.py
+++ b/ships/gametest/getchannel.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python
+# Copyright (C) 2019 The Xaya developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+from shipstest import ShipsTest
+
+"""
+Tests the getchannel RPC method of the (generic) channel GSP RPC server.
+"""
+
+
+class GetChannelTest (ShipsTest):
+
+  def run (self):
+    self.generate (110)
+    self.expectGameState ({
+      "gamestats": {},
+      "channels": {},
+    })
+
+    # Create a test channel and join it.
+    self.mainLogger.info ("Creating test channel...")
+    addr1 = self.rpc.xaya.getnewaddress ()
+    channelId = self.sendMove ("foo", {"c": {"addr": addr1}})
+    self.generate (1)
+    addr2 = self.rpc.xaya.getnewaddress ()
+    self.sendMove ("bar", {"j": {"id": channelId, "addr": addr2}})
+    self.generate (1)
+
+    # Verify the channel using getcurrentstate.
+    self.mainLogger.info ("Verifying channel data...")
+    state = self.getGameState ()
+    self.assertEqual (state["gamestats"], {})
+    channels = state["channels"]
+    self.assertEqual (len (channels), 1)
+
+    assert channelId in channels
+    ch = channels[channelId]
+    self.assertEqual (ch["meta"]["participants"], [
+      {"name": "foo", "address": addr1},
+      {"name": "bar", "address": addr2},
+    ])
+    self.assertEqual (ch["state"]["parsed"]["phase"], "first commitment")
+
+    # Verify what we get with getchannel.
+    self.mainLogger.info ("getchannel for our test channel...")
+    data = self.getCustomState ("channel", "getchannel", channelId)
+    self.assertEqual (data, ch)
+
+    # Error cases for getchannel.
+    self.mainLogger.info ("getchannel for non-existant channel...")
+    nonExistantId = "aa" * 32
+    data = self.getCustomState ("channel", "getchannel", "aa" * 32)
+    self.assertEqual (data, None)
+
+    self.mainLogger.info ("getchannel with invalid hex string...")
+    self.expectError (-32602, ".*not a valid uint256",
+                      self.getCustomState,
+                      "channel", "getchannel", "invalid id")
+
+
+if __name__ == "__main__":
+  GetChannelTest ().main ()

--- a/ships/main.cpp
+++ b/ships/main.cpp
@@ -6,6 +6,7 @@
 
 #include "logic.hpp"
 
+#include <gamechannel/gsprpc.hpp>
 #include <xayagame/defaultmain.hpp>
 
 #include <gflags/gflags.h>
@@ -70,8 +71,10 @@ main (int argc, char** argv)
   config.DataDirectory = FLAGS_datadir;
 
   ships::ShipsLogic rules;
-  const int res = xaya::SQLiteMain (config, "xs", rules);
+  xaya::ChannelGspInstanceFactory instanceFact(rules);
+  config.InstanceFactory = &instanceFact;
 
+  const int res = xaya::SQLiteMain (config, "xs", rules);
   google::protobuf::ShutdownProtobufLibrary ();
   return res;
 }

--- a/xayagame/gamerpcserver.cpp
+++ b/xayagame/gamerpcserver.cpp
@@ -34,8 +34,6 @@ Json::Value
 GameRpcServer::DefaultWaitForChange (const Game& g,
                                      const std::string& knownBlock)
 {
-  LOG (INFO) << "RPC method called: waitforchange " << knownBlock;
-
   uint256 oldBlock;
   oldBlock.SetNull ();
   if (!knownBlock.empty () && !oldBlock.FromHex (knownBlock))

--- a/xayagame/gamerpcserver.cpp
+++ b/xayagame/gamerpcserver.cpp
@@ -23,14 +23,14 @@ GameRpcServer::getcurrentstate ()
   return game.GetCurrentJsonState ();
 }
 
-Json::Value
+std::string
 GameRpcServer::waitforchange (const std::string& knownBlock)
 {
   LOG (INFO) << "RPC method called: waitforchange " << knownBlock;
   return DefaultWaitForChange (game, knownBlock);
 }
 
-Json::Value
+std::string
 GameRpcServer::DefaultWaitForChange (const Game& g,
                                      const std::string& knownBlock)
 {
@@ -45,7 +45,7 @@ GameRpcServer::DefaultWaitForChange (const Game& g,
 
   /* If there is no best block so far, return JSON null.  */
   if (newBlock.IsNull ())
-    return Json::Value ();
+    return "";
 
   /* Otherwise, return the block hash.  */
   return newBlock.ToHex ();

--- a/xayagame/gamerpcserver.hpp
+++ b/xayagame/gamerpcserver.hpp
@@ -41,14 +41,14 @@ public:
 
   virtual void stop () override;
   virtual Json::Value getcurrentstate () override;
-  virtual Json::Value waitforchange (const std::string& knownBlock) override;
+  virtual std::string waitforchange (const std::string& knownBlock) override;
 
   /**
    * Implements the standard waitforchange RPC method independent of a
    * particular server instance.  This can be used by customised RPC servers
    * of games that have more methods, so that the code can still be reused.
    */
-  static Json::Value DefaultWaitForChange (const Game& g,
+  static std::string DefaultWaitForChange (const Game& g,
                                            const std::string& knownBlock);
 
 };

--- a/xayagame/rpc-stubs/.gitignore
+++ b/xayagame/rpc-stubs/.gitignore
@@ -1,2 +1,0 @@
-*rpcclient.h
-*rpcserverstub.h

--- a/xayagame/rpc-stubs/game.json
+++ b/xayagame/rpc-stubs/game.json
@@ -11,6 +11,6 @@
   {
     "name": "waitforchange",
     "params": [ "known block" ],
-    "returns": {}
+    "returns": ""
   }
 ]


### PR DESCRIPTION
This implements the logic to feed updates from an on-chain GSP (via `waitforchange` and a new `getchannel `RPC method) onto a `ChannelManager` instance (#58).