### PR TITLE
Implement automoves for game channels

### DIFF
--- a/gamechannel/Makefile.am
+++ b/gamechannel/Makefile.am
@@ -48,6 +48,7 @@ libgamechannel_la_SOURCES = \
   gamestatejson.cpp \
   gsprpc.cpp \
   movesender.cpp \
+  openchannel.cpp \
   rollingstate.cpp \
   rpcbroadcast.cpp \
   schema.cpp \

--- a/gamechannel/channelmanager.cpp
+++ b/gamechannel/channelmanager.cpp
@@ -120,7 +120,8 @@ ChannelManager::ProcessOffChain (const std::string& reinitId,
       return;
     }
 
-  boardStates.UpdateWithMove (reinitId, proof);
+  if (!boardStates.UpdateWithMove (reinitId, proof))
+    return;
 
   TryResolveDispute ();
   NotifyStateChange ();
@@ -231,7 +232,10 @@ ChannelManager::ProcessLocalMove (const BoardMove& mv)
     }
 
   const auto& reinit = boardStates.GetReinitId ();
-  boardStates.UpdateWithMove (reinit, newProof);
+
+  /* The update is guaranteed to yield a change at this point, since otherwise
+     ExtendStateProof would already have failed.  */
+  CHECK (boardStates.UpdateWithMove (reinit, newProof));
 
   CHECK (offChainSender != nullptr);
   offChainSender->SendNewState (reinit, newProof);

--- a/gamechannel/channelmanager.hpp
+++ b/gamechannel/channelmanager.hpp
@@ -179,6 +179,16 @@ private:
   bool ProcessAutoMoves ();
 
   /**
+   * Performs internal updates after the state was changed.  In particular,
+   * this performs automoves, resolves disputes and notifies the OpenChannel
+   * and WaitForChange listeners about a new change.
+   *
+   * If automoves were found or broadcast is true, then it also broadcasts
+   * the new state to the off-chain channel.
+   */
+  void ProcessStateUpdate (bool broadcast);
+
+  /**
    * Returns the current state of the channel as JSON, assuming that mut is
    * already locked.  This is used internally for ToJson as well as
    * WaitForChange (the latter cannot call the former directly, since that would

--- a/gamechannel/channelmanager.hpp
+++ b/gamechannel/channelmanager.hpp
@@ -8,6 +8,7 @@
 #include "boardrules.hpp"
 #include "broadcast.hpp"
 #include "movesender.hpp"
+#include "openchannel.hpp"
 #include "rollingstate.hpp"
 
 #include "proto/stateproof.pb.h"
@@ -91,6 +92,9 @@ private:
   /** The board rules of the game being played.  */
   const BoardRules& rules;
 
+  /** OpenChannel instance for this game.  */
+  OpenChannel& game;
+
   /** RPC connection to Xaya Core used for verifying signatures.  */
   XayaRpcClient& rpc;
 
@@ -154,11 +158,25 @@ private:
   bool pendingDispute = false;
 
   /**
+   * Tries to apply a local move to the current state.  Returns true if
+   * a change was made successfully.  This method just updates the
+   * state, without triggering any more processing by itself.  It is
+   * the shared code between ProcessLocalMove and processing of automoves.
+   */
+  bool ApplyLocalMove (const BoardMove& mv);
+
+  /**
    * Tries to resolve the current dispute, if there is any.  This can be called
    * whenever a change may have happened that affects this, like a new state
    * being known (e.g. off-chain / local move) or an on-chain update.
    */
   void TryResolveDispute ();
+
+  /**
+   * Tries to apply a chain of automoves to the current state, if applicable.
+   * Returns true if at least one move was found.
+   */
+  bool ProcessAutoMoves ();
 
   /**
    * Returns the current state of the channel as JSON, assuming that mut is
@@ -184,7 +202,7 @@ public:
    */
   static constexpr int WAITFORCHANGE_ALWAYS_BLOCK = 0;
 
-  explicit ChannelManager (const BoardRules& r,
+  explicit ChannelManager (const BoardRules& r, OpenChannel& oc,
                            XayaRpcClient& c, XayaWalletRpcClient& w,
                            const uint256& id, const std::string& name);
 

--- a/gamechannel/openchannel.cpp
+++ b/gamechannel/openchannel.cpp
@@ -4,6 +4,8 @@
 
 #include "openchannel.hpp"
 
+#include "movesender.hpp"
+
 namespace xaya
 {
 
@@ -12,5 +14,11 @@ OpenChannel::MaybeAutoMove (const ParsedBoardState& state, BoardMove& mv)
 {
   return false;
 }
+
+void
+OpenChannel::MaybeOnChainMove (const proto::ChannelMetadata& meta,
+                               const ParsedBoardState& state,
+                               MoveSender& sender)
+{}
 
 } // namespace xaya

--- a/gamechannel/openchannel.cpp
+++ b/gamechannel/openchannel.cpp
@@ -1,0 +1,16 @@
+// Copyright (C) 2019 The Xaya developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "openchannel.hpp"
+
+namespace xaya
+{
+
+bool
+OpenChannel::MaybeAutoMove (const ParsedBoardState& state, BoardMove& mv)
+{
+  return false;
+}
+
+} // namespace xaya

--- a/gamechannel/openchannel.hpp
+++ b/gamechannel/openchannel.hpp
@@ -6,6 +6,7 @@
 #define GAMECHANNEL_OPENCHANNEL_HPP
 
 #include "boardrules.hpp"
+#include "proto/metadata.pb.h"
 #include "proto/stateproof.pb.h"
 
 #include <xayautil/uint256.hpp>
@@ -14,6 +15,8 @@
 
 namespace xaya
 {
+
+class MoveSender;
 
 /**
  * Data that a game wants to store about a particular open channel the player
@@ -62,6 +65,19 @@ public:
    * a hash commitment.
    */
   virtual bool MaybeAutoMove (const ParsedBoardState& state, BoardMove& mv);
+
+  /**
+   * Checks if the game-specific logic wants to send an on-chain move in
+   * response to the current channel state.  This can be used, for instance,
+   * to close a channel in agreement after the off-chain game has finished.
+   *
+   * Note that this function is called independent of whose turn it is
+   * (unlike auto moves, which are processed only if the player owning the
+   * channel daemon is to play).
+   */
+  virtual void MaybeOnChainMove (const proto::ChannelMetadata& meta,
+                                 const ParsedBoardState& state,
+                                 MoveSender& sender);
 
 };
 

--- a/gamechannel/openchannel.hpp
+++ b/gamechannel/openchannel.hpp
@@ -5,6 +5,7 @@
 #ifndef GAMECHANNEL_OPENCHANNEL_HPP
 #define GAMECHANNEL_OPENCHANNEL_HPP
 
+#include "boardrules.hpp"
 #include "proto/stateproof.pb.h"
 
 #include <xayautil/uint256.hpp>
@@ -47,6 +48,20 @@ public:
    */
   virtual Json::Value DisputeMove (const uint256& channelId,
                                    const proto::StateProof& proof) const = 0;
+
+  /**
+   * Checks if an automatic move can be sent right now for the given game
+   * state.  This is useful for situations where moves are made according
+   * to some protocol, e.g. for hash commitments and random numbers.  The
+   * default implementation just returns false, i.e. indicating that auto
+   * moves are never available.
+   *
+   * This function is not marked as "const", since it may change the internal
+   * state of the game-specific data.  For instance, when computing the auto
+   * move, the game might construct and save some random salt value for
+   * a hash commitment.
+   */
+  virtual bool MaybeAutoMove (const ParsedBoardState& state, BoardMove& mv);
 
 };
 

--- a/gamechannel/rollingstate.hpp
+++ b/gamechannel/rollingstate.hpp
@@ -120,8 +120,11 @@ public:
    * Updates the state for a newly received on-chain update.  This assumes
    * that the state proof is valid, and it also updates the "current"
    * reinitialisation to the one seen in the update.
+   *
+   * Returns true if an actual change has been made (i.e. the provided
+   * state proof was valid and newer than what we had so far).
    */
-  void UpdateOnChain (const proto::ChannelMetadata& meta,
+  bool UpdateOnChain (const proto::ChannelMetadata& meta,
                       const BoardState& reinitState,
                       const proto::StateProof& proof);
 
@@ -129,8 +132,11 @@ public:
    * Updates the state for a newly received off-chain state with the
    * given reinitialisation ID (if we know it).  This verifies the state proof,
    * and ignores invalid updates.
+   *
+   * Returns true if an actual change has been made, i.e. the reinit was
+   * known and the state advanced forward with the new state proof.
    */
-  void UpdateWithMove (const std::string& updReinit,
+  bool UpdateWithMove (const std::string& updReinit,
                        const proto::StateProof& proof);
 
 };

--- a/gamechannel/test_rpcbroadcast.cpp
+++ b/gamechannel/test_rpcbroadcast.cpp
@@ -86,7 +86,8 @@ private:
 public:
 
   explicit TestRpcBroadcast (const std::string& rpcUrl, const uint256& id)
-    : cm(NullReference<BoardRules> (), NullReference<XayaRpcClient> (),
+    : cm(NullReference<BoardRules> (), NullReference<OpenChannel> (),
+         NullReference<XayaRpcClient> (),
          NullReference<XayaWalletRpcClient> (), id, "player name"),
       bc(rpcUrl, cm)
   {

--- a/gamechannel/testgame.cpp
+++ b/gamechannel/testgame.cpp
@@ -4,6 +4,7 @@
 
 #include "testgame.hpp"
 
+#include "movesender.hpp"
 #include "protoutils.hpp"
 #include "signatures.hpp"
 
@@ -127,6 +128,13 @@ public:
     return true;
   }
 
+  void
+  MaybeOnChainMove (MoveSender& sender) const
+  {
+    if (data.number == 100)
+      sender.SendMove (Json::Value ("100"));
+  }
+
 };
 
 } // anonymous namespace
@@ -172,6 +180,15 @@ AdditionChannel::MaybeAutoMove (const ParsedBoardState& state, BoardMove& mv)
 {
   const auto& addState = dynamic_cast<const AdditionState&> (state);
   return addState.MaybeAutoMove (mv);
+}
+
+void
+AdditionChannel::MaybeOnChainMove (const proto::ChannelMetadata& meta,
+                                   const ParsedBoardState& state,
+                                   MoveSender& sender)
+{
+  const auto& addState = dynamic_cast<const AdditionState&> (state);
+  addState.MaybeOnChainMove (sender);
 }
 
 void

--- a/gamechannel/testgame.cpp
+++ b/gamechannel/testgame.cpp
@@ -117,6 +117,16 @@ public:
     return res;
   }
 
+  bool
+  MaybeAutoMove (BoardMove& mv) const
+  {
+    if (data.number % 10 < 6)
+      return false;
+
+    mv = "2";
+    return true;
+  }
+
 };
 
 } // anonymous namespace
@@ -155,6 +165,13 @@ AdditionChannel::DisputeMove (const uint256& channelId,
   res["proof"] = ProtoToBase64 (proof);
 
   return res;
+}
+
+bool
+AdditionChannel::MaybeAutoMove (const ParsedBoardState& state, BoardMove& mv)
+{
+  const auto& addState = dynamic_cast<const AdditionState&> (state);
+  return addState.MaybeAutoMove (mv);
 }
 
 void

--- a/gamechannel/testgame.hpp
+++ b/gamechannel/testgame.hpp
@@ -70,6 +70,14 @@ public:
   Json::Value DisputeMove (const uint256& channelId,
                            const proto::StateProof& proof) const override;
 
+  /**
+   * When the last digit of the current number in the addition game is 6-9,
+   * we apply an automove of +2.  This way, we can test both a situation
+   * where just one automove is applied (8 -> 10) and one where
+   * two moves in a row are automatic (6 -> 8 -> 10).
+   */
+  bool MaybeAutoMove (const ParsedBoardState& state, BoardMove& mv) override;
+
 };
 
 /**

--- a/gamechannel/testgame.hpp
+++ b/gamechannel/testgame.hpp
@@ -78,6 +78,14 @@ public:
    */
   bool MaybeAutoMove (const ParsedBoardState& state, BoardMove& mv) override;
 
+  /**
+   * If the state reached exactly 100, then we send an on-chain move (that
+   * is just a string "100").  This can be triggered through auto-moves as well.
+   */
+  void MaybeOnChainMove (const proto::ChannelMetadata& meta,
+                         const ParsedBoardState& state,
+                         MoveSender& sender) override;
+
 };
 
 /**

--- a/gamechannel/testgame_tests.cpp
+++ b/gamechannel/testgame_tests.cpp
@@ -109,5 +109,51 @@ TEST_F (AdditionRulesTests, ApplyMoveInvalid)
   EXPECT_FALSE (ApplyMove ("42 1", "-1", newState));
 }
 
+class AdditionChannelTests : public TestGameFixture
+{
+
+private:
+
+  const uint256 channelId = SHA256::Hash ("foo");
+  proto::ChannelMetadata meta;
+
+protected:
+
+  /**
+   * Calls MaybeAutoMove after parsing the given state.
+   */
+  bool
+  MaybeAutoMove (const BoardState& state, BoardMove& mv)
+  {
+    const auto p = game.rules.ParseState (channelId, meta, state);
+    CHECK (p != nullptr);
+    return game.channel.MaybeAutoMove (*p, mv);
+  }
+
+};
+
+TEST_F (AdditionChannelTests, AutoMoves)
+{
+  BoardMove mv;
+
+  EXPECT_FALSE (MaybeAutoMove ("5 0", mv));
+  EXPECT_FALSE (MaybeAutoMove ("30 0", mv));
+
+  ASSERT_TRUE (MaybeAutoMove ("6 5", mv));
+  EXPECT_EQ (mv, "2");
+
+  ASSERT_TRUE (MaybeAutoMove ("17 5", mv));
+  EXPECT_EQ (mv, "2");
+
+  ASSERT_TRUE (MaybeAutoMove ("88 5", mv));
+  EXPECT_EQ (mv, "2");
+
+  ASSERT_TRUE (MaybeAutoMove ("99 5", mv));
+  EXPECT_EQ (mv, "2");
+
+  ASSERT_TRUE (MaybeAutoMove ("108 5", mv));
+  EXPECT_EQ (mv, "2");
+}
+
 } // anonymous namespace
 } // namespace xaya


### PR DESCRIPTION
This set of changes gives channel games the ability to define game-specific behaviour for sending "automatic moves" and specific on-chain moves based on updates to the board state in a channel (see #62).