### PR TITLE
Real implementation for MoveSender

### DIFF
--- a/gamechannel/Makefile.am
+++ b/gamechannel/Makefile.am
@@ -42,6 +42,7 @@ libgamechannel_la_SOURCES = \
   database.cpp \
   gamestatejson.cpp \
   gsprpc.cpp \
+  movesender.cpp \
   rollingstate.cpp \
   schema.cpp \
   signatures.cpp \
@@ -56,6 +57,7 @@ gamechannel_HEADERS = \
   gamestatejson.hpp \
   gsprpc.hpp \
   movesender.hpp \
+  openchannel.hpp \
   protoboard.hpp protoboard.tpp \
   protoutils.hpp protoutils.tpp \
   rollingstate.hpp \
@@ -94,6 +96,7 @@ tests_SOURCES = \
   chaintochannel_tests.cpp \
   database_tests.cpp \
   gamestatejson_tests.cpp \
+  movesender_tests.cpp \
   protoboard_tests.cpp \
   protoutils_tests.cpp \
   rollingstate_tests.cpp \

--- a/gamechannel/Makefile.am
+++ b/gamechannel/Makefile.am
@@ -57,6 +57,7 @@ gamechannel_HEADERS = \
   gsprpc.hpp \
   movesender.hpp \
   protoboard.hpp protoboard.tpp \
+  protoutils.hpp protoutils.tpp \
   rollingstate.hpp \
   schema.hpp \
   signatures.hpp \
@@ -94,6 +95,7 @@ tests_SOURCES = \
   database_tests.cpp \
   gamestatejson_tests.cpp \
   protoboard_tests.cpp \
+  protoutils_tests.cpp \
   rollingstate_tests.cpp \
   schema_tests.cpp \
   signatures_tests.cpp \

--- a/gamechannel/chaintochannel.cpp
+++ b/gamechannel/chaintochannel.cpp
@@ -4,6 +4,8 @@
 
 #include "chaintochannel.hpp"
 
+#include "protoutils.hpp"
+
 #include "proto/metadata.pb.h"
 #include "proto/stateproof.pb.h"
 
@@ -43,11 +45,8 @@ template <typename Proto>
 {
   CHECK (val.isString ());
 
-  std::string bytes;
-  CHECK (DecodeBase64 (val.asString (), bytes));
-
   Proto res;
-  CHECK (res.ParseFromString (bytes));
+  CHECK (ProtoFromBase64 (val.asString (), res));
 
   return res;
 }

--- a/gamechannel/channelmanager.hpp
+++ b/gamechannel/channelmanager.hpp
@@ -101,7 +101,7 @@ private:
 
   /**
    * The Xaya name that corresponds to the player that is using the
-   * current channel daemon.
+   * current channel daemon (without p/ prefix).
    */
   const std::string playerName;
 

--- a/gamechannel/gamestatejson.cpp
+++ b/gamechannel/gamestatejson.cpp
@@ -1,5 +1,7 @@
 #include "gamestatejson.hpp"
 
+#include "protoutils.hpp"
+
 #include <xayautil/base64.hpp>
 
 #include <glog/logging.h>
@@ -8,23 +10,6 @@
 
 namespace xaya
 {
-
-namespace
-{
-
-/**
- * Encodes a protocol buffer as base64 string.
- */
-template <typename Proto>
-  std::string
-  EncodeProto (const Proto& msg)
-{
-  std::string serialised;
-  CHECK (msg.SerializeToString (&serialised));
-  return EncodeBase64 (serialised);
-}
-
-} // anonymous namespace
 
 Json::Value
 ChannelMetadataToJson (const proto::ChannelMetadata& meta)
@@ -42,7 +27,7 @@ ChannelMetadataToJson (const proto::ChannelMetadata& meta)
   res["participants"] = participants;
 
   res["reinit"] = EncodeBase64 (meta.reinit ());
-  res["proto"] = EncodeProto (meta);
+  res["proto"] = ProtoToBase64 (meta);
 
   return res;
 }
@@ -86,7 +71,7 @@ ChannelToGameStateJson (const ChannelData& ch, const BoardRules& r)
   res["meta"] = ChannelMetadataToJson (meta);
 
   res["state"] = BoardStateToJson (r, id, meta, ch.GetLatestState ());
-  res["state"]["proof"] = EncodeProto (ch.GetStateProof ());
+  res["state"]["proof"] = ProtoToBase64 (ch.GetStateProof ());
   res["reinit"] = BoardStateToJson (r, id, meta, ch.GetReinitState ());
 
   return res;

--- a/gamechannel/gamestatejson_tests.cpp
+++ b/gamechannel/gamestatejson_tests.cpp
@@ -4,6 +4,7 @@
 
 #include "gamestatejson.hpp"
 
+#include "protoutils.hpp"
 #include "testgame.hpp"
 
 #include <xayautil/base64.hpp>
@@ -54,10 +55,8 @@ CheckChannelJson (Json::Value actual, const std::string& expected,
   ASSERT_EQ (actual["state"]["base64"].asString (), EncodeBase64 (proofState));
   actual["state"].removeMember ("base64");
 
-  std::string bytes;
-  ASSERT_TRUE (DecodeBase64 (actual["state"]["proof"].asString (), bytes));
   proto::StateProof proof;
-  ASSERT_TRUE (proof.ParseFromString (bytes));
+  ASSERT_TRUE (ProtoFromBase64 (actual["state"]["proof"].asString (), proof));
   ASSERT_EQ (proof.initial_state ().data (), proofState);
   actual["state"].removeMember ("proof");
 
@@ -127,10 +126,8 @@ TEST_F (GameStateJsonTests, ChannelMetadataToJson)
   ASSERT_EQ (actual["reinit"], EncodeBase64 (meta2.reinit ()));
   actual.removeMember ("reinit");
 
-  std::string bytes;
-  ASSERT_TRUE (DecodeBase64 (actual["proto"].asString (), bytes));
   proto::ChannelMetadata actualMeta;
-  ASSERT_TRUE (actualMeta.ParseFromString (bytes));
+  ASSERT_TRUE (ProtoFromBase64 (actual["proto"].asString (), actualMeta));
   ASSERT_TRUE (MessageDifferencer::Equals (actualMeta, meta2));
   actual.removeMember ("proto");
 

--- a/gamechannel/movesender.cpp
+++ b/gamechannel/movesender.cpp
@@ -1,0 +1,64 @@
+// Copyright (C) 2019 The Xaya developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "movesender.hpp"
+
+#include <jsonrpccpp/common/exception.h>
+
+#include <glog/logging.h>
+
+namespace xaya
+{
+
+MoveSender::MoveSender (const std::string& gId,
+                        const uint256& chId, const std::string& nm,
+                        XayaWalletRpcClient& w, OpenChannel& oc)
+  : rpc(w), game(oc), channelId(chId), playerName("p/" + nm), gameId(gId)
+{
+  jsonWriterBuilder["commentStyle"] = "None";
+  jsonWriterBuilder["indentation"] = "";
+  jsonWriterBuilder["enableYAMLCompatibility"] = false;
+}
+
+uint256
+MoveSender::SendMove (const Json::Value& mv)
+{
+  Json::Value fullValue(Json::objectValue);
+  fullValue["g"][gameId] = mv;
+
+  const std::string strValue = Json::writeString (jsonWriterBuilder, fullValue);
+  uint256 res;
+  try
+    {
+      LOG (INFO)
+          << "Sending move: name_update " << playerName
+          << "\n" << strValue;
+
+      const std::string txidHex = rpc.name_update (playerName, strValue);
+      LOG (INFO) << "Success, name txid = " << txidHex;
+
+      CHECK (res.FromHex (txidHex));
+    }
+  catch (const jsonrpc::JsonRpcException& exc)
+    {
+      LOG (ERROR) << "name_update failed: " << exc.what ();
+      res.SetNull ();
+    }
+
+  return res;
+}
+
+void
+MoveSender::SendDispute (const proto::StateProof& proof)
+{
+  SendMove (game.DisputeMove (channelId, proof));
+}
+
+void
+MoveSender::SendResolution (const proto::StateProof& proof)
+{
+  SendMove (game.ResolutionMove (channelId, proof));
+}
+
+} // namespace xaya

--- a/gamechannel/movesender.hpp
+++ b/gamechannel/movesender.hpp
@@ -5,7 +5,13 @@
 #ifndef GAMECHANNEL_MOVESENDER_HPP
 #define GAMECHANNEL_MOVESENDER_HPP
 
+#include "openchannel.hpp"
 #include "proto/stateproof.pb.h"
+
+#include <xayagame/rpc-stubs/xayawalletrpcclient.h>
+#include <xayautil/uint256.hpp>
+
+#include <json/writer.h>
 
 #include <string>
 
@@ -41,34 +47,72 @@ public:
 };
 
 /**
- * Interface for sending on-chain moves (resolutions / disputes).  This is
- * used by the ChannelManager.  The main implementation for this interface
- * uses a Xaya Core RPC connection with name_update, but it is also mocked
- * for unit tests.
+ * A connection to the Xaya wallet that allows sending moves (mainly
+ * disputes and resolutions from ChannelManager, but also game-specific code
+ * may use it e.g. for winner statements).  They are sent by name_update's
+ * to a given player name.
  *
- * Functions of the interface may be called by different threads, but it is
- * guaranteed that only one thread at a time is accessing the instance.
+ * The actual format for dispute and resolution moves is game-dependent,
+ * and construction of the moves is done through the game's implementation
+ * of OpenChannel.
  */
 class MoveSender
 {
 
-protected:
+private:
 
-  MoveSender () = default;
+  /** Xaya wallet RPC that we use.  */
+  XayaWalletRpcClient& rpc;
+
+  /** OpenChannel instance for building moves.  */
+  OpenChannel& game;
+
+  /** ID of the game channel this is for.  */
+  const uint256 channelId;
+
+  /** The Xaya name that should be updated (including p/).  */
+  const std::string playerName;
+
+  /** The game ID for constructing moves.  */
+  const std::string gameId;
+
+  /**
+   * Builder for JSON serialisation, with the options configured as we want
+   * them (i.e. to avoid any unnecessary whitespace).
+   */
+  Json::StreamWriterBuilder jsonWriterBuilder;
 
 public:
 
+  explicit MoveSender (const std::string& gId,
+                       const uint256& chId, const std::string& nm,
+                       XayaWalletRpcClient& w, OpenChannel& oc);
+
   virtual ~MoveSender () = default;
+
+  MoveSender () = delete;
+  MoveSender (const MoveSender&) = delete;
+  void operator= (const MoveSender&) = delete;
+
+  /**
+   * Sends the given JSON value as move.  This is used for the implementations
+   * of SendDispute and SendResolution, and it can also be used by game-specific
+   * logic for sending other moves (e.g. submitting a winner statement).
+   *
+   * Returns the txid if successful and a null uint256 if an error occurred
+   * and the move could not be sent.
+   */
+  uint256 SendMove (const Json::Value& mv);
 
   /**
    * Sends a dispute based on the given state proof.
    */
-  virtual void SendDispute (const proto::StateProof& proof) = 0;
+  virtual void SendDispute (const proto::StateProof& proof);
 
   /**
    * Sends a resolution based on the given state proof.
    */
-  virtual void SendResolution (const proto::StateProof& proof) = 0;
+  virtual void SendResolution (const proto::StateProof& proof);
 
 };
 

--- a/gamechannel/movesender_tests.cpp
+++ b/gamechannel/movesender_tests.cpp
@@ -1,0 +1,64 @@
+// Copyright (C) 2019 The Xaya developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "movesender.hpp"
+
+#include "testgame.hpp"
+
+#include <xayautil/hash.hpp>
+
+#include <jsonrpccpp/common/exception.h>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <glog/logging.h>
+
+namespace xaya
+{
+namespace
+{
+
+using testing::Return;
+using testing::Throw;
+
+class MoveSenderTests : public TestGameFixture
+{
+
+protected:
+
+  const std::string gameId = "game id";
+  const uint256 channelId = SHA256::Hash ("channel id");
+
+  MoveSender onChain;
+
+  MoveSenderTests ()
+    : onChain(gameId, channelId, "player", rpcWallet, game.channel)
+  {}
+
+};
+
+TEST_F (MoveSenderTests, SendMoveSuccess)
+{
+  const uint256 txid = SHA256::Hash ("txid");
+  const std::string expectedValue = R"({"g":{"game id":[42,null,{"a":"b"}]}})";
+  EXPECT_CALL (mockXayaWallet, name_update ("p/player", expectedValue))
+      .WillOnce (Return (txid.ToHex ()));
+
+  EXPECT_EQ (onChain.SendMove (ParseJson (R"([
+    42, null, {"a": "b"} 
+  ])")), txid);
+}
+
+TEST_F (MoveSenderTests, SendMoveError)
+{
+  const std::string expectedValue = R"({"g":{"game id":{}}})";
+  EXPECT_CALL (mockXayaWallet, name_update ("p/player", expectedValue))
+      .WillOnce (Throw (jsonrpc::JsonRpcException ("error")));
+
+  EXPECT_TRUE (onChain.SendMove (ParseJson ("{}")).IsNull ());
+}
+
+} // anonymous namespace
+} // namespace xaya

--- a/gamechannel/openchannel.hpp
+++ b/gamechannel/openchannel.hpp
@@ -1,0 +1,55 @@
+// Copyright (C) 2019 The Xaya developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef GAMECHANNEL_OPENCHANNEL_HPP
+#define GAMECHANNEL_OPENCHANNEL_HPP
+
+#include "proto/stateproof.pb.h"
+
+#include <xayautil/uint256.hpp>
+
+#include <json/json.h>
+
+namespace xaya
+{
+
+/**
+ * Data that a game wants to store about a particular open channel the player
+ * is taking part in.  This can hold state (e.g. preimages for hash commitments)
+ * and also needs to implement game-specific functions like building dispute
+ * moves and processing auto-moves.
+ *
+ * This class is an equivalent of GameLogic and BoardRules for managing
+ * an open channel in the channel daemon process.
+ */
+class OpenChannel
+{
+
+protected:
+
+  OpenChannel () = default;
+
+public:
+
+  virtual ~OpenChannel () = default;
+
+  /**
+   * Builds a resolution move (just the move data without the game ID
+   * envelope) for the given state proof and channel.
+   */
+  virtual Json::Value ResolutionMove (const uint256& channelId,
+                                      const proto::StateProof& proof) const = 0;
+
+  /**
+   * Builds a dispute move (just the move data without the game ID
+   * envelope) for the given state proof and channel.
+   */
+  virtual Json::Value DisputeMove (const uint256& channelId,
+                                   const proto::StateProof& proof) const = 0;
+
+};
+
+} // namespace xaya
+
+#endif // GAMECHANNEL_OPENCHANNEL_HPP

--- a/gamechannel/protoutils.hpp
+++ b/gamechannel/protoutils.hpp
@@ -1,0 +1,30 @@
+// Copyright (C) 2019 The Xaya developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef GAMECHANNEL_PROTOUTILS_HPP
+#define GAMECHANNEL_PROTOUTILS_HPP
+
+#include <string>
+
+namespace xaya
+{
+
+/**
+ * Encodes a protocol buffer as base64 string (e.g. suitable for storing in
+ * a JSON value).
+ */
+template <typename Proto>
+  std::string ProtoToBase64 (const Proto& msg);
+
+/**
+ * Decodes a base64-encoded string into a protocol buffer.
+ */
+template <typename Proto>
+  bool ProtoFromBase64 (const std::string& str, Proto& msg);
+
+} // namespace xaya
+
+#include "protoutils.tpp"
+
+#endif // GAMECHANNEL_PROTOUTILS_HPP

--- a/gamechannel/protoutils.tpp
+++ b/gamechannel/protoutils.tpp
@@ -1,0 +1,43 @@
+// Copyright (C) 2019 The Xaya developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+/* Template implementation code for protoutils.hpp.  */
+
+#include <xayautil/base64.hpp>
+
+#include <glog/logging.h>
+
+namespace xaya
+{
+
+template <typename Proto>
+  std::string
+  ProtoToBase64 (const Proto& msg)
+{
+  std::string serialised;
+  CHECK (msg.SerializeToString (&serialised));
+  return EncodeBase64 (serialised);
+}
+
+template <typename Proto>
+  bool
+  ProtoFromBase64 (const std::string& str, Proto& msg)
+{
+  std::string bytes;
+  if (!DecodeBase64 (str, bytes))
+    {
+      LOG (ERROR) << "Invalid base64: " << str;
+      return false;
+    }
+
+  if (!msg.ParseFromString (bytes))
+    {
+      LOG (ERROR) << "Failed to parse protocol buffer from decoded string";
+      return false;
+    }
+
+  return true;
+}
+
+} // namespace xaya

--- a/gamechannel/protoutils_tests.cpp
+++ b/gamechannel/protoutils_tests.cpp
@@ -1,0 +1,90 @@
+// Copyright (C) 2019 The Xaya developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "protoutils.hpp"
+
+#include "proto/metadata.pb.h"
+#include "proto/stateproof.pb.h"
+
+#include <google/protobuf/text_format.h>
+#include <google/protobuf/util/message_differencer.h>
+
+#include <gtest/gtest.h>
+
+namespace xaya
+{
+namespace
+{
+
+using google::protobuf::TextFormat;
+using google::protobuf::util::MessageDifferencer;
+
+class ProtoUtilsTests : public testing::Test
+{
+
+protected:
+
+  /**
+   * Performs a roundtrip of encoding and decoding the given protocol buffer
+   * message to/from base64.  Checks that the resulting value is equal
+   * to the original input.
+   */
+  template <typename Proto>
+    void
+    CheckRoundtrip (const Proto& input)
+  {
+    const std::string encoded = ProtoToBase64 (input);
+
+    Proto output;
+    ASSERT_TRUE (ProtoFromBase64 (encoded, output));
+
+    ASSERT_TRUE (MessageDifferencer::Equals (input, output));
+  }
+
+};
+
+TEST_F (ProtoUtilsTests, MetadataRoundtrip)
+{
+  proto::ChannelMetadata meta;
+  CHECK (TextFormat::ParseFromString (R"(
+    reinit: "foo"
+    participants:
+      {
+        name: "player 1"
+        address: "my address"
+      }
+    participants:
+      {
+        name: "player 2"
+        address: "some other address"
+      }
+  )", &meta));
+  CheckRoundtrip (meta);
+}
+
+TEST_F (ProtoUtilsTests, StateProofRoundtrip)
+{
+  proto::StateProof proof;
+  CHECK (TextFormat::ParseFromString (R"(
+    initial_state:
+      {
+        data: "1 2"
+        signatures: "sgn"
+      }
+    transitions:
+      {
+        move: "42"
+        new_state:
+          {
+            data: "100 5"
+            signatures: "a"
+            signatures: "b"
+          }
+      }
+  )", &proof));
+  CheckRoundtrip (proof);
+}
+
+} // anonymous namespace
+} // namespace xaya

--- a/gamechannel/testgame.cpp
+++ b/gamechannel/testgame.cpp
@@ -4,6 +4,7 @@
 
 #include "testgame.hpp"
 
+#include "protoutils.hpp"
 #include "signatures.hpp"
 
 #include <xayautil/base64.hpp>
@@ -130,6 +131,30 @@ AdditionRules::ParseState (const uint256& channelId,
     return nullptr;
 
   return std::make_unique<AdditionState> (p);
+}
+
+Json::Value
+AdditionChannel::ResolutionMove (const uint256& channelId,
+                                 const proto::StateProof& proof) const
+{
+  Json::Value res(Json::objectValue);
+  res["type"] = "resolution";
+  res["id"] = channelId.ToHex ();
+  res["proof"] = ProtoToBase64 (proof);
+
+  return res;
+}
+
+Json::Value
+AdditionChannel::DisputeMove (const uint256& channelId,
+                              const proto::StateProof& proof) const
+{
+  Json::Value res(Json::objectValue);
+  res["type"] = "dispute";
+  res["id"] = channelId.ToHex ();
+  res["proof"] = ProtoToBase64 (proof);
+
+  return res;
 }
 
 void

--- a/gamechannel/testgame.hpp
+++ b/gamechannel/testgame.hpp
@@ -7,20 +7,24 @@
 
 #include "boardrules.hpp"
 #include "channelgame.hpp"
+#include "openchannel.hpp"
+
+#include "proto/metadata.pb.h"
+#include "proto/stateproof.pb.h"
 
 #include <xayagame/testutils.hpp>
-#include <xayagame/rpc-stubs/xayarpcclient.h>
-#include <xayagame/rpc-stubs/xayawalletrpcclient.h>
 #include <xayautil/uint256.hpp>
 
+#include <xayagame/rpc-stubs/xayarpcclient.h>
+#include <xayagame/rpc-stubs/xayawalletrpcclient.h>
+
+#include <json/json.h>
 #include <jsonrpccpp/client/connectors/httpclient.h>
 #include <jsonrpccpp/server/connectors/httpserver.h>
 
 #include <gtest/gtest.h>
 
 #include <sqlite3.h>
-
-#include <json/json.h>
 
 #include <memory>
 #include <string>
@@ -53,6 +57,22 @@ public:
 };
 
 /**
+ * OpenChannel implementation for our test game.
+ */
+class AdditionChannel : public OpenChannel
+{
+
+public:
+
+  Json::Value ResolutionMove (const uint256& channelId,
+                              const proto::StateProof& proof) const override;
+
+  Json::Value DisputeMove (const uint256& channelId,
+                           const proto::StateProof& proof) const override;
+
+};
+
+/**
  * Subclass of ChannelGame that implements a trivial game only as much as
  * necessary for unit tests of the game-channel framework.
  */
@@ -75,6 +95,7 @@ protected:
 public:
 
   AdditionRules rules;
+  AdditionChannel channel;
 
   using ChannelGame::ProcessDispute;
   using ChannelGame::ProcessResolution;


### PR DESCRIPTION
This adds a real implementation for `MoveSender`, which performs `name_update`'s on-chain through the Xaya wallet.  This resolves #60.