### PR TITLE
OpenChannel implementation for Xayaships

### DIFF
--- a/gamechannel/channelmanager.cpp
+++ b/gamechannel/channelmanager.cpp
@@ -163,9 +163,7 @@ ChannelManager::ProcessStateUpdate (bool broadcast)
   TryResolveDispute ();
 
   if (onChainSender != nullptr)
-    game.MaybeOnChainMove (boardStates.GetMetadata (),
-                           boardStates.GetLatestState (),
-                           *onChainSender);
+    game.MaybeOnChainMove (boardStates.GetLatestState (), *onChainSender);
 
   NotifyStateChange ();
 }

--- a/gamechannel/openchannel.cpp
+++ b/gamechannel/openchannel.cpp
@@ -16,8 +16,7 @@ OpenChannel::MaybeAutoMove (const ParsedBoardState& state, BoardMove& mv)
 }
 
 void
-OpenChannel::MaybeOnChainMove (const proto::ChannelMetadata& meta,
-                               const ParsedBoardState& state,
+OpenChannel::MaybeOnChainMove (const ParsedBoardState& state,
                                MoveSender& sender)
 {}
 

--- a/gamechannel/openchannel.hpp
+++ b/gamechannel/openchannel.hpp
@@ -6,7 +6,6 @@
 #define GAMECHANNEL_OPENCHANNEL_HPP
 
 #include "boardrules.hpp"
-#include "proto/metadata.pb.h"
 #include "proto/stateproof.pb.h"
 
 #include <xayautil/uint256.hpp>
@@ -75,8 +74,7 @@ public:
    * (unlike auto moves, which are processed only if the player owning the
    * channel daemon is to play).
    */
-  virtual void MaybeOnChainMove (const proto::ChannelMetadata& meta,
-                                 const ParsedBoardState& state,
+  virtual void MaybeOnChainMove (const ParsedBoardState& state,
                                  MoveSender& sender);
 
 };

--- a/gamechannel/signatures.hpp
+++ b/gamechannel/signatures.hpp
@@ -9,6 +9,7 @@
 #include "proto/signatures.pb.h"
 
 #include <xayagame/rpc-stubs/xayarpcclient.h>
+#include <xayagame/rpc-stubs/xayawalletrpcclient.h>
 #include <xayautil/uint256.hpp>
 
 #include <set>
@@ -49,6 +50,17 @@ std::set<int> VerifyParticipantSignatures (XayaRpcClient& rpc,
                                            const proto::ChannelMetadata& meta,
                                            const std::string& topic,
                                            const proto::SignedData& data);
+
+/**
+ * Tries to sign the given data for the given participant index, using
+ * the provided Xaya wallet.  Returns true if a signature could be made.
+ */
+bool SignDataForParticipant (XayaWalletRpcClient& wallet,
+                             const uint256& channelId,
+                             const proto::ChannelMetadata& meta,
+                             const std::string& topic,
+                             int index,
+                             proto::SignedData& data);
 
 } // namespace xaya
 

--- a/gamechannel/stateproof_tests.cpp
+++ b/gamechannel/stateproof_tests.cpp
@@ -13,6 +13,7 @@
 
 #include <google/protobuf/text_format.h>
 
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include <glog/logging.h>

--- a/gamechannel/testgame.cpp
+++ b/gamechannel/testgame.cpp
@@ -183,8 +183,7 @@ AdditionChannel::MaybeAutoMove (const ParsedBoardState& state, BoardMove& mv)
 }
 
 void
-AdditionChannel::MaybeOnChainMove (const proto::ChannelMetadata& meta,
-                                   const ParsedBoardState& state,
+AdditionChannel::MaybeOnChainMove (const ParsedBoardState& state,
                                    MoveSender& sender)
 {
   const auto& addState = dynamic_cast<const AdditionState&> (state);

--- a/gamechannel/testgame.hpp
+++ b/gamechannel/testgame.hpp
@@ -82,8 +82,7 @@ public:
    * If the state reached exactly 100, then we send an on-chain move (that
    * is just a string "100").  This can be triggered through auto-moves as well.
    */
-  void MaybeOnChainMove (const proto::ChannelMetadata& meta,
-                         const ParsedBoardState& state,
+  void MaybeOnChainMove (const ParsedBoardState& state,
                          MoveSender& sender) override;
 
 };

--- a/ships/Makefile.am
+++ b/ships/Makefile.am
@@ -27,6 +27,7 @@ libships_la_LIBADD = \
   $(JSONCPP_LIBS) $(SQLITE3_CFLAGS) $(GLOG_LIBS) $(PROTOBUF_LIBS)
 libships_la_SOURCES = \
   board.cpp \
+  channel.cpp \
   coord.cpp \
   gamestatejson.cpp \
   grid.cpp \
@@ -35,6 +36,7 @@ libships_la_SOURCES = \
   $(PROTOSOURCES)
 noinst_HEADERS = \
   board.hpp \
+  channel.hpp \
   coord.hpp \
   gamestatejson.hpp \
   grid.hpp \
@@ -70,6 +72,7 @@ tests_LDADD = \
   $(JSONCPP_LIBS) $(GLOG_LIBS) $(GTEST_LIBS) $(PROTOBUF_LIBS)
 tests_SOURCES = \
   board_tests.cpp \
+  channel_tests.cpp \
   coord_tests.cpp \
   gamestatejson_tests.cpp \
   grid_tests.cpp \

--- a/ships/board.hpp
+++ b/ships/board.hpp
@@ -103,6 +103,12 @@ private:
                                     Phase phase,
                                     proto::BoardState& newState);
 
+  /* ShipsChannel handles the automoves and is thus directly tied to the
+     board state itself.  We split the logic out nevertheless, because then
+     there is a clear separation between "core board state" stuff (e.g.
+     applying moves) and the logic needed only for channel daemons.  */
+  friend class ShipsChannel;
+
   friend class BoardTests;
 
 protected:

--- a/ships/channel.cpp
+++ b/ships/channel.cpp
@@ -1,0 +1,84 @@
+// Copyright (C) 2019 The Xaya developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "channel.hpp"
+
+#include "board.hpp"
+#include "proto/winnerstatement.pb.h"
+
+#include <gamechannel/proto/signatures.pb.h>
+#include <gamechannel/protoutils.hpp>
+
+namespace ships
+{
+
+namespace
+{
+
+Json::Value
+DisputeResolutionMove (const std::string& type,
+                       const xaya::uint256& channelId,
+                       const xaya::proto::StateProof& p)
+{
+  Json::Value data(Json::objectValue);
+  data["id"] = channelId.ToHex ();
+  data["state"] = xaya::ProtoToBase64 (p);
+
+  Json::Value res(Json::objectValue);
+  res[type] = data;
+
+  return res;
+}
+
+} // anonymous namespace
+
+Json::Value
+ShipsChannel::ResolutionMove (const xaya::uint256& channelId,
+                              const xaya::proto::StateProof& p) const
+{
+  return DisputeResolutionMove ("r", channelId, p);
+}
+
+Json::Value
+ShipsChannel::DisputeMove (const xaya::uint256& channelId,
+                           const xaya::proto::StateProof& p) const
+{
+  return DisputeResolutionMove ("d", channelId, p);
+}
+
+void
+ShipsChannel::MaybeOnChainMove (const xaya::ParsedBoardState& state,
+                                xaya::MoveSender& sender)
+{
+  const auto& shipsState = dynamic_cast<const ShipsBoardState&> (state);
+  const auto& id = shipsState.GetChannelId ();
+  const auto& meta = shipsState.GetMetadata ();
+
+  if (shipsState.GetPhase () != ShipsBoardState::Phase::FINISHED)
+    return;
+
+  const auto& statePb = shipsState.GetState ();
+  CHECK (statePb.has_winner_statement ());
+  const auto& signedStmt = statePb.winner_statement ();
+
+  proto::WinnerStatement stmt;
+  CHECK (stmt.ParseFromString (signedStmt.data ()));
+  CHECK (stmt.has_winner ());
+  CHECK_GE (stmt.winner (), 0);
+  CHECK_LT (stmt.winner (), meta.participants_size ());
+  if (meta.participants (stmt.winner ()).name () != playerName)
+    return;
+
+  LOG (INFO) << "Channel has a winner statement and we won, closing on-chain";
+
+  Json::Value data(Json::objectValue);
+  data["id"] = id.ToHex ();
+  data["stmt"] = xaya::ProtoToBase64 (signedStmt);
+
+  Json::Value mv(Json::objectValue);
+  mv["w"] = data;
+  sender.SendMove (mv);
+}
+
+} // namespace ships

--- a/ships/channel.cpp
+++ b/ships/channel.cpp
@@ -4,14 +4,219 @@
 
 #include "channel.hpp"
 
-#include "board.hpp"
 #include "proto/winnerstatement.pb.h"
 
 #include <gamechannel/proto/signatures.pb.h>
 #include <gamechannel/protoutils.hpp>
+#include <gamechannel/signatures.hpp>
+#include <xayautil/hash.hpp>
 
 namespace ships
 {
+
+bool
+ShipsChannel::IsPositionSet () const
+{
+  return position.GetBits () != 0;
+}
+
+void
+ShipsChannel::SetPosition (const Grid& g)
+{
+  CHECK (!IsPositionSet ());
+
+  if (!VerifyPositionOfShips (g))
+    {
+      LOG (ERROR)
+          << "Cannot set " << g.GetBits () << " as position, that is invalid";
+      return;
+    }
+
+  position = g;
+  positionSalt = rnd.Get<xaya::uint256> ();
+  LOG (INFO)
+      << "Stored player position " << position.GetBits ()
+      << " and generated salt: " << positionSalt.ToHex ();
+
+  CHECK (IsPositionSet ());
+}
+
+proto::BoardMove
+ShipsChannel::GetShotMove (const Coord& c) const
+{
+  CHECK (c.IsOnBoard ());
+
+  proto::BoardMove res;
+  res.mutable_shot ()->set_location (c.GetIndex ());
+
+  return res;
+}
+
+proto::BoardMove
+ShipsChannel::GetPositionRevealMove () const
+{
+  CHECK (IsPositionSet ());
+
+  proto::BoardMove res;
+  auto* reveal = res.mutable_position_reveal ();
+  reveal->set_position (position.GetBits ());
+  reveal->set_salt (positionSalt.GetBinaryString ());
+
+  return res;
+}
+
+int
+ShipsChannel::GetPlayerIndex (const ShipsBoardState& state) const
+{
+  const auto& meta = state.GetMetadata ();
+
+  int res = -1;
+  for (int i = 0; i < meta.participants_size (); ++i)
+    if (meta.participants (i).name () == playerName)
+      {
+        CHECK_EQ (res, -1);
+        res = i;
+      }
+
+  CHECK_GE (res, 0);
+  CHECK_LE (res, 1);
+  return res;
+}
+
+bool
+ShipsChannel::AutoPositionCommitment (proto::BoardMove& mv)
+{
+  if (!IsPositionSet ())
+    return false;
+
+  xaya::SHA256 hasher;
+  hasher << position.Blob () << positionSalt;
+  const std::string hashStr = hasher.Finalise ().GetBinaryString ();
+
+  mv.mutable_position_commitment ()->set_position_hash (hashStr);
+  return true;
+}
+
+bool
+ShipsChannel::InternalAutoMove (const ShipsBoardState& state,
+                                proto::BoardMove& mv)
+{
+  const auto& id = state.GetChannelId ();
+  const auto& meta = state.GetMetadata ();
+  const auto& pb = state.GetState ();
+
+  const int index = GetPlayerIndex (state);
+  CHECK_EQ (index, pb.turn ());
+
+  const auto phase = state.GetPhase ();
+  switch (phase)
+    {
+    case ShipsBoardState::Phase::FIRST_COMMITMENT:
+      {
+        CHECK_EQ (index, 0);
+
+        if (!AutoPositionCommitment (mv))
+          return false;
+
+        seed0 = rnd.Get<xaya::uint256> ();
+        LOG (INFO) << "Random seed for first player: " << seed0.ToHex ();
+
+        xaya::SHA256 seedHasher;
+        seedHasher << seed0;
+        const std::string seedHash = seedHasher.Finalise ().GetBinaryString ();
+
+        mv.mutable_position_commitment ()->set_seed_hash (seedHash);
+        return true;
+      }
+
+    case ShipsBoardState::Phase::SECOND_COMMITMENT:
+      {
+        CHECK_EQ (index, 1);
+
+        if (!AutoPositionCommitment (mv))
+          return false;
+
+        const auto seed1 = rnd.Get<xaya::uint256> ();
+        LOG (INFO) << "Random seed for second player: " << seed1.ToHex ();
+
+        mv.mutable_position_commitment ()->set_seed (seed1.GetBinaryString ());
+        return true;
+      }
+
+    case ShipsBoardState::Phase::FIRST_REVEAL_SEED:
+      {
+        CHECK_EQ (index, 0);
+        mv.mutable_seed_reveal ()->set_seed (seed0.GetBinaryString ());
+        return true;
+      }
+
+    case ShipsBoardState::Phase::SHOOT:
+      {
+        /* If we already hit all ships of the opponent, then we go on
+           to reveal our position to ensure that we win.  */
+
+        const int other = 1 - index;
+        CHECK_GE (other, 0);
+        CHECK_LE (other, 1);
+
+        const Grid hits(pb.known_ships (other).hits ());
+        if (hits.CountOnes () >= Grid::TotalShipCells ())
+          {
+            LOG (INFO) << "We hit all opponent ships, revealing";
+            mv = GetPositionRevealMove ();
+            return true;
+          }
+
+        return false;
+      }
+
+    case ShipsBoardState::Phase::ANSWER:
+      {
+        CHECK (IsPositionSet ());
+        const Coord target(pb.current_shot ());
+        CHECK (target.IsOnBoard ());
+
+        const bool hit = position.Get (target);
+        mv.mutable_reply ()->set_reply (hit ? proto::ReplyMove::HIT
+                                            : proto::ReplyMove::MISS);
+        return true;
+      }
+
+    case ShipsBoardState::Phase::SECOND_REVEAL_POSITION:
+      {
+        mv = GetPositionRevealMove ();
+        return true;
+      }
+
+    case ShipsBoardState::Phase::WINNER_DETERMINED:
+      {
+        CHECK (pb.has_winner ());
+
+        proto::WinnerStatement stmt;
+        stmt.set_winner (pb.winner ());
+
+        CHECK_NE (index, stmt.winner ());
+
+        auto* data = mv.mutable_winner_statement ()->mutable_statement ();
+        CHECK (stmt.SerializeToString (data->mutable_data ()));
+
+        if (!xaya::SignDataForParticipant (wallet, id, meta, "winnerstatement",
+                                           index, *data))
+          {
+            LOG (ERROR)
+                << "Tried to send winner statement, but signature failed";
+            return false;
+          }
+
+        return true;
+      }
+
+    case ShipsBoardState::Phase::FINISHED:
+    default:
+      LOG (FATAL)
+          << "Invalid phase for auto move: " << static_cast<int> (phase);
+    }
+}
 
 namespace
 {
@@ -45,6 +250,20 @@ ShipsChannel::DisputeMove (const xaya::uint256& channelId,
                            const xaya::proto::StateProof& p) const
 {
   return DisputeResolutionMove ("d", channelId, p);
+}
+
+bool
+ShipsChannel::MaybeAutoMove (const xaya::ParsedBoardState& state,
+                             xaya::BoardMove& mv)
+{
+  const auto& shipsState = dynamic_cast<const ShipsBoardState&> (state);
+
+  proto::BoardMove mvPb;
+  if (!InternalAutoMove (shipsState, mvPb))
+    return false;
+
+  CHECK (mvPb.SerializeToString (&mv));
+  return true;
 }
 
 void

--- a/ships/channel.hpp
+++ b/ships/channel.hpp
@@ -5,14 +5,23 @@
 #ifndef XAYASHIPS_CHANNEL_HPP
 #define XAYASHIPS_CHANNEL_HPP
 
+#include "board.hpp"
+#include "coord.hpp"
+#include "grid.hpp"
+
+#include "proto/boardmove.pb.h"
+
 #include <gamechannel/boardrules.hpp>
 #include <gamechannel/openchannel.hpp>
 #include <gamechannel/movesender.hpp>
 #include <gamechannel/proto/stateproof.pb.h>
+#include <xayagame/rpc-stubs/xayawalletrpcclient.h>
+#include <xayautil/cryptorand.hpp>
 #include <xayautil/uint256.hpp>
 
 #include <json/json.h>
 
+#include <cstdint>
 #include <string>
 
 namespace ships
@@ -27,13 +36,48 @@ class ShipsChannel : public xaya::OpenChannel
 
 private:
 
+  /** RPC connection to the wallet (for signing winner statements).  */
+  XayaWalletRpcClient& wallet;
+
   /** The player name who is running this channel daemon.  */
   const std::string playerName;
 
+  /** Generator for random salt values.  */
+  xaya::CryptoRand rnd;
+
+  /** The position of this player.  */
+  Grid position;
+
+  /** Salt for the position hash.  */
+  xaya::uint256 positionSalt;
+
+  /**
+   * If this channel corresponds to the first player, then we save the
+   * seed for determining the initial player here.
+   */
+  xaya::uint256 seed0;
+
+  /**
+   * Returns the index that the current player has for the given state.
+   */
+  int GetPlayerIndex (const ShipsBoardState& state) const;
+
+  /**
+   * Tries to do a position-commitment move (either for the first or second
+   * player) as automove.  Returns true if possible (i.e. we have a position).
+   */
+  bool AutoPositionCommitment (proto::BoardMove& mv);
+
+  /**
+   * Real implementation of MaybeAutoMove, for which the conversion to
+   * ShipsBoardState and between the proto and BoardMove is taken care of.
+   */
+  bool InternalAutoMove (const ShipsBoardState& state, proto::BoardMove& mv);
+
 public:
 
-  ShipsChannel (const std::string& nm)
-    : playerName(nm)
+  explicit ShipsChannel (XayaWalletRpcClient& w, const std::string& nm)
+    : wallet(w), playerName(nm)
   {}
 
   ShipsChannel (const ShipsChannel&) = delete;
@@ -44,8 +88,36 @@ public:
   Json::Value DisputeMove (const xaya::uint256& channelId,
                            const xaya::proto::StateProof& p) const override;
 
+  bool MaybeAutoMove (const xaya::ParsedBoardState& state,
+                      xaya::BoardMove& mv) override;
   void MaybeOnChainMove (const xaya::ParsedBoardState& state,
                          xaya::MoveSender& sender) override;
+
+  /**
+   * Returns true if the position has already been initialised.
+   */
+  bool IsPositionSet () const;
+
+  /**
+   * Sets the player's position from the given Grid if it is valid.
+   * Must not be called if IsPositionSet() is already true.
+   */
+  void SetPosition (const Grid& g);
+
+  /**
+   * Returns a ShotMove for the given target coordinate.
+   */
+  proto::BoardMove GetShotMove (const Coord& c) const;
+
+  /**
+   * Returns the move for revealing the player's position.  This is sent as
+   * auto move if the other player revealed already or if all of their ships
+   * have been hit, but it may also be used explicitly if the player
+   * requests a revelation because they suspect fraud.
+   *
+   * This must only be called if IsPositionSet() is true.
+   */
+  proto::BoardMove GetPositionRevealMove () const;
 
 };
 

--- a/ships/channel.hpp
+++ b/ships/channel.hpp
@@ -1,0 +1,54 @@
+// Copyright (C) 2019 The Xaya developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef XAYASHIPS_CHANNEL_HPP
+#define XAYASHIPS_CHANNEL_HPP
+
+#include <gamechannel/boardrules.hpp>
+#include <gamechannel/openchannel.hpp>
+#include <gamechannel/movesender.hpp>
+#include <gamechannel/proto/stateproof.pb.h>
+#include <xayautil/uint256.hpp>
+
+#include <json/json.h>
+
+#include <string>
+
+namespace ships
+{
+
+/**
+ * Ships-specific data and logic for an open channel the player is involved
+ * in.  This mostly takes care of the various commit-reveal schemes.
+ */
+class ShipsChannel : public xaya::OpenChannel
+{
+
+private:
+
+  /** The player name who is running this channel daemon.  */
+  const std::string playerName;
+
+public:
+
+  ShipsChannel (const std::string& nm)
+    : playerName(nm)
+  {}
+
+  ShipsChannel (const ShipsChannel&) = delete;
+  void operator= (const ShipsChannel&) = delete;
+
+  Json::Value ResolutionMove (const xaya::uint256& channelId,
+                              const xaya::proto::StateProof& p) const override;
+  Json::Value DisputeMove (const xaya::uint256& channelId,
+                           const xaya::proto::StateProof& p) const override;
+
+  void MaybeOnChainMove (const xaya::ParsedBoardState& state,
+                         xaya::MoveSender& sender) override;
+
+};
+
+} // namespace ships
+
+#endif // XAYASHIPS_CHANNEL_HPP

--- a/ships/channel_tests.cpp
+++ b/ships/channel_tests.cpp
@@ -1,0 +1,258 @@
+// Copyright (C) 2019 The Xaya developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "channel.hpp"
+
+#include "board.hpp"
+#include "proto/boardstate.pb.h"
+#include "proto/winnerstatement.pb.h"
+#include "testutils.hpp"
+
+#include <gamechannel/protoutils.hpp>
+#include <xayagame/rpc-stubs/xayawalletrpcclient.h>
+#include <xayagame/testutils.hpp>
+#include <xayautil/hash.hpp>
+
+#include <jsonrpccpp/client/connectors/httpclient.h>
+#include <jsonrpccpp/server/connectors/httpserver.h>
+
+#include <google/protobuf/text_format.h>
+#include <google/protobuf/util/message_differencer.h>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <glog/logging.h>
+
+namespace ships
+{
+namespace
+{
+
+using google::protobuf::TextFormat;
+using google::protobuf::util::MessageDifferencer;
+using testing::Return;
+using testing::Truly;
+
+/**
+ * Parses a text-format state proto.
+ */
+proto::BoardState
+TextState (const std::string& str)
+{
+  proto::BoardState res;
+  CHECK (TextFormat::ParseFromString (str, &res));
+  return res;
+}
+
+/**
+ * Parses a text-format state proof proto.
+ */
+xaya::proto::StateProof
+TextProof (const std::string& str)
+{
+  xaya::proto::StateProof res;
+  CHECK (TextFormat::ParseFromString (str, &res));
+  return res;
+}
+
+/**
+ * Builds a winner statement with (fake) signatures for the given winner.
+ */
+xaya::proto::SignedData
+FakeWinnerStatement (const int winner)
+{
+  proto::WinnerStatement stmt;
+  stmt.set_winner (winner);
+
+  xaya::proto::SignedData res;
+  CHECK (stmt.SerializeToString (res.mutable_data ()));
+  res.add_signatures ("sgn");
+
+  return res;
+}
+
+class ChannelTests : public testing::Test
+{
+
+protected:
+
+  const xaya::uint256 channelId = xaya::SHA256::Hash ("foo");
+
+  /** In the metadata, "we" are player 0.  */
+  xaya::proto::ChannelMetadata meta;
+
+  ShipsBoardRules rules;
+  ShipsChannel channel;
+
+  ChannelTests ()
+    : channel("player")
+  {
+    CHECK (TextFormat::ParseFromString (R"(
+      participants:
+        {
+          name: "player"
+          address: "my addr"
+        }
+      participants:
+        {
+          name: "other player"
+          address: "other addr"
+        }
+    )", &meta));
+  }
+
+  /**
+   * Parses a BoardState proto into a ParsedBoardState.
+   */
+  std::unique_ptr<xaya::ParsedBoardState>
+  ParseState (const proto::BoardState& pb)
+  {
+    std::string serialised;
+    CHECK (pb.SerializeToString (&serialised));
+
+    auto res = rules.ParseState (channelId, meta, serialised);
+    CHECK (res != nullptr);
+
+    return res;
+  }
+
+};
+
+/* ************************************************************************** */
+
+class OnChainMoveTests : public ChannelTests
+{
+
+private:
+
+  jsonrpc::HttpServer httpServerWallet;
+  jsonrpc::HttpClient httpClientWallet;
+
+protected:
+
+  xaya::MockXayaWalletRpcServer mockXayaWallet;
+  XayaWalletRpcClient rpcWallet;
+
+  xaya::MoveSender sender;
+
+  OnChainMoveTests ()
+    : httpServerWallet(xaya::MockXayaWalletRpcServer::HTTP_PORT),
+      httpClientWallet(xaya::MockXayaWalletRpcServer::HTTP_URL),
+      mockXayaWallet(httpServerWallet),
+      rpcWallet(httpClientWallet),
+      sender("xs", channelId, "player", rpcWallet, channel)
+  {
+    mockXayaWallet.StartListening ();
+  }
+
+  ~OnChainMoveTests ()
+  {
+    mockXayaWallet.StopListening ();
+  }
+
+  /**
+   * Verifies that a given JSON object matches the expected move format
+   * for the given key ("r", "d" or "w"), channel ID and encoded data proto.
+   * Note that all three types of moves (disputes, resolutions and channel
+   * closes with WinnerStatement's) have the same basic structure.
+   */
+  template <typename Proto>
+    static bool
+    IsExpectedMove (const Json::Value& actual,
+                    const std::string& key, const std::string& protoKey,
+                    const xaya::uint256& id, const Proto& expectedPb)
+  {
+    if (!actual.isObject ())
+      return false;
+    if (actual.size () != 1)
+      return false;
+
+    const auto& sub = actual[key];
+    if (!sub.isObject ())
+      return false;
+    if (sub.size () != 2)
+      return false;
+
+    if (!sub["id"].isString ())
+      return false;
+    if (sub["id"].asString () != id.ToHex ())
+      return false;
+
+    if (!sub[protoKey].isString ())
+      return false;
+
+    Proto actualPb;
+    if (!xaya::ProtoFromBase64 (sub[protoKey].asString (), actualPb))
+      return false;
+
+    return MessageDifferencer::Equals (actualPb, expectedPb);
+  }
+
+};
+
+TEST_F (OnChainMoveTests, ResolutionMove)
+{
+  const auto proof = TextProof (R"(
+    initial_state:
+      {
+        data: ""
+        signatures: "sgn 0"
+      }
+  )");
+
+  EXPECT_TRUE (IsExpectedMove (channel.ResolutionMove (channelId, proof),
+                               "r", "state", channelId, proof));
+}
+
+TEST_F (OnChainMoveTests, DisputeMove)
+{
+  const auto proof = TextProof (R"(
+    initial_state:
+      {
+        data: ""
+        signatures: "sgn 0"
+      }
+  )");
+
+  EXPECT_TRUE (IsExpectedMove (channel.DisputeMove (channelId, proof),
+                               "d", "state", channelId, proof));
+}
+
+TEST_F (OnChainMoveTests, MaybeOnChainMoveNotFinished)
+{
+  channel.MaybeOnChainMove (*ParseState (TextState ("turn: 0")), sender);
+}
+
+TEST_F (OnChainMoveTests, MaybeOnChainMoveNotMe)
+{
+  proto::BoardState state;
+  *state.mutable_winner_statement () = FakeWinnerStatement (1);
+
+  channel.MaybeOnChainMove (*ParseState (state), sender);
+}
+
+TEST_F (OnChainMoveTests, MaybeOnChainMoveSending)
+{
+  const auto stmt = FakeWinnerStatement (0);
+
+  const auto isOk = [this, stmt] (const std::string& str)
+    {
+      const auto val = ParseJson (str);
+      const auto& mv = val["g"]["xs"];
+      return IsExpectedMove (mv, "w", "stmt", channelId, stmt);
+    };
+  EXPECT_CALL (mockXayaWallet, name_update ("p/player", Truly (isOk)))
+      .WillOnce (Return (xaya::SHA256::Hash ("txid").ToHex ()));
+
+  proto::BoardState state;
+  *state.mutable_winner_statement () = stmt;
+
+  channel.MaybeOnChainMove (*ParseState (state), sender);
+}
+
+/* ************************************************************************** */
+
+} // anonymous namespace
+} // namespace ships

--- a/ships/gamestatejson_tests.cpp
+++ b/ships/gamestatejson_tests.cpp
@@ -7,7 +7,7 @@
 #include "proto/boardstate.pb.h"
 #include "testutils.hpp"
 
-#include <xayautil/base64.hpp>
+#include <gamechannel/protoutils.hpp>
 #include <xayautil/hash.hpp>
 
 #include <google/protobuf/text_format.h>
@@ -164,11 +164,9 @@ TEST_F (GameStateJsonTests, TwoParticipantChannel)
   EXPECT_EQ (stateJson["turncount"].asInt (), 1);
   EXPECT_EQ (stateJson["parsed"]["phase"].asString (), "first commitment");
 
-  std::string protoBytes;
-  ASSERT_TRUE (xaya::DecodeBase64 (stateJson["base64"].asString (),
-                                   protoBytes));
   proto::BoardState stateFromJson;
-  ASSERT_TRUE (stateFromJson.ParseFromString (protoBytes));
+  ASSERT_TRUE (xaya::ProtoFromBase64 (stateJson["base64"].asString (),
+                                      stateFromJson));
   EXPECT_TRUE (MessageDifferencer::Equals (state, stateFromJson));
 }
 

--- a/ships/logic.cpp
+++ b/ships/logic.cpp
@@ -9,7 +9,7 @@
 
 #include <gamechannel/database.hpp>
 #include <gamechannel/proto/stateproof.pb.h>
-#include <xayautil/base64.hpp>
+#include <gamechannel/protoutils.hpp>
 
 #include <glog/logging.h>
 
@@ -300,16 +300,9 @@ template <typename T>
     return false;
   const std::string str = val.asString ();
 
-  std::string bytes;
-  if (!xaya::DecodeBase64 (val.asString (), bytes))
+  if (!xaya::ProtoFromBase64 (val.asString (), res))
     {
-      LOG (WARNING) << "Invalid base64: " << str;
-      return false;
-    }
-
-  if (!res.ParseFromString (bytes))
-    {
-      LOG (WARNING) << "Failed to decode serialised proto";
+      LOG (WARNING) << "Could not get proto from base64 string";
       return false;
     }
 

--- a/ships/logic_tests.cpp
+++ b/ships/logic_tests.cpp
@@ -9,6 +9,7 @@
 
 #include <gamechannel/database.hpp>
 #include <gamechannel/proto/stateproof.pb.h>
+#include <gamechannel/protoutils.hpp>
 #include <gamechannel/signatures.hpp>
 #include <xayautil/base64.hpp>
 #include <xayautil/hash.hpp>
@@ -600,10 +601,7 @@ protected:
     Json::Value data(Json::objectValue);
     data["w"] = Json::Value (Json::objectValue);
     data["w"]["id"] = channelId.ToHex ();
-
-    std::string serialised;
-    CHECK (signedData.SerializeToString (&serialised));
-    data["w"]["stmt"] = xaya::EncodeBase64 (serialised);
+    data["w"]["stmt"] = xaya::ProtoToBase64 (signedData);
 
     return Move ("xyz", txid, data);
   }
@@ -817,10 +815,7 @@ protected:
     Json::Value data(Json::objectValue);
     data[key] = Json::Value (Json::objectValue);
     data[key]["id"] = channelId.ToHex ();
-
-    std::string serialised;
-    CHECK (proof.SerializeToString (&serialised));
-    data[key]["state"] = xaya::EncodeBase64 (serialised);
+    data[key]["state"] = xaya::ProtoToBase64 (proof);
 
     return Move ("xyz", txid, data);
   }

--- a/xayautil/Makefile.am
+++ b/xayautil/Makefile.am
@@ -7,11 +7,13 @@ libxayautil_la_CXXFLAGS = $(OPENSSL_CFLAGS) $(GLOG_CFLAGS)
 libxayautil_la_LIBADD = $(OPENSSL_LIBS) $(GLOG_LIBS)
 libxayautil_la_SOURCES = \
   base64.cpp \
+  cryptorand.cpp \
   hash.cpp \
   random.cpp \
   uint256.cpp
 xayautil_HEADERS = \
   base64.hpp \
+  cryptorand.hpp \
   hash.hpp \
   random.hpp \
   uint256.hpp
@@ -24,6 +26,7 @@ tests_LDADD = $(builddir)/libxayautil.la \
   $(GLOG_LIBS) $(GTEST_LIBS)
 tests_SOURCES = \
   base64_tests.cpp \
+  cryptorand_tests.cpp \
   hash_tests.cpp \
   random_tests.cpp \
   uint256_tests.cpp

--- a/xayautil/cryptorand.cpp
+++ b/xayautil/cryptorand.cpp
@@ -1,0 +1,27 @@
+// Copyright (C) 2019 The Xaya developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "cryptorand.hpp"
+
+#include <glog/logging.h>
+
+#include <openssl/rand.h>
+
+namespace xaya
+{
+
+template <>
+  uint256
+  CryptoRand::Get<uint256> ()
+{
+  unsigned char bytes[uint256::NUM_BYTES];
+  CHECK_EQ (RAND_bytes (bytes, uint256::NUM_BYTES), 1);
+
+  uint256 res;
+  res.FromBlob (bytes);
+
+  return res;
+}
+
+} // namespace xaya

--- a/xayautil/cryptorand.hpp
+++ b/xayautil/cryptorand.hpp
@@ -1,0 +1,38 @@
+// Copyright (C) 2019 The Xaya developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef XAYAUTIL_CRYPTORAND_HPP
+#define XAYAUTIL_CRYPTORAND_HPP
+
+#include "uint256.hpp"
+
+namespace xaya
+{
+
+/**
+ * Generator for secure random data, i.e. not deterministic like Random.
+ * This can be used e.g. to generate hash commitments and salt values for
+ * channel games.
+ */
+class CryptoRand
+{
+
+public:
+
+  CryptoRand () = default;
+
+  CryptoRand (const CryptoRand&) = delete;
+  void operator= (const CryptoRand&) = delete;
+
+  /**
+   * Returns a random value of given type (e.g. uint256).
+   */
+  template <typename T>
+    T Get ();
+
+};
+
+} // namespace xaya
+
+#endif // XAYAUTIL_CRYPTORAND_HPP

--- a/xayautil/cryptorand_tests.cpp
+++ b/xayautil/cryptorand_tests.cpp
@@ -1,0 +1,46 @@
+// Copyright (C) 2019 The Xaya developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "cryptorand.hpp"
+
+#include <gtest/gtest.h>
+
+#include <glog/logging.h>
+
+#include <set>
+
+namespace xaya
+{
+namespace
+{
+
+TEST (CryptoRandTests, Uint256)
+{
+  /* This test obviously cannot verify that the returned bytes are truly
+     random.  It just makes sure the function actually "works" (e.g. does not
+     crash) and does not have obvious errors.  */
+
+  constexpr unsigned generators = 10;
+  constexpr unsigned tries = 1000;
+
+  std::set<uint256> found;
+
+  for (unsigned i = 0; i < generators; ++i)
+    {
+      CryptoRand rnd;
+      for (unsigned j = 0; j < tries; ++j)
+        {
+          const auto num = rnd.Get<uint256> ();
+          if (i == 0 && j == 0)
+            LOG (INFO) << "First random number: " << num.ToHex ();
+          ASSERT_FALSE (num.IsNull ());
+          found.insert (num);
+        }
+    }
+
+  ASSERT_EQ (found.size (), generators * tries);
+}
+
+} // anonymous namespace
+} // namespace xaya


### PR DESCRIPTION
This adds the `OpenChannel` implementation for Xayaships.  It handles automatic moves and all necessary storage of "local" data.  In particular, all the initial commit-reveal sequence is done automatically; shots are answered automatically; the game is ended automatically when all opponent ships have been hit; winner statements are signed automatically; and the on-chain close move with a winner statement is sent automatically.

With this change in, all the "actual" game logic for Xayaships is there.  This is a first major milestone towards #70.