### PR TITLE
Correctly reference metadata in ParsedBoardState

### DIFF
--- a/gamechannel/boardrules.hpp
+++ b/gamechannel/boardrules.hpp
@@ -40,9 +40,28 @@ using BoardMove = std::string;
 class ParsedBoardState
 {
 
+private:
+
+  /**
+   * A reference to the channel ID.  This is stored in the constructor and
+   * can be accessed by subclasses.
+   */
+  const uint256& channelId;
+
+  /**
+   * A reference to the channel's metadata.  This is stored in the constructor
+   * (from the BoardRules instance) and can be accessed by subclasses as
+   * they need it for the game logic.  The reference originally comes from
+   * BoardRules::ParseState, by which it is guaranteed to be valid as long
+   * as the instance of the parsed state is there.
+   */
+  const proto::ChannelMetadata& meta;
+
 protected:
 
-  ParsedBoardState () = default;
+  explicit ParsedBoardState (const uint256& id, const proto::ChannelMetadata& m)
+    : channelId(id), meta(m)
+  {}
 
 public:
 
@@ -54,6 +73,24 @@ public:
   static constexpr int NO_TURN = -1;
 
   virtual ~ParsedBoardState () = default;
+
+  /**
+   * Returns the channel ID.
+   */
+  const uint256&
+  GetChannelId () const
+  {
+    return channelId;
+  }
+
+  /**
+   * Returns the metadata associated with this channel state.
+   */
+  const proto::ChannelMetadata&
+  GetMetadata () const
+  {
+    return meta;
+  }
 
   /**
    * Compares the current state to the given other board state.  Returns true
@@ -130,8 +167,8 @@ public:
    * nullptr instead.
    *
    * The passed-in ID and metadata can be used to put the board state into
-   * context.  It is guaranteed that the reference stays valid at least as
-   * long as the returned ParsedBoardState instance will be alive.
+   * context.  It is guaranteed that the references stay valid at least as
+   * long as the returned ParsedBoardState instance will be kept alive.
    */
   virtual std::unique_ptr<ParsedBoardState> ParseState (
       const uint256& channelId, const proto::ChannelMetadata& meta,

--- a/gamechannel/protoboard.hpp
+++ b/gamechannel/protoboard.hpp
@@ -30,19 +30,6 @@ template <typename State, typename Move>
 
 private:
 
-  /**
-   * A reference to the channel ID.  This is stored in the constructor and
-   * can be accessed by subclasses.
-   */
-  const uint256& channelId;
-
-  /**
-   * A reference to the channel's metadata.  This is stored in the constructor
-   * (from the BoardRules instance) and can be accessed by subclasses as
-   * they need it for the game logic.
-   */
-  const proto::ChannelMetadata& meta;
-
   /** The parsed state proto itself.  */
   State state;
 
@@ -86,24 +73,6 @@ public:
   ProtoBoardState () = delete;
   ProtoBoardState (const ProtoBoardState<State, Move>&) = delete;
   void operator= (const ProtoBoardState<State, Move>&) = delete;
-
-  /**
-   * Returns the channel ID.
-   */
-  const uint256&
-  GetChannelId () const
-  {
-    return channelId;
-  }
-
-  /**
-   * Returns the metadata associated with this channel state.
-   */
-  const proto::ChannelMetadata&
-  GetMetadata () const
-  {
-    return meta;
-  }
 
   /**
    * Returns the protocol buffer representing the current state.

--- a/gamechannel/protoboard.tpp
+++ b/gamechannel/protoboard.tpp
@@ -16,7 +16,7 @@ namespace xaya
 template <typename State, typename Move>
   ProtoBoardState<State, Move>::ProtoBoardState (
       const uint256& id, const proto::ChannelMetadata& m, State&& s)
-  : channelId(id), meta(m)
+  : ParsedBoardState(id, m)
 {
   state.Swap (&s);
 }

--- a/gamechannel/rollingstate.hpp
+++ b/gamechannel/rollingstate.hpp
@@ -43,8 +43,13 @@ private:
   struct ReinitData
   {
 
-    /** The metadata for this reinitialisation.  */
-    proto::ChannelMetadata meta;
+    /**
+     * The metadata for this reinitialisation.  We keep a pointer to it rather
+     * than the instance itself, because a reference to the proto is encoded
+     * in latestState and we need it to remain valid even if the instance
+     * gets moved around.
+     */
+    std::unique_ptr<proto::ChannelMetadata> meta;
 
     /** The initial state for that reinitialisation.  */
     BoardState reinitState;

--- a/gamechannel/testgame.cpp
+++ b/gamechannel/testgame.cpp
@@ -55,8 +55,9 @@ private:
 
 public:
 
-  explicit AdditionState (const ParsedState& d)
-    : data(d)
+  explicit AdditionState (const uint256& id, const proto::ChannelMetadata& m,
+                          const ParsedState& d)
+    : ParsedBoardState(id, m), data(d)
   {}
 
   AdditionState () = delete;
@@ -148,7 +149,7 @@ AdditionRules::ParseState (const uint256& channelId,
   if (!ParsePair (state, p))
     return nullptr;
 
-  return std::make_unique<AdditionState> (p);
+  return std::make_unique<AdditionState> (channelId, meta, p);
 }
 
 Json::Value


### PR DESCRIPTION
`ParsedBoardState`'s (with this change, previously just `ProtoBoardState`'s) contain a *reference* to a `ChannelMetadata` proto.  This reference comes from `BoardRules::ParseState`, and is must be valid as long as the `ParsedBoardState` instance is alive.

This assumption was violated previously in `RollingBoardState`, because we used a temporary metadata instance rather than the copy stored in a reinit entry for parsing the states.  With this change, we fix this, so that no bad references are used.