### PR TITLE
Implement the real-time broadcast system

### DIFF
--- a/gamechannel/.gitignore
+++ b/gamechannel/.gitignore
@@ -1,1 +1,3 @@
 schema.cpp
+
+test_rpcbroadcast

--- a/gamechannel/Makefile.am
+++ b/gamechannel/Makefile.am
@@ -10,6 +10,7 @@ RPC_STUBS = \
   rpc-stubs/channelgsprpcserverstub.h
 
 PROTOS = \
+  proto/broadcast.proto \
   proto/metadata.proto \
   proto/protoboardtest.proto \
   proto/signatures.proto \
@@ -36,6 +37,7 @@ libgamechannel_la_LIBADD = \
   $(GLOG_LIBS) $(SQLITE3_LIBS) $(PROTOBUF_LIBS)
 libgamechannel_la_SOURCES = \
   boardrules.cpp \
+  broadcast.cpp \
   channelgame.cpp \
   channelmanager.cpp \
   chaintochannel.cpp \
@@ -92,6 +94,7 @@ tests_LDADD = \
   $(JSONCPP_LIBS) $(JSONRPCCLIENT_LIBS) $(JSONRPCSERVER_LIBS) \
   $(GLOG_LIBS) $(GTEST_LIBS) $(SQLITE3_LIBS) $(PROTOBUF_LIBS)
 tests_SOURCES = \
+  broadcast_tests.cpp \
   channelgame_tests.cpp \
   channelmanager_tests.cpp \
   chaintochannel_tests.cpp \

--- a/gamechannel/Makefile.am
+++ b/gamechannel/Makefile.am
@@ -108,6 +108,8 @@ tests_SOURCES = \
   \
   testgame.cpp
 check_HEADERS = \
+  channelmanager_tests.hpp \
+  \
   testgame.hpp
 
 schema.cpp: schema_head.cpp schema.sql schema_tail.cpp

--- a/gamechannel/Makefile.am
+++ b/gamechannel/Makefile.am
@@ -50,6 +50,7 @@ libgamechannel_la_SOURCES = \
   $(PROTOSOURCES)
 gamechannel_HEADERS = \
   boardrules.hpp \
+  broadcast.hpp \
   channelgame.hpp \
   channelmanager.hpp \
   chaintochannel.hpp \

--- a/gamechannel/Makefile.am
+++ b/gamechannel/Makefile.am
@@ -1,4 +1,5 @@
 lib_LTLIBRARIES = libgamechannel.la
+dist_bin_SCRIPTS = rpc-channel-server.py
 gamechanneldir = $(includedir)/gamechannel
 rpcstubdir = $(gamechanneldir)/rpc-stubs
 protodir = $(gamechanneldir)/proto
@@ -7,7 +8,8 @@ pyprotodir = $(pydir)/proto
 
 RPC_STUBS = \
   rpc-stubs/channelgsprpcclient.h \
-  rpc-stubs/channelgsprpcserverstub.h
+  rpc-stubs/channelgsprpcserverstub.h \
+  rpc-stubs/rpcbroadcastclient.h
 
 PROTOS = \
   proto/broadcast.proto \
@@ -21,6 +23,7 @@ PROTOPY = $(PROTOS:.proto=_pb2.py)
 
 EXTRA_DIST = $(PROTOS) \
   rpc-stubs/gsp.json \
+  rpc-stubs/rpcbroadcast.json \
   schema.sql schema_head.cpp schema_tail.cpp
 
 BUILT_SOURCES = $(RPC_STUBS) $(PROTOHEADERS) $(PROTOPY)
@@ -46,6 +49,7 @@ libgamechannel_la_SOURCES = \
   gsprpc.cpp \
   movesender.cpp \
   rollingstate.cpp \
+  rpcbroadcast.cpp \
   schema.cpp \
   signatures.cpp \
   stateproof.cpp \
@@ -64,6 +68,7 @@ gamechannel_HEADERS = \
   protoboard.hpp protoboard.tpp \
   protoutils.hpp protoutils.tpp \
   rollingstate.hpp \
+  rpcbroadcast.hpp \
   schema.hpp \
   signatures.hpp \
   stateproof.hpp
@@ -71,15 +76,19 @@ rpcstub_HEADERS = $(RPC_STUBS)
 proto_HEADERS = $(PROTOHEADERS)
 
 PYTHONTESTS = \
-  signatures_tests.py
+  signatures_tests.py \
+  test_rpcbroadcast.py
 noinst_PYTHON = $(PYTHONTESTS)
-py_PYTHON = __init__.py signatures.py
+py_PYTHON = \
+  __init__.py \
+  rpcbroadcast.py \
+  signatures.py
 pyproto_PYTHON = proto/__init__.py $(PROTOPY)
 
 AM_TESTS_ENVIRONMENT = \
   PYTHONPATH=$(srcdir)
 
-check_PROGRAMS = tests
+check_PROGRAMS = tests test_rpcbroadcast
 TESTS = tests $(PYTHONTESTS)
 
 tests_CXXFLAGS = \
@@ -115,6 +124,18 @@ check_HEADERS = \
   \
   testgame.hpp
 
+test_rpcbroadcast_CXXFLAGS = \
+  -I$(top_srcdir) \
+  $(JSONCPP_CFLAGS) $(JSONRPCCLIENT_CFLAGS) $(JSONRPCSERVER_CFLAGS) \
+  $(GLOG_CFLAGS) $(GFLAGS_CFLAGS) $(PROTOBUF_CFLAGS)
+test_rpcbroadcast_LDADD = \
+  $(builddir)/libgamechannel.la \
+  $(top_builddir)/xayautil/libxayautil.la \
+  $(top_builddir)/xayagame/libxayagame.la \
+  $(JSONCPP_LIBS) $(JSONRPCCLIENT_LIBS) $(JSONRPCSERVER_LIBS) \
+  $(GLOG_LIBS) $(GFLAGS_LIBS) $(PROTOBUF_LIBS)
+test_rpcbroadcast_SOURCES = test_rpcbroadcast.cpp
+
 schema.cpp: schema_head.cpp schema.sql schema_tail.cpp
 	cat $^ >$@
 
@@ -124,6 +145,9 @@ rpc-stubs/channelgsprpcserverstub.h: $(srcdir)/rpc-stubs/gsp.json
 	jsonrpcstub "$<" \
 	  --cpp-server=ChannelGspRpcServerStub \
 	  --cpp-server-file="$@"
+
+rpc-stubs/rpcbroadcastclient.h: $(srcdir)/rpc-stubs/rpcbroadcast.json
+	jsonrpcstub "$<" --cpp-client=RpcBroadcastClient --cpp-client-file="$@"
 
 proto/%.pb.h proto/%.pb.cc: $(top_srcdir)/gamechannel/proto/%.proto
 	protoc -I$(top_srcdir) --cpp_out=$(top_builddir) "$<"

--- a/gamechannel/broadcast.cpp
+++ b/gamechannel/broadcast.cpp
@@ -1,0 +1,132 @@
+// Copyright (C) 2019 The Xaya developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "broadcast.hpp"
+
+#include "channelmanager.hpp"
+#include "proto/broadcast.pb.h"
+
+#include <xayautil/base64.hpp>
+
+#include <glog/logging.h>
+
+#include <sstream>
+
+namespace xaya
+{
+
+OffChainBroadcast::~OffChainBroadcast ()
+{
+  Stop ();
+}
+
+const uint256&
+OffChainBroadcast::GetChannelId () const
+{
+  return manager.GetChannelId ();
+}
+
+void
+OffChainBroadcast::SetParticipants (const proto::ChannelMetadata& meta)
+{
+  std::set<std::string> newParticipants;
+  for (const auto& p : meta.participants ())
+    newParticipants.insert (p.name ());
+
+  std::lock_guard<std::mutex> lock(mut);
+
+  if (participants != newParticipants)
+    {
+      std::ostringstream msg;
+      msg << "Updating list of participants in broadcast channel to:";
+      for (const auto& p : newParticipants)
+        msg << " " << p;
+      LOG (INFO) << msg.str ();
+    }
+
+  participants = std::move (newParticipants);
+}
+
+std::vector<std::string>
+OffChainBroadcast::GetMessages ()
+{
+  LOG (FATAL)
+      << "Subclasses should either override GetMessages()"
+         " or ensure that their own Start/Stop event loop does not"
+         " call GetMessages";
+}
+
+void
+OffChainBroadcast::Start ()
+{
+  LOG (INFO) << "Starting default event loop...";
+  CHECK (loop == nullptr) << "The event loop is already running";
+
+  stopLoop = false;
+  loop = std::make_unique<std::thread> ([this] ()
+    {
+      RunLoop ();
+    });
+}
+
+void
+OffChainBroadcast::Stop ()
+{
+  if (loop == nullptr)
+    return;
+
+  LOG (INFO) << "Stopping default event loop...";
+  stopLoop = true;
+  loop->join ();
+  loop.reset ();
+}
+
+void
+OffChainBroadcast::RunLoop ()
+{
+  LOG (INFO) << "Running default event loop...";
+  while (!stopLoop)
+    {
+      const auto messages = GetMessages ();
+      VLOG_IF (1, !messages.empty ())
+          << "Received " << messages.size () << " messages";
+      for (const auto& msg : messages)
+        FeedMessage (msg);
+    }
+}
+
+void
+OffChainBroadcast::SendNewState (const std::string& reinitId,
+                                 const proto::StateProof& proof)
+{
+  VLOG (1) << "Broadcasting new state for reinit " << EncodeBase64 (reinitId);
+
+  proto::BroadcastMessage pb;
+  pb.set_reinit (reinitId);
+  *pb.mutable_proof () = proof;
+
+  std::string msg;
+  CHECK (pb.SerializeToString (&msg));
+
+  std::lock_guard<std::mutex> lock(mut);
+  SendMessage (msg);
+}
+
+void
+OffChainBroadcast::FeedMessage (const std::string& msg)
+{
+  VLOG (1) << "Processing received broadcast message...";
+
+  proto::BroadcastMessage pb;
+  if (!pb.ParseFromString (msg))
+    {
+      LOG (ERROR)
+          << "Failed to parse BroadcastMessage proto from received data";
+      return;
+    }
+
+  manager.ProcessOffChain (pb.reinit (), pb.proof ());
+}
+
+} // namespace xaya

--- a/gamechannel/broadcast.hpp
+++ b/gamechannel/broadcast.hpp
@@ -118,6 +118,10 @@ protected:
    * the default Start/Stop and event loop, then they should override this
    * method.  Calls should never block for an unlimited amount of time,
    * but time out and return an empty vector after some delay.
+   *
+   * It is guaranteed that this function is only called by one concurrent
+   * thread at any given time (when used in combination with the default
+   * Start/Stop event loop).
    */
   virtual std::vector<std::string> GetMessages ();
 

--- a/gamechannel/broadcast.hpp
+++ b/gamechannel/broadcast.hpp
@@ -1,0 +1,45 @@
+// Copyright (C) 2019 The Xaya developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef GAMECHANNEL_BROADCAST_HPP
+#define GAMECHANNEL_BROADCAST_HPP
+
+#include "proto/stateproof.pb.h"
+
+#include <string>
+
+namespace xaya
+{
+
+/**
+ * Interface for a class that allows broadcasting moves / state-proofs
+ * off-chain to the channel participants.  This is implemented by the
+ * real-time implementations and mocked for testing.
+ *
+ * Functions of the interface may be called by different threads, but it is
+ * guaranteed that only one thread at a time is accessing the instance.
+ */
+class OffChainBroadcast
+{
+
+protected:
+
+  OffChainBroadcast () = default;
+
+public:
+
+  virtual ~OffChainBroadcast () = default;
+
+  /**
+   * Sends a new state (presumably after the player made a move) to all
+   * channel participants.
+   */
+  virtual void SendNewState (const std::string& reinitId,
+                             const proto::StateProof& proof) = 0;
+
+};
+
+} // namespace xaya
+
+#endif // GAMECHANNEL_BROADCAST_HPP

--- a/gamechannel/broadcast.hpp
+++ b/gamechannel/broadcast.hpp
@@ -5,38 +5,156 @@
 #ifndef GAMECHANNEL_BROADCAST_HPP
 #define GAMECHANNEL_BROADCAST_HPP
 
+#include "proto/metadata.pb.h"
 #include "proto/stateproof.pb.h"
 
+#include <xayautil/uint256.hpp>
+
+#include <atomic>
+#include <memory>
+#include <mutex>
+#include <set>
 #include <string>
+#include <thread>
+#include <vector>
 
 namespace xaya
 {
 
+class ChannelManager;
+
 /**
- * Interface for a class that allows broadcasting moves / state-proofs
- * off-chain to the channel participants.  This is implemented by the
- * real-time implementations and mocked for testing.
+ * This class handles the off-chain broadcast of messages within a channel.
+ * It contains some general logic, but also concrete implementations for
+ * exchanging messages (e.g. via a server, XMPP, IRC, P2P, ...) have to
+ * subclass OffChainBroadcaster and implement their logic.
  *
- * Functions of the interface may be called by different threads, but it is
- * guaranteed that only one thread at a time is accessing the instance.
+ * For sending messages (local moves to everyone else in the channel),
+ * subclasses need to implement the SendMessage function.  Receiving
+ * messages is more complex, as that needs to take care of waiting for
+ * incoming messages.
+ *
+ * There are two general architectures that implementations can use for
+ * that:  If they have their own event loop, then they should override the
+ * Start and Stop methods, and feed messages they receive to FeedMessage.
+ *
+ * Alternatively, the default implementation of Start and Stop will run
+ * a waiting loop in a new thread, and repeatedly call GetMessages to
+ * retrieve the next message in a blocking call.
  */
 class OffChainBroadcast
 {
 
+private:
+
+  /** The ChannelManager instance that is updated with received messges.  */
+  ChannelManager& manager;
+
+  /**
+   * The list of channel participants (names without p/ prefix).  This is
+   * updated to the latest known on-chain state with channel reinitialisations.
+   * It may be used by concrete implementations for sending messages to all
+   * known participants.
+   */
+  std::set<std::string> participants;
+
+  /**
+   * Lock for shared state, in particular participants.  This lock is held
+   * while SendNewState is running.  It is not held through the receive
+   * cycle, though.
+   */
+  mutable std::mutex mut;
+
+  /** The currently running wait loop, if any.  */
+  std::unique_ptr<std::thread> loop;
+
+  /** If set to true, signals the loop to stop.  */
+  std::atomic<bool> stopLoop;
+
+  /**
+   * Runs the default event loop, waiting for messages.
+   */
+  void RunLoop ();
+
 protected:
 
-  OffChainBroadcast () = default;
+  explicit OffChainBroadcast (ChannelManager& cm)
+    : manager(cm)
+  {}
+
+  /**
+   * Returns the current list of participants.  This may be used by
+   * subclasses for their implementation of SendMessage.  While SendMessage
+   * is running, the participants are properly synchronised.  At any other
+   * time, calling this function may lead to race conditions.
+   */
+  const std::set<std::string>&
+  GetParticipants () const
+  {
+    return participants;
+  }
+
+  /**
+   * Returns the ID of the channel for which this is.  Can be used by
+   * implementations if they need it.
+   */
+  const uint256& GetChannelId () const;
+
+  /**
+   * Sends a given encoded message to all participants in the channel.
+   * This function may be called from different threads, but it is guaranteed
+   * that it is only called by one concurrent thread at any time.
+   */
+  virtual void SendMessage (const std::string& msg) = 0;
+
+  /**
+   * Processes a message retrieved through the broadcast channel.
+   */
+  void FeedMessage (const std::string& msg);
+
+  /**
+   * Tries to retrieve more messages from the underlying communication system,
+   * blocking until one is available.  If subclasses want to make use of
+   * the default Start/Stop and event loop, then they should override this
+   * method.  Calls should never block for an unlimited amount of time,
+   * but time out and return an empty vector after some delay.
+   */
+  virtual std::vector<std::string> GetMessages ();
 
 public:
 
-  virtual ~OffChainBroadcast () = default;
+  virtual ~OffChainBroadcast ();
+
+  OffChainBroadcast () = delete;
+  OffChainBroadcast (const OffChainBroadcast&) = delete;
+  void operator= (const OffChainBroadcast&) = delete;
 
   /**
    * Sends a new state (presumably after the player made a move) to all
    * channel participants.
    */
-  virtual void SendNewState (const std::string& reinitId,
-                             const proto::StateProof& proof) = 0;
+  void SendNewState (const std::string& reinitId,
+                     const proto::StateProof& proof);
+
+  /**
+   * Updates the list of channel participants when the on-chain state changes.
+   */
+  void SetParticipants (const proto::ChannelMetadata& meta);
+
+  /**
+   * Starts an event loop listening for new messages and feeding them into
+   * FeedMessage as received.  Subclasses can override this (together with
+   * Stop) to provide their own event loop.  The default implementation will
+   * start a new thread that just calls GetMessages repeatedly.
+   */
+  virtual void Start ();
+
+  /**
+   * Stops the event loop if one is running.  If subclasses override this
+   * method, they need to ensure that it is fine to call it even if the event
+   * loop is not running at the moment.
+   */
+  virtual void Stop ();
 
 };
 

--- a/gamechannel/broadcast_tests.cpp
+++ b/gamechannel/broadcast_tests.cpp
@@ -1,0 +1,157 @@
+// Copyright (C) 2019 The Xaya developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "broadcast.hpp"
+
+#include "channelmanager.hpp"
+#include "channelmanager_tests.hpp"
+
+#include <google/protobuf/text_format.h>
+
+#include <gtest/gtest.h>
+
+#include <glog/logging.h>
+
+#include <chrono>
+#include <condition_variable>
+
+namespace xaya
+{
+namespace
+{
+
+using google::protobuf::TextFormat;
+
+/** Timeout for the waiters in the test broadcast.  */
+constexpr auto WAITER_TIMEOUT = std::chrono::milliseconds (50);
+
+/**
+ * Implementation of OffChainBroadcast that simply feeds sent messages back
+ * to GetMessages using a condition variable.
+ */
+class FeedBackBroadcast : public OffChainBroadcast
+{
+
+private:
+
+  std::mutex mut;
+  std::condition_variable cv;
+
+  /** Current list of unforwarded messages.  */
+  std::vector<std::string> messages;
+
+protected:
+
+  void
+  SendMessage (const std::string& msg) override
+  {
+    std::lock_guard<std::mutex> lock(mut);
+    messages.push_back (msg);
+  }
+
+  std::vector<std::string>
+  GetMessages () override
+  {
+    std::unique_lock<std::mutex> lock(mut);
+    if (messages.empty ())
+      cv.wait_for (lock, WAITER_TIMEOUT);
+
+    return std::move (messages);
+  }
+
+public:
+
+  explicit FeedBackBroadcast (ChannelManager& cm)
+    : OffChainBroadcast(cm)
+  {}
+
+  using OffChainBroadcast::GetParticipants;
+
+  /**
+   * Forwards the queued messages (by notifying the waiting thread).
+   */
+  void
+  Notify ()
+  {
+    std::lock_guard<std::mutex> lock(mut);
+    cv.notify_all ();
+  }
+
+};
+
+class BroadcastTests : public ChannelManagerTestFixture
+{
+
+protected:
+
+  FeedBackBroadcast offChain;
+
+  BroadcastTests ()
+    : offChain(cm)
+  {
+    cm.SetOffChainBroadcast (offChain);
+    offChain.Start ();
+  }
+
+  ~BroadcastTests ()
+  {
+    offChain.Stop ();
+  }
+
+  /**
+   * Expects the given list of participants.
+   */
+  void
+  ExpectParticipants (const std::set<std::string>& expected)
+  {
+    EXPECT_EQ (offChain.GetParticipants (), expected);
+  }
+
+};
+
+TEST_F (BroadcastTests, Participants)
+{
+  cm.ProcessOnChain (meta, "0 0", ValidProof ("10 5"), 0);
+  ExpectParticipants ({"player", "other"});
+
+  cm.ProcessOnChainNonExistant ();
+  ExpectParticipants ({});
+}
+
+TEST_F (BroadcastTests, FeedingMoves)
+{
+  meta.set_reinit ("reinit");
+  cm.ProcessOnChain (meta, "0 0", ValidProof ("1 2"), 0);
+
+  meta.clear_reinit ();
+  cm.ProcessOnChain (meta, "0 0", ValidProof ("0 0"), 0);
+
+  offChain.SendNewState ("", ValidProof ("10 5"));
+  offChain.SendNewState ("reinit", ValidProof ("9 10"));
+
+  SleepSome ();
+  EXPECT_EQ (GetLatestState (), "0 0");
+
+  offChain.Notify ();
+  SleepSome ();
+  EXPECT_EQ (GetLatestState (), "10 5");
+
+  meta.set_reinit ("reinit");
+  cm.ProcessOnChain (meta, "0 0", ValidProof ("1 2"), 0);
+  EXPECT_EQ (GetLatestState (), "9 10");
+}
+
+TEST_F (BroadcastTests, BeyondTimeout)
+{
+  cm.ProcessOnChain (meta, "0 0", ValidProof ("0 0"), 0);
+  offChain.SendNewState ("", ValidProof ("10 5"));
+
+  /* Even without a notification, we will get the new state because the
+     waiter thread times out and recalls GetMessages.  */
+  std::this_thread::sleep_for (2 * WAITER_TIMEOUT);
+  EXPECT_EQ (GetLatestState (), "10 5");
+}
+
+} // anonymous namespace
+} // namespace xaya

--- a/gamechannel/channelmanager.cpp
+++ b/gamechannel/channelmanager.cpp
@@ -140,6 +140,12 @@ ChannelManager::ProcessOnChainNonExistant ()
     }
 
   exists = false;
+
+  /* If the channel no longer exists on chain, set the list of participants
+     for the broadcaster to empty.  */
+  if (offChainSender != nullptr)
+    offChainSender->SetParticipants (proto::ChannelMetadata ());
+
   NotifyStateChange ();
 }
 
@@ -187,6 +193,11 @@ ChannelManager::ProcessOnChain (const proto::ChannelMetadata& meta,
       dispute->turn = p->WhoseTurn ();
       dispute->count = p->TurnCount ();
     }
+
+  /* Update the list of participants for the off-chain broadcaster to the
+     latest known version.  */
+  if (offChainSender != nullptr)
+    offChainSender->SetParticipants (meta);
 
   TryResolveDispute ();
   NotifyStateChange ();

--- a/gamechannel/channelmanager.hpp
+++ b/gamechannel/channelmanager.hpp
@@ -6,6 +6,7 @@
 #define GAMECHANNEL_CHANNELMANAGER_HPP
 
 #include "boardrules.hpp"
+#include "broadcast.hpp"
 #include "movesender.hpp"
 #include "rollingstate.hpp"
 

--- a/gamechannel/channelmanager.hpp
+++ b/gamechannel/channelmanager.hpp
@@ -174,8 +174,7 @@ private:
    */
   void NotifyStateChange ();
 
-  friend class ChannelManagerTests;
-  friend class ChainToChannelFeederTests;
+  friend class ChannelManagerTestFixture;
 
 public:
 

--- a/gamechannel/channelmanager_tests.hpp
+++ b/gamechannel/channelmanager_tests.hpp
@@ -1,0 +1,73 @@
+// Copyright (C) 2019 The Xaya developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef GAMECHANNEL_CHANNELMANAGER_TESTS_HPP
+#define GAMECHANNEL_CHANNELMANAGER_TESTS_HPP
+
+#include "channelmanager.hpp"
+
+#include "testgame.hpp"
+
+#include <xayautil/base64.hpp>
+#include <xayautil/hash.hpp>
+
+namespace xaya
+{
+
+/**
+ * Constructs a state proof for the given state, signed by both players
+ * (and thus valid).
+ */
+proto::StateProof ValidProof (const std::string& state);
+
+class ChannelManagerTestFixture : public TestGameFixture
+{
+
+protected:
+
+  const uint256 channelId = SHA256::Hash ("channel id");
+  proto::ChannelMetadata meta;
+
+  ChannelManager cm;
+
+  ChannelManagerTestFixture ();
+  ~ChannelManagerTestFixture ();
+
+  /**
+   * Extracts the latest state from boardStates.
+   */
+  BoardState GetLatestState () const;
+
+  /**
+   * Exposes the boardStates member of our ChannelManager to subtests.
+   */
+  const RollingState&
+  GetBoardStates () const
+  {
+    return cm.boardStates;
+  }
+
+  /**
+   * Exposes the exists member to subtests.
+   */
+  bool
+  GetExists () const
+  {
+    return cm.exists;
+  }
+
+  /**
+   * Exposes the dispute member to subtests.
+   */
+  const ChannelManager::DisputeData*
+  GetDispute () const
+  {
+    return cm.dispute.get ();
+  }
+
+};
+
+} // namespace xaya
+
+#endif // GAMECHANNEL_CHANNELMANAGER_TESTS_HPP

--- a/gamechannel/movesender.hpp
+++ b/gamechannel/movesender.hpp
@@ -19,34 +19,6 @@ namespace xaya
 {
 
 /**
- * Interface for a class that allows broadcasting moves / state-proofs
- * off-chain to the channel participants.  This is implemented by the
- * real-time implementations and mocked for testing.
- *
- * Functions of the interface may be called by different threads, but it is
- * guaranteed that only one thread at a time is accessing the instance.
- */
-class OffChainBroadcast
-{
-
-protected:
-
-  OffChainBroadcast () = default;
-
-public:
-
-  virtual ~OffChainBroadcast () = default;
-
-  /**
-   * Sends a new state (presumably after the player made a move) to all
-   * channel participants.
-   */
-  virtual void SendNewState (const std::string& reinitId,
-                             const proto::StateProof& proof) = 0;
-
-};
-
-/**
  * A connection to the Xaya wallet that allows sending moves (mainly
  * disputes and resolutions from ChannelManager, but also game-specific code
  * may use it e.g. for winner statements).  They are sent by name_update's

--- a/gamechannel/proto/broadcast.proto
+++ b/gamechannel/proto/broadcast.proto
@@ -1,0 +1,25 @@
+// Copyright (C) 2019 The Xaya developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+syntax = "proto2";
+
+import "gamechannel/proto/stateproof.proto";
+
+package xaya.proto;
+
+/** A message on the off-chain broadcast channel.  */
+message BroadcastMessage
+{
+
+  /** The channel reinit ID this corresponds to.  */
+  optional string reinit = 1;
+
+  /* There is no need to also store the channel ID, since that is part of the
+     broadcast channel itself (and implementations of OffChainBroadcast need
+     to make sure that routing by channel works).  */
+
+  /** The state proof for the move that this represents.  */
+  optional StateProof proof = 2;
+
+}

--- a/gamechannel/rpc-channel-server.py
+++ b/gamechannel/rpc-channel-server.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python
+# Copyright (C) 2019 The Xaya developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+from gamechannel import rpcbroadcast
+
+import argparse
+import logging
+import sys
+
+
+desc = "JSON-RPC game-channel broadcast server"
+parser = argparse.ArgumentParser (description=desc)
+parser.add_argument ("--host", default="localhost",
+                   help="host address where to bind the server")
+parser.add_argument ("--port", type=int, required=True,
+                   help="listening port for the server")
+args = parser.parse_args ()
+
+logFmt = "%(asctime)s %(name)s (%(levelname)s): %(message)s"
+logHandler = logging.StreamHandler (sys.stderr)
+logHandler.setFormatter (logging.Formatter (logFmt))
+logger = logging.getLogger ()
+logger.setLevel (logging.INFO)
+logger.addHandler (logHandler)
+
+server = rpcbroadcast.Server (args.host, args.port)
+server.serve ()

--- a/gamechannel/rpc-stubs/rpcbroadcast.json
+++ b/gamechannel/rpc-stubs/rpcbroadcast.json
@@ -1,0 +1,27 @@
+[
+  {
+    "name": "send",
+    "params":
+      {
+        "channel": "hex",
+        "message": "string"
+      }
+  },
+  {
+    "name": "getseq",
+    "params":
+      {
+        "channel": "hex"
+      },
+    "returns": {}
+  },
+  {
+    "name": "receive",
+    "params":
+      {
+        "channel": "hex",
+        "fromseq": 42
+      },
+    "returns": {}
+  }
+]

--- a/gamechannel/rpcbroadcast.cpp
+++ b/gamechannel/rpcbroadcast.cpp
@@ -1,0 +1,81 @@
+// Copyright (C) 2019 The Xaya developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "rpcbroadcast.hpp"
+
+#include <xayautil/base64.hpp>
+
+#include <glog/logging.h>
+
+namespace xaya
+{
+
+RpcBroadcast::RpcBroadcast (const std::string& rpcUrl, ChannelManager& cm)
+  : OffChainBroadcast(cm),
+    sendConnector(rpcUrl), receiveConnector(rpcUrl),
+    sendRpc(sendConnector), receiveRpc(receiveConnector)
+{}
+
+void
+RpcBroadcast::InitialiseSequence ()
+{
+  LOG (INFO) << "Querying RPC server for initial sequence number...";
+  UpdateSequence (receiveRpc.getseq (GetChannelId ().ToHex ()));
+}
+
+void
+RpcBroadcast::UpdateSequence (const Json::Value& resp)
+{
+  CHECK (resp.isObject ());
+  const auto& seqVal = resp["seq"];
+  CHECK (seqVal.isUInt ());
+  seq = seqVal.asUInt ();
+  VLOG (1) << "New sequence number: " << seq;
+}
+
+void
+RpcBroadcast::Start ()
+{
+  InitialiseSequence ();
+  OffChainBroadcast::Start ();
+}
+
+void
+RpcBroadcast::SendMessage (const std::string& msg)
+{
+  /* While going through the RPC server, we encode messages as base64 to
+     ensure that they can safely and easily be transmitted through JSON.  */
+  sendRpc.send (GetChannelId ().ToHex (), EncodeBase64 (msg));
+}
+
+std::vector<std::string>
+RpcBroadcast::GetMessages ()
+{
+  const Json::Value res = receiveRpc.receive (GetChannelId ().ToHex (), seq);
+  CHECK (res.isObject ());
+  UpdateSequence (res);
+
+  const auto& msgVal = res["messages"];
+  CHECK (msgVal.isArray ());
+  std::vector<std::string> messages;
+  messages.reserve (msgVal.size ());
+  for (const auto& m : msgVal)
+    {
+      CHECK (m.isString ());
+
+      std::string decoded;
+      if (!DecodeBase64 (m.asString (), decoded))
+        {
+          LOG (WARNING)
+              << "Invalid base64 detected in broadcast message: " << m;
+          continue;
+        }
+
+      messages.push_back (decoded);
+    }
+
+  return messages;
+}
+
+} // namespace xaya

--- a/gamechannel/rpcbroadcast.hpp
+++ b/gamechannel/rpcbroadcast.hpp
@@ -1,0 +1,82 @@
+// Copyright (C) 2019 The Xaya developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef GAMECHANNEL_RPCBROADCAST_HPP
+#define GAMECHANNEL_RPCBROADCAST_HPP
+
+#include "broadcast.hpp"
+#include "channelmanager.hpp"
+
+#include "rpc-stubs/rpcbroadcastclient.h"
+
+#include <jsonrpccpp/client/connectors/httpclient.h>
+
+#include <string>
+#include <vector>
+
+namespace xaya
+{
+
+/**
+ * Implementation of OffChainBroadcast that talks to a JSON-RPC server
+ * for sending and receiving messages.  The server manages the individual
+ * channels and takes care of distributing the messages to clients.
+ */
+class RpcBroadcast : public OffChainBroadcast
+{
+
+private:
+
+  /** The HTTP connector used for sending messages.  */
+  jsonrpc::HttpClient sendConnector;
+
+  /**
+   * The HTTP connector used for receiving messages.  We need a separate one
+   * here from sendConnector, because both may be used concurrently by
+   * different threads and that is not possible with a single one.
+   */
+  jsonrpc::HttpClient receiveConnector;
+
+  /** The RPC client used for sending messages.  */
+  RpcBroadcastClient sendRpc;
+
+  /** The RPC client used for receiving messages.  */
+  RpcBroadcastClient receiveRpc;
+
+  /** The last known sequence number of the channel.  */
+  unsigned seq;
+
+  /**
+   * Initialises the sequence number from the RPC server.
+   */
+  void InitialiseSequence ();
+
+  /**
+   * Updates the internal sequence number from a received response (either
+   * for getseq or receive).
+   */
+  void UpdateSequence (const Json::Value& resp);
+
+  friend class TestRpcBroadcast;
+
+protected:
+
+  void SendMessage (const std::string& msg) override;
+  std::vector<std::string> GetMessages () override;
+
+public:
+
+  explicit RpcBroadcast (const std::string& rpcUrl, ChannelManager& cm);
+
+  /**
+   * Starts the broadcast channel.  We use the default event loop, but override
+   * this method to query for the initial sequence number when starting.
+   */
+  void Start () override;
+
+};
+
+} // namespace xaya
+
+#endif // GAMECHANNEL_BROADCAST_HPP

--- a/gamechannel/rpcbroadcast.py
+++ b/gamechannel/rpcbroadcast.py
@@ -1,0 +1,139 @@
+# Copyright (C) 2019 The Xaya developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+"""
+A JSON-RPC server that can be used as broadcasting system, in conjunction
+with the RpcBroadcast client implementation.  Messages can be published
+by calling RPC methods on the server, and also retrieved by long-polling
+RPC calls.
+
+Messages for each channel ID have sequence numbers (assigned by the server).
+When a new participant joins the channel, they can request the current number.
+Then, when requesting messages, client can specify the sequence number
+starting from which they want to retrieve new messages.
+
+Note that while this server is fully functional and can be used for
+real game play, it is not optimised for production use yet (e.g. with
+proper logging or DoS protection).  For instance, it does not attempt
+to ever remove data of previously opened channels.  If we assume that active
+clients will poll the server repeatedly, we can implement cleaning up of
+old data (messages in an active channel as well as inactive channels) by
+simply removing everything that has not been touched in a while.
+"""
+
+import logging
+import threading
+
+import SocketServer
+
+from jsonrpclib.SimpleJSONRPCServer import SimpleJSONRPCServer
+
+
+class ThreadingJsonRpcServer (SocketServer.ThreadingMixIn, SimpleJSONRPCServer):
+  pass
+
+
+class Channel (object):
+  """
+  Data and logic for one particular broadcast channel in the server
+  (as identified by its channel ID).
+  """
+
+  def __init__ (self):
+    self.cv = threading.Condition ()
+
+    # We simply keep track of all messages in a growing list.  The sequence
+    # number of each message is its index plus one.  In other words, the
+    # "current" sequence number in the beginning is zero.  When we add the
+    # first message, the current sequence number is one, and so on.
+    self.messages = []
+
+  def send (self, msg):
+    with self.cv:
+      self.messages.append (msg)
+      self.cv.notifyAll ()
+
+  def getSeq (self):
+    with self.cv:
+      return len (self.messages)
+
+  def receive (self, fromSeq, timeout):
+    with self.cv:
+      if len (self.messages) <= fromSeq:
+        self.cv.wait (timeout)
+      return self.messages[fromSeq:], len (self.messages)
+
+
+class Server (object):
+  """
+  One instance of the server.  It holds all the data required for the
+  running process, and provides the functionality to start and stop it
+  as required.
+
+  This class is used by the simple main method below, but it may also be
+  used directly to start a server in an integration test (for instance).
+  """
+
+  # Timeout value for receive calls.
+  RECEIVE_TIMEOUT = 3
+
+  def __init__ (self, host, port):
+    self.host = host
+    self.port = port
+    self.log = logging.getLogger ("rpcbroadcast.Server")
+    self.server = ThreadingJsonRpcServer ((host, port))
+
+    # We need to synchronise access to the dictionary of channels, so that
+    # we can safely access and potentially add channels to it.  The mutex
+    # only covers access to self.channels, though.  Once a channel is
+    # retrieved, it will be released and the Channel instance will
+    # be responsible for synchronisation of further work with it.
+    self.channels = {}
+    self.mutex = threading.Lock ()
+
+    def sendMsg (channel, message):
+      self.getChannel (channel).send (message)
+    self.server.register_function (sendMsg, "send")
+
+    def getSeq (channel):
+      return {"seq": self.getChannel (channel).getSeq ()}
+    self.server.register_function (getSeq, "getseq")
+
+    def receiveMsg (channel, fromseq):
+      ch = self.getChannel (channel)
+      (msg, seq) = ch.receive (fromseq, self.RECEIVE_TIMEOUT)
+      return {
+        "messages": msg,
+        "seq": seq,
+      }
+    self.server.register_function (receiveMsg, "receive")
+
+  def getChannel (self, channel):
+    """
+    Retrieves the Channel instance for the given ID.  If it does not
+    exist yet in our dictionary, we create a fresh channel.
+    """
+
+    with self.mutex:
+      if channel not in self.channels:
+        self.channels[channel] = Channel ()
+
+      return self.channels[channel]
+
+  def serve (self):
+    """
+    Starts serving with the server.  This function call blocks until the
+    server is finished.
+    """
+
+    self.log.info ("Starting server at %s:%d..." % (self.host, self.port))
+    self.server.serve_forever ()
+
+  def shutdown (self):
+    """
+    Stops the running server (blocking until done).
+    """
+
+    self.log.info ("Shutting down server at %s:%d..." % (self.host, self.port))
+    self.server.shutdown ()

--- a/gamechannel/test_rpcbroadcast.cpp
+++ b/gamechannel/test_rpcbroadcast.cpp
@@ -1,0 +1,197 @@
+// Copyright (C) 2018-2019 The Xaya developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "config.h"
+
+#include "channelmanager.hpp"
+#include "rpcbroadcast.hpp"
+
+#include <xayagame/rpc-stubs/xayarpcclient.h>
+#include <xayagame/rpc-stubs/xayawalletrpcclient.h>
+#include <xayautil/hash.hpp>
+#include <xayautil/uint256.hpp>
+
+#include <gflags/gflags.h>
+#include <glog/logging.h>
+
+#include <google/protobuf/stubs/common.h>
+
+#include <cstdlib>
+#include <iostream>
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace
+{
+
+DEFINE_string (rpc_url, "",
+               "URL at which the broadcast server's RPC interface is");
+
+/**
+ * Returns a fake reference to an instance of the given type.  The value
+ * will be a nullptr.  This is used to quickly stub out dependencies for
+ * ChannelManager that are not actually accessed in our tests here.
+ */
+template <typename T>
+  T&
+  NullReference ()
+{
+  return *static_cast<T*> (nullptr);
+}
+
+} // anonymous namespace
+
+/**
+ * Utility method to print vectors of messages for CHECK_EQ.
+ */
+template <typename S>
+  S&
+  operator<< (S& out, const std::vector<std::string>& msg)
+{
+  out << "[";
+  for (const auto& m : msg)
+    out << " " << m;
+  out << " ]";
+
+  return out;
+}
+
+namespace xaya
+{
+
+/**
+ * Broadcast channel with faked ChannelManager.  The main test uses multiple
+ * of them connected to the same server to send messages and test receiving
+ * of them as expected.
+ */
+class TestRpcBroadcast
+{
+
+private:
+
+  /** The faked ChannelManager.  */
+  ChannelManager cm;
+
+  /** The broadcast channel itself.  */
+  RpcBroadcast bc;
+
+  /** Thread running a pending call to GetMessages.  */
+  std::unique_ptr<std::thread> runningCall;
+
+  /** The result of the last GetMessages call.  */
+  std::vector<std::string> messages;
+
+public:
+
+  explicit TestRpcBroadcast (const std::string& rpcUrl, const uint256& id)
+    : cm(NullReference<BoardRules> (), NullReference<XayaRpcClient> (),
+         NullReference<XayaWalletRpcClient> (), id, "player name"),
+      bc(rpcUrl, cm)
+  {
+    /* We do not want to run the broadcast's event loop (as that would mess
+       up our custom calls to SendMessage and GetMessages).  We still need
+       to initialise the sequence number, though, just like Start() would
+       do in a real usage situation.  */
+    bc.InitialiseSequence ();
+  }
+
+  ~TestRpcBroadcast ()
+  {
+    cm.StopUpdates ();
+  }
+
+  /**
+   * Sends a message on the channel.
+   */
+  void
+  Send (const std::string& msg)
+  {
+    bc.SendMessage (msg);
+  }
+
+  /**
+   * Starts a new call to GetMessages in a new thread.
+   */
+  void
+  StartReceive ()
+  {
+    CHECK (runningCall == nullptr);
+    runningCall = std::make_unique<std::thread> ([this] ()
+      {
+        messages = bc.GetMessages ();
+      });
+  }
+
+  /**
+   * Waits for the last call to GetMessages to finish and checks that
+   * the received messages match the expectations.
+   */
+  void
+  ExpectResult (const std::vector<std::string>& expected)
+  {
+    CHECK (runningCall != nullptr);
+    runningCall->join ();
+    runningCall.reset ();
+    if (messages != expected)
+      {
+        LOG (FATAL)
+            << "Messages do not match expectations!"
+               "\nActual: " << messages
+            << "\nExpected: " << expected;
+      }
+  }
+
+};
+
+} // namespace xaya
+
+int
+main (int argc, char** argv)
+{
+  google::InitGoogleLogging (argv[0]);
+  GOOGLE_PROTOBUF_VERIFY_VERSION;
+
+  gflags::SetUsageMessage ("Run RPC broadcast tests");
+  gflags::SetVersionString (PACKAGE_VERSION);
+  gflags::ParseCommandLineFlags (&argc, &argv, true);
+
+  if (FLAGS_rpc_url.empty ())
+    {
+      std::cerr << "Error: --rpc_url must be set" << std::endl;
+      return EXIT_FAILURE;
+    }
+
+  const auto id1 = xaya::SHA256::Hash ("channel 1");
+  const auto id2 = xaya::SHA256::Hash ("channel 2");
+
+  using xaya::TestRpcBroadcast;
+
+  TestRpcBroadcast bc1(FLAGS_rpc_url, id1);
+  bc1.Send ("foo");
+  bc1.StartReceive ();
+  bc1.ExpectResult ({"foo"});
+
+  TestRpcBroadcast bc2(FLAGS_rpc_url, id2);
+  bc2.StartReceive ();
+  bc2.Send ("bar");
+  bc2.ExpectResult ({"bar"});
+
+  bc1.Send ("baz");
+  TestRpcBroadcast bc3(FLAGS_rpc_url, id1);
+  bc3.Send ("abc");
+  bc1.StartReceive ();
+  bc1.ExpectResult ({"baz", "abc"});
+  bc3.StartReceive ();
+  bc3.ExpectResult ({"abc"});
+
+  /* Test a string that is not valid UTF-8.  */
+  const std::string weirdStr("abc\0def\xFF", 8);
+  bc2.Send (weirdStr);
+  bc2.StartReceive ();
+  bc2.ExpectResult ({weirdStr});
+
+  google::protobuf::ShutdownProtobufLibrary ();
+  return EXIT_SUCCESS;
+}

--- a/gamechannel/test_rpcbroadcast.py
+++ b/gamechannel/test_rpcbroadcast.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python
+# Copyright (C) 2019 The Xaya developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+"""
+Integration test for the JSON-RPC broadcast method.  This starts up a local
+server and then runs the test binary pointed to it.
+"""
+
+import rpcbroadcast
+
+import os
+import os.path
+import subprocess
+import sys
+import threading
+
+
+class DetachedBroadcastServer (threading.Thread):
+
+  PORT = 32500
+
+  def __init__ (self):
+    super (DetachedBroadcastServer, self).__init__ ()
+    self.server = rpcbroadcast.Server ("localhost", self.PORT)
+
+  def run (self):
+    self.server.serve ()
+
+  def stop (self):
+    self.server.shutdown ()
+    self.join ()
+
+
+if __name__ == "__main__":
+  server = DetachedBroadcastServer ()
+
+  builddir = os.getenv ("builddir")
+  if builddir is None:
+    builddir = "."
+  testbin = os.path.join (builddir, "test_rpcbroadcast")
+
+  url = "--rpc_url=http://localhost:%d" % server.PORT
+
+  try:
+    server.start ()
+    sys.exit (subprocess.call ([testbin, url]))
+  finally:
+    server.stop ()


### PR DESCRIPTION
This set of changes adds generic code for the real-time broadcast system, extending `OffChainBroadcast`.  It also includes a concrete implementation of one system, based on a JSON-RPC server.  This will be sufficient for integration tests, and may even be good for demo or production use with some more tweaks.

Fixes #59.