### PR TITLE
Integration tests for Xayaships channel daemon

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -50,6 +50,7 @@ AC_CONFIG_FILES([
   mover/Makefile \
   mover/gametest/Makefile \
   ships/Makefile \
+  ships/channeltest/Makefile \
   ships/gametest/Makefile \
   xayagame/Makefile \
   xayagametest/Makefile \

--- a/gamechannel/Makefile.am
+++ b/gamechannel/Makefile.am
@@ -84,6 +84,7 @@ PYTHONTESTS = \
 noinst_PYTHON = $(PYTHONTESTS)
 py_PYTHON = \
   __init__.py \
+  channeltest.py \
   rpcbroadcast.py \
   signatures.py
 pyproto_PYTHON = proto/__init__.py $(PROTOPY)

--- a/gamechannel/broadcast_tests.cpp
+++ b/gamechannel/broadcast_tests.cpp
@@ -112,20 +112,20 @@ protected:
 
 TEST_F (BroadcastTests, Participants)
 {
-  cm.ProcessOnChain (meta, "0 0", ValidProof ("10 5"), 0);
+  ProcessOnChain ("0 0", ValidProof ("10 5"), 0);
   ExpectParticipants ({"player", "other"});
 
-  cm.ProcessOnChainNonExistant ();
+  ProcessOnChainNonExistant ();
   ExpectParticipants ({});
 }
 
 TEST_F (BroadcastTests, FeedingMoves)
 {
   meta.set_reinit ("reinit");
-  cm.ProcessOnChain (meta, "0 0", ValidProof ("1 2"), 0);
+  ProcessOnChain ("0 0", ValidProof ("1 2"), 0);
 
   meta.clear_reinit ();
-  cm.ProcessOnChain (meta, "0 0", ValidProof ("0 0"), 0);
+  ProcessOnChain ("0 0", ValidProof ("0 0"), 0);
 
   offChain.SendNewState ("", ValidProof ("10 5"));
   offChain.SendNewState ("reinit", ValidProof ("9 10"));
@@ -138,13 +138,13 @@ TEST_F (BroadcastTests, FeedingMoves)
   EXPECT_EQ (GetLatestState (), "10 5");
 
   meta.set_reinit ("reinit");
-  cm.ProcessOnChain (meta, "0 0", ValidProof ("1 2"), 0);
+  ProcessOnChain ("0 0", ValidProof ("1 2"), 0);
   EXPECT_EQ (GetLatestState (), "9 10");
 }
 
 TEST_F (BroadcastTests, BeyondTimeout)
 {
-  cm.ProcessOnChain (meta, "0 0", ValidProof ("0 0"), 0);
+  ProcessOnChain ("0 0", ValidProof ("0 0"), 0);
   offChain.SendNewState ("", ValidProof ("10 5"));
 
   /* Even without a notification, we will get the new state because the

--- a/gamechannel/channelmanager.hpp
+++ b/gamechannel/channelmanager.hpp
@@ -148,6 +148,11 @@ private:
    */
   bool exists = false;
 
+  /** The latest block hash for which we did an on-chain update.  */
+  uint256 blockHash;
+  /** The height of the latest on-chain update we know of.  */
+  unsigned onChainHeight;
+
   /** Data about an open dispute, if any.  */
   std::unique_ptr<DisputeData> dispute;
 
@@ -241,12 +246,13 @@ public:
   /**
    * Processes an on-chain update that did not contain any data for our channel.
    */
-  void ProcessOnChainNonExistant ();
+  void ProcessOnChainNonExistant (const uint256& blk, unsigned h);
 
   /**
    * Processes a (potentially) new on-chain state for the channel.
    */
-  void ProcessOnChain (const proto::ChannelMetadata& meta,
+  void ProcessOnChain (const uint256& blk, unsigned h,
+                       const proto::ChannelMetadata& meta,
                        const BoardState& reinitState,
                        const proto::StateProof& proof,
                        unsigned disputeHeight);

--- a/gamechannel/channelmanager_tests.hpp
+++ b/gamechannel/channelmanager_tests.hpp
@@ -26,6 +26,9 @@ class ChannelManagerTestFixture : public TestGameFixture
 
 protected:
 
+  const uint256 blockHash = SHA256::Hash ("block hash");
+  const unsigned height = 42;
+
   const uint256 channelId = SHA256::Hash ("channel id");
   proto::ChannelMetadata meta;
 
@@ -33,6 +36,30 @@ protected:
 
   ChannelManagerTestFixture ();
   ~ChannelManagerTestFixture ();
+
+  /**
+   * Processes an on-chain update with fixed block hash and height, our
+   * metadata and for the given data state.
+   */
+  void ProcessOnChain (const BoardState& reinitState,
+                       const proto::StateProof& proof,
+                       unsigned dispHeight);
+
+  /**
+   * Processes an on-chain update without the channel for our fixed block height
+   * and hash.
+   */
+  void ProcessOnChainNonExistant ();
+
+  /**
+   * Returns the manager's current block hash and height.
+   */
+  const uint256&
+  GetOnChainBlock (unsigned& height) const
+  {
+    height = cm.onChainHeight;
+    return cm.blockHash;
+  }
 
   /**
    * Extracts the latest state from boardStates.

--- a/gamechannel/channeltest.py
+++ b/gamechannel/channeltest.py
@@ -1,0 +1,243 @@
+# Copyright (C) 2019 The Xaya developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+"""
+Integration tests running channel daemons in addition to Xaya Core
+on regtest and a GSP.
+"""
+
+import rpcbroadcast
+
+from xayagametest.testcase import XayaGameTest
+
+import jsonrpclib
+import logging
+import os
+import os.path
+import random
+import shutil
+import subprocess
+import threading
+import time
+
+
+class Daemon ():
+  """
+  An instance of a game's channel daemon, connected to a regtest
+  Xaya Core and the game's GSP.
+
+  This class is used for the Xayaships and game-channel integration tests,
+  but other games can use it as well if their channel daemons:
+
+  * Have the --xaya_rpc_url, --gsp_rpc_url, --broadcast_rpc_url,
+    --rpc_port, --playername and --channelid flags of ships-channel, and
+  * provide the "stop" and "getcurrentstate" RPC methods.
+  """
+
+  def __init__ (self, channelId, playerName, basedir, port, binary):
+    self.log = logging.getLogger ("gamechannel.channeltest.Daemon")
+    self.channelId = channelId
+    self.playerName = playerName
+    self.datadir = os.path.join (basedir, "channel_%s" % playerName)
+    self.port = port
+    self.binary = binary
+
+    self.log.info ("Creating fresh data directory for the channel daemon in %s"
+                    % self.datadir)
+    shutil.rmtree (self.datadir, ignore_errors=True)
+    os.mkdir (self.datadir)
+
+    self.proc = None
+
+  def start (self, xayarpc, gsprpc, bcrpc, extraArgs=[]):
+    if self.proc is not None:
+      self.log.error ("Channel process is already running, not starting again")
+      return
+
+    self.log.info ("Starting channel daemon for %s" % self.playerName)
+    args = [self.binary]
+    args.append ("--xaya_rpc_url=%s" % xayarpc)
+    args.append ("--gsp_rpc_url=%s" % gsprpc)
+    args.append ("--broadcast_rpc_url=%s" % bcrpc)
+    args.append ("--rpc_port=%d" % self.port)
+    args.append ("--channelid=%s" % self.channelId)
+    args.append ("--playername=%s" % self.playerName)
+    args.extend (extraArgs)
+    envVars = dict (os.environ)
+    envVars["GLOG_log_dir"] = self.datadir
+    self.proc = subprocess.Popen (args, env=envVars)
+
+    self.rpc = self.createRpc ()
+    self.xayaRpc = jsonrpclib.Server (xayarpc)
+
+    self.log.info ("Waiting for the JSON-RPC server to be up...")
+    while True:
+      try:
+        data = self.rpc.getcurrentstate ()
+        self.log.info ("Channel daemon is up for %s" % self.playerName)
+        break
+      except:
+        time.sleep (0.1)
+
+  def stop (self):
+    if self.proc is None:
+      self.log.error ("No channel process is running cannot stop it")
+      return
+
+    self.log.info ("Stopping channel process for %s" % self.playerName)
+    self.rpc._notify.stop ()
+
+    self.log.info ("Waiting for channelprocess to stop...")
+    self.proc.wait ()
+    self.proc = None
+
+  def createRpc (self):
+    """
+    Returns a freshly created JSON-RPC connection for this daemon.  This can
+    be used if multiple threads need to send RPCs in parallel.
+    """
+
+    return jsonrpclib.Server ("http://localhost:%d" % self.port)
+
+  def getCurrentState (self):
+    """
+    Queries for the current state of the tracked channel.  This also queries
+    Xaya Core for the best block hash, and waits until the block known to
+    the channel daemon matches it.  That way we can ensure that updates are
+    propagated before doing any tests.
+    """
+
+    assert self.proc is not None
+
+    bestblk = self.xayaRpc.getbestblockhash ()
+    bestheight = self.xayaRpc.getblockcount ()
+
+    while True:
+      state = self.rpc.getcurrentstate ()
+      if state["blockhash"] == bestblk:
+        assert state["height"] == bestheight
+        return state
+
+      self.log.warning (("Channel daemon for %s has best block %s,"
+                            + " waiting to catch up to %s")
+          % (self.playerName, state["blockhash"], bestblk))
+      time.sleep (0.01)
+
+
+class DaemonContext ():
+  """
+  A context manager that runs a channel daemon and shuts it down upon exit.
+  """
+
+  def __init__ (self, daemon, *args, **kwargs):
+    self.daemon = daemon
+    self.args = args
+    self.kwargs = kwargs
+
+  def __enter__ (self):
+    self.daemon.start (*self.args, **self.kwargs)
+    return self.daemon
+
+  def __exit__ (self, excType, excValue, traceback):
+    self.daemon.stop ()
+
+
+class TestCase (XayaGameTest):
+  """
+  Integration test case for channel games, which may include testing
+  for channel daemons in addition to the GSP.
+  """
+
+  def __init__ (self, gameId, gspBinary, channelBinary):
+    self.channelBinary = channelBinary
+    super (TestCase, self).__init__ (gameId, gspBinary)
+
+  def addArguments (self, parser):
+    parser.add_argument ("--channel_daemon", default=self.channelBinary,
+                         help="channel daemon binary")
+
+  def setup (self):
+    super (TestCase, self).setup ()
+
+    bcPort = random.randint (1024, 3000)
+    self.nextChannelPort = bcPort + 1
+    self.log.info ("Using ports starting from %d for channel daemons" % bcPort)
+
+    self.broadcast = rpcbroadcast.Server ("localhost", bcPort)
+    self.bcurl = "http://localhost:%d" % bcPort
+    def serveBroadcast ():
+      self.broadcast.serve ()
+    self.broadcastThread = threading.Thread (target=serveBroadcast)
+    self.broadcastThread.start ()
+
+  def shutdown (self):
+    self.broadcast.shutdown ()
+    self.broadcastThread.join ()
+    super (TestCase, self).shutdown ()
+
+  def runChannelDaemon (self, channelId, playerName):
+    """
+    Starts a new channel daemon for the given ID and player name.
+    This returns a context manager instance, which returns the
+    underlying Daemon instance when entered.
+    """
+
+    port = self.nextChannelPort
+    self.nextChannelPort += 1
+    daemon = Daemon (channelId, playerName, self.basedir, port,
+                     self.args.channel_daemon)
+
+    return DaemonContext (daemon, self.xayanode.rpcurl, self.gamenode.rpcurl,
+                          self.bcurl)
+
+  def newSigningAddress (self):
+    """
+    Returns a new address from the local wallet that can be used as signing
+    address in a channel.
+    """
+
+    return self.rpc.xaya.getnewaddress ("", "legacy")
+
+  def getSyncedChannelState (self, daemons):
+    """
+    Queries all channel daemons in the passed-in array for their current
+    state and returns it when they match up.  This can be used to wait
+    with a test until all channel daemons have caught up on some latest
+    moves done off-chain.
+
+    Note that the returned state is from one of the daemons, and may contain
+    daemon-specific fields (like version).  It is not specified what the
+    values of those fields are.
+    """
+
+    ok = False
+    while not ok:
+      ok = True
+
+      state = None
+      for c in daemons:
+        cur = c.getCurrentState ()
+
+        # If the channel does not exist on chain, there is no point to sync.
+        # Each channel daemon is synced to the latest on-chain state anyway
+        # already by getCurrentState, and in that situation, there is no
+        # additional state to be returned by any of the daemons that could
+        # be different.
+        if not cur["existsonchain"]:
+          return cur
+
+        if state is None:
+          state = cur
+          continue
+
+        oldTc = state["current"]["state"]["turncount"]
+        newTc = cur["current"]["state"]["turncount"]
+        if oldTc != newTc:
+          ok = False
+          break
+
+      self.log.warning ("Channel states differ, waiting...")
+      time.sleep (0.01)
+
+    return state

--- a/gamechannel/rpcbroadcast.py
+++ b/gamechannel/rpcbroadcast.py
@@ -92,7 +92,14 @@ class Server (object):
     self.channels = {}
     self.mutex = threading.Lock ()
 
+    # For testing purposes the server can be "muted".  If that's the case,
+    # then sent messages are just dropped rather than broadcasted.
+    self.muted = False
+
     def sendMsg (channel, message):
+      with self.mutex:
+        if self.muted:
+          return
       self.getChannel (channel).send (message)
     self.server.register_function (sendMsg, "send")
 
@@ -108,6 +115,10 @@ class Server (object):
         "seq": seq,
       }
     self.server.register_function (receiveMsg, "receive")
+
+  def setMuted (self, value):
+    with self.mutex:
+      self.muted = value
 
   def getChannel (self, channel):
     """

--- a/ships/Makefile.am
+++ b/ships/Makefile.am
@@ -1,4 +1,4 @@
-SUBDIRS = gametest
+SUBDIRS = gametest channeltest
 
 noinst_LTLIBRARIES = libships.la
 bin_PROGRAMS = shipsd ships-channel

--- a/ships/channeltest/Makefile.am
+++ b/ships/channeltest/Makefile.am
@@ -3,7 +3,8 @@ AM_TESTS_ENVIRONMENT = \
 
 REGTESTS = \
   disputes.py \
-  full_game.py
+  full_game.py \
+  tx_fail.py
 
 EXTRA_DIST = $(REGTESTS)
 TESTS = $(REGTESTS)

--- a/ships/channeltest/Makefile.am
+++ b/ships/channeltest/Makefile.am
@@ -2,6 +2,7 @@ AM_TESTS_ENVIRONMENT = \
   PYTHONPATH=$(top_srcdir):$(top_srcdir)/ships:$(top_srcdir)/ships/gametest
 
 REGTESTS = \
+  disputes.py \
   full_game.py
 
 EXTRA_DIST = $(REGTESTS)

--- a/ships/channeltest/Makefile.am
+++ b/ships/channeltest/Makefile.am
@@ -1,0 +1,8 @@
+AM_TESTS_ENVIRONMENT = \
+  PYTHONPATH=$(top_srcdir):$(top_srcdir)/ships:$(top_srcdir)/ships/gametest
+
+REGTESTS = \
+  full_game.py
+
+EXTRA_DIST = $(REGTESTS)
+TESTS = $(REGTESTS)

--- a/ships/channeltest/Makefile.am
+++ b/ships/channeltest/Makefile.am
@@ -4,6 +4,7 @@ AM_TESTS_ENVIRONMENT = \
 REGTESTS = \
   disputes.py \
   full_game.py \
+  reorg.py \
   tx_fail.py
 
 EXTRA_DIST = $(REGTESTS)

--- a/ships/channeltest/disputes.py
+++ b/ships/channeltest/disputes.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python
+# Copyright (C) 2019 The Xaya developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+"""
+Tests a full channel game including the channel daemons.  There are no edge
+cases tested, though (e.g. reorgs), as that is deferred to other
+more specialised integration tests.
+"""
+
+from shipstest import ShipsTest
+
+
+class DisputesTest (ShipsTest):
+
+  def run (self):
+    self.generate (110)
+
+    # Create a test channel with two participants.
+    self.mainLogger.info ("Creating test channel...")
+    channelId = self.openChannel (["foo", "bar"])
+
+    # Start up the two channel daemons.
+    self.mainLogger.info ("Starting channel daemons...")
+    with self.runChannelDaemon (channelId, "foo") as foo, \
+         self.runChannelDaemon (channelId, "bar") as bar:
+
+      daemons = [foo, bar]
+
+      self.mainLogger.info ("Running initialisation sequence...")
+      foo.rpc._notify.setposition ("""
+        xxxx..xx
+        ........
+        xxx.xxx.
+        ........
+        xx.xx.xx
+        ........
+        ........
+        ........
+      """)
+      bar.rpc._notify.setposition ("""
+        ........
+        ........
+        ........
+        xxxx..xx
+        ........
+        xxx.xxx.
+        ........
+        xx.xx.xx
+      """)
+      _, state = self.waitForPhase (daemons, ["shoot"])
+
+      # Make sure it is foo's turn.  If not, miss a shot with bar.
+      if state["current"]["state"]["whoseturn"] == 1:
+        bar.rpc._notify.shoot (row=7, column=0)
+        _, state = self.waitForPhase (daemons, ["shoot"])
+      self.assertEqual (state["current"]["state"]["whoseturn"], 0)
+
+      # Let bar file a dispute against foo.
+      self.mainLogger.info ("Filing and resolving a dispute...")
+      bar.rpc._notify.filedispute ()
+      self.generate (2)
+      state = foo.getCurrentState ()
+      self.assertEqual (state["dispute"], {
+        "whoseturn": 0,
+        "canresolve": False,
+        "height": self.rpc.xaya.getblockcount () - 1,
+      })
+
+      # Resolve the dispute with a new move.
+      foo.rpc._notify.shoot (row=7, column=0)
+      state = foo.getCurrentState ()
+      self.assertEqual (state["dispute"], {
+        "whoseturn": 0,
+        "canresolve": True,
+        "height": self.rpc.xaya.getblockcount () - 1,
+      })
+      self.expectPendingMoves ("foo", ["r"])
+      self.generate (1)
+      _, state = self.waitForPhase (daemons, ["shoot"])
+      assert "dispute" not in state
+
+      # Simulate a dispute based on a "lost" broadcast message.  It will be
+      # resolved immediately (without user interaction) when the dispute
+      # gets on-chain.
+      self.mainLogger.info ("Resolving dispute from missed broadcast...")
+      self.broadcast.setMuted (True)
+      foo.rpc._notify.shoot (row=7, column=1)
+      bar.rpc._notify.filedispute ()
+
+      self.broadcast.setMuted (False)
+      self.generate (1)
+      state = foo.getCurrentState ()
+      self.assertEqual (state["dispute"], {
+        "whoseturn": 0,
+        "canresolve": True,
+        "height": self.rpc.xaya.getblockcount (),
+      })
+
+      self.expectPendingMoves ("foo", ["r"])
+      self.generate (1)
+      _, state = self.waitForPhase (daemons, ["shoot"])
+      assert "dispute" not in state
+
+      self.mainLogger.info ("Closing channel due to dispute...")
+      bar.rpc._notify.filedispute ()
+      self.generate (10)
+      state = foo.getCurrentState ()
+      self.assertEqual (state["dispute"], {
+        "whoseturn": 0,
+        "canresolve": False,
+        "height": self.rpc.xaya.getblockcount () - 9,
+      })
+      self.generate (1)
+      state = foo.getCurrentState ()
+      self.assertEqual (state["existsonchain"], False)
+      self.expectGameState ({
+        "channels": {},
+        "gamestats": {
+          "foo": {"won": 0, "lost": 1},
+          "bar": {"won": 1, "lost": 0},
+        },
+      })
+
+
+if __name__ == "__main__":
+  DisputesTest ().main ()

--- a/ships/channeltest/full_game.py
+++ b/ships/channeltest/full_game.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python
+# Copyright (C) 2019 The Xaya developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+"""
+Tests a full channel game including the channel daemons.  There are no edge
+cases tested, though (e.g. reorgs), as that is deferred to other
+more specialised integration tests.
+"""
+
+from shipstest import ShipsTest
+
+
+class FullGameTest (ShipsTest):
+
+  def run (self):
+    self.generate (110)
+
+    # Create a test channel with two participants (but with the join
+    # not yet confirmed on chain).
+    self.mainLogger.info ("Creating test channel...")
+    channelId = self.sendMove ("foo", {"c": {
+      "addr": self.newSigningAddress (),
+    }})
+    self.generate (1)
+    self.sendMove ("bar", {"j": {
+      "id": channelId,
+      "addr": self.newSigningAddress (),
+    }})
+
+    # Start up the two channel daemons.
+    self.mainLogger.info ("Starting channel daemons...")
+    with self.runChannelDaemon (channelId, "foo") as foo, \
+         self.runChannelDaemon (channelId, "bar") as bar:
+
+      daemons = [foo, bar]
+      state = self.getSyncedChannelState (daemons)
+      self.assertEqual (state["current"]["state"]["parsed"]["phase"],
+                        "single participant")
+
+      # Set foo's position before the channel is created on-chain.  This means
+      # that after channel creation, the first commitment will already be
+      # done immediately.  The second commitment will be delayed until bar also
+      # sets their position.
+      foo.rpc._notify.setposition ("""
+        xxxx..xx
+        ........
+        xxx.xxx.
+        ........
+        xx.xx.xx
+        ........
+        ........
+        ........
+      """)
+
+      self.mainLogger.info ("Running initialisation sequence...")
+      self.generate (1)
+      self.waitForPhase (daemons, ["second commitment"])
+
+      bar.rpc._notify.setposition ("""
+        ........
+        ........
+        ........
+        xxxx..xx
+        ........
+        xxx.xxx.
+        ........
+        xx.xx.xx
+      """)
+      self.waitForPhase (daemons, ["shoot"])
+
+      # We play the game as in "FullGameTests/WithShots":  Both players
+      # try coordinates in increasing order when it is their turn, which
+      # means that bar wins.
+      self.mainLogger.info ("Playing the channel...")
+      nextCoord = [0, 0]
+      while True:
+        phase, state = self.waitForPhase (daemons, ["finished", "shoot"])
+        if phase == "finished":
+          break
+
+        turn = state["current"]["state"]["whoseturn"]
+        assert turn in [0, 1]
+
+        target = nextCoord[turn]
+        nextCoord[turn] += 1
+
+        row = target // 8
+        column = target % 8
+        self.log.info ("Player %d shoots at (%d, %d)..." % (turn, row, column))
+        daemons[turn].rpc._notify.shoot (row=row, column=column)
+
+      # Verify the result.
+      self.mainLogger.info ("Verifying result of channel game...")
+      state = self.getSyncedChannelState (daemons)["current"]["state"]["parsed"]
+      self.assertEqual (state["phase"], "finished")
+      self.assertEqual (state["winner"], 1)
+
+      self.expectPendingMoves ("bar", ["w"])
+      self.generate (1)
+      self.expectGameState ({
+        "channels": {},
+        "gamestats":
+          {
+            "foo": {"won": 0, "lost": 1},
+            "bar": {"won": 1, "lost": 0},
+          },
+      })
+      state = self.getSyncedChannelState (daemons)
+      self.assertEqual (state["existsonchain"], False)
+
+
+if __name__ == "__main__":
+  FullGameTest ().main ()

--- a/ships/channeltest/reorg.py
+++ b/ships/channeltest/reorg.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python
+# Copyright (C) 2019 The Xaya developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+"""
+Tests how a game channel reacts to reorgs of important on-chain transactions
+(channel creation, join, resolutions, winner statements).
+"""
+
+from shipstest import ShipsTest
+
+
+class ReogTest (ShipsTest):
+
+  def run (self):
+    self.generate (110)
+
+    # Create a test channel with two participants.  Remember the block hashes
+    # where it was created and joined by the second one, so that we can
+    # later invalidate those.
+    self.mainLogger.info ("Creating test channel...")
+    channelId = self.sendMove ("foo", {"c": {
+      "addr": self.newSigningAddress (),
+    }})
+    self.generate (1)
+    createBlk = self.rpc.xaya.getbestblockhash ()
+    self.sendMove ("bar", {"j": {
+      "id": channelId,
+      "addr": self.newSigningAddress (),
+    }})
+    self.generate (1)
+    joinBlk = self.rpc.xaya.getbestblockhash ()
+
+    # Start up three channel daemons:  The two participants and
+    # a third one, which will join the channel later in a reorged
+    # alternate reality.
+    self.mainLogger.info ("Starting channel daemons...")
+    with self.runChannelDaemon (channelId, "foo") as foo, \
+         self.runChannelDaemon (channelId, "bar") as bar, \
+         self.runChannelDaemon (channelId, "baz") as baz:
+
+      daemons = [foo, bar, baz]
+
+      self.mainLogger.info ("Running initialisation sequence...")
+      pos = """
+        xxxx..xx
+        ........
+        xxx.xxx.
+        ........
+        xx.xx.xx
+        ........
+        ........
+        ........
+      """
+      foo.rpc._notify.setposition (pos)
+      bar.rpc._notify.setposition (pos)
+      baz.rpc._notify.setposition (pos)
+
+      # Play a couple of turns and save the resulting "original" state.
+      for c in range (8):
+        _, state = self.waitForPhase (daemons, ["shoot"])
+        turn = state["current"]["state"]["whoseturn"]
+        daemons[turn].rpc._notify.shoot (row=7, column=c)
+      _, originalState = self.waitForPhase (daemons, ["shoot"])
+
+      # Generate a couple of blocks to make sure this will be the longest
+      # chain in the end.
+      self.generate (10)
+
+      self.mainLogger.info ("Reorg to channel creation...")
+      self.rpc.xaya.invalidateblock (createBlk)
+      self.assertEqual (foo.getCurrentState ()["existsonchain"], False)
+      self.rpc.xaya.reconsiderblock (createBlk)
+      self.rpc.xaya.invalidateblock (joinBlk)
+      self.assertEqual (self.rpc.xaya.getbestblockhash (), createBlk)
+      state = foo.getCurrentState ()
+      self.assertEqual (state["existsonchain"], True)
+      self.assertEqual (state["current"]["state"]["parsed"]["phase"],
+                        "single participant")
+
+      self.mainLogger.info ("Alternate join...")
+      self.sendMove ("baz", {"j": {
+        "id": channelId,
+        "addr": self.newSigningAddress (),
+      }})
+      self.expectPendingMoves ("bar", [])
+      self.expectPendingMoves ("baz", ["j"])
+      self.generate (1)
+
+      # Make sure it is baz' turn.  If not, miss a shot with foo.
+      self.mainLogger.info ("Building alternate reality...")
+      _, state = self.waitForPhase (daemons, ["shoot"])
+      if state["current"]["state"]["whoseturn"] == 0:
+        foo.rpc._notify.shoot (row=6, column=0)
+        _, state = self.waitForPhase (daemons, ["shoot"])
+      self.assertEqual (state["current"]["state"]["whoseturn"], 1)
+
+      # Finish the game and let foo win.
+      baz.rpc._notify.revealposition ()
+      _, state = self.waitForPhase (daemons, ["finished"])
+      self.assertEqual (state["current"]["state"]["parsed"]["winner"], 0)
+      self.generate (1)
+      self.expectGameState ({
+        "channels": {},
+        "gamestats": {
+          "foo": {"won": 1, "lost": 0},
+          "baz": {"won": 0, "lost": 1},
+        },
+      })
+
+      self.mainLogger.info ("Restoring original state...")
+      self.rpc.xaya.reconsiderblock (joinBlk)
+      state = foo.getCurrentState ()
+      self.assertEqual (state["current"]["meta"],
+                        originalState["current"]["meta"])
+      self.assertEqual (state["current"]["state"]["parsed"],
+                        originalState["current"]["state"]["parsed"])
+
+      # Make sure it is foo's turn.
+      _, state = self.waitForPhase (daemons, ["shoot"])
+      if state["current"]["state"]["whoseturn"] == 1:
+        bar.rpc._notify.shoot (row=6, column=1)
+        _, state = self.waitForPhase (daemons, ["shoot"])
+      self.assertEqual (state["current"]["state"]["whoseturn"], 0)
+
+      # Test what happens if a resolution move gets reorged away.  Then the
+      # player who resolved should still make sure it gets into the chain
+      # again (since they obviously still know a better state).
+      self.mainLogger.info ("Reorg of a resolution move...")
+      bar.rpc._notify.filedispute ()
+      self.expectPendingMoves ("bar", ["d"])
+      self.generate (1)
+      state = foo.getCurrentState ()
+      self.assertEqual (state["dispute"], {
+        "whoseturn": 0,
+        "canresolve": False,
+        "height": self.rpc.xaya.getblockcount (),
+      })
+      foo.rpc._notify.shoot (row=0, column=0)
+      self.expectPendingMoves ("foo", ["r"])
+      self.generate (1)
+      resolutionBlk = self.rpc.xaya.getbestblockhash ()
+      state = foo.getCurrentState ()
+      assert "dispute" not in state
+
+      self.rpc.xaya.invalidateblock (resolutionBlk)
+      state = foo.getCurrentState ()
+      self.assertEqual (state["dispute"], {
+        "whoseturn": 0,
+        "canresolve": True,
+        "height": self.rpc.xaya.getblockcount (),
+      })
+
+      # Currently, the channel daemon always resends, even if the
+      # previous move is still in the mempool.  For fixing this, see
+      # https://github.com/xaya/libxayagame/issues/65.  Hence, we should
+      # get *two* resolution moves.  If this issue gets fixed at some point,
+      # we should do two tests:  When the original move remains in the
+      # mempool, then no additional one should be sent.  If it is not anymore
+      # (e.g. because of a long reorg), then a *new* one should be sent.
+      self.expectPendingMoves ("foo", ["r", "r"])
+      self.generate (1)
+      state = foo.getCurrentState ()
+      assert "dispute" not in state
+
+      self.mainLogger.info ("Letting the game end with a dispute...")
+      bar.rpc._notify.filedispute ()
+      self.expectPendingMoves ("bar", ["d"])
+      self.generate (11)
+      self.expectGameState ({
+        "channels": {},
+        "gamestats": {
+          "foo": {"won": 0, "lost": 1},
+          "bar": {"won": 1, "lost": 0},
+        },
+      })
+
+      self.mainLogger.info ("Detaching a block and ending the game normally...")
+      disputeTimeoutBlk = self.rpc.xaya.getbestblockhash ()
+      self.rpc.xaya.invalidateblock (disputeTimeoutBlk)
+      state = foo.getCurrentState ()
+      self.assertEqual (state["existsonchain"], True)
+
+      # We miss a shot with foo and reveal with bar, so that this time
+      # foo wins the channel (but ordinarily).
+      foo.rpc._notify.shoot (row=6, column=2)
+      self.expectPendingMoves ("foo", ["r"])
+      self.generate (1)
+      self.waitForPhase (daemons, ["shoot"])
+      bar.rpc._notify.revealposition ()
+      _, state = self.waitForPhase (daemons, ["finished"])
+      self.assertEqual (state["current"]["state"]["parsed"]["winner"], 0)
+      self.expectPendingMoves ("foo", ["w"])
+      self.generate (1)
+      self.expectGameState ({
+        "channels": {},
+        "gamestats": {
+          "foo": {"won": 1, "lost": 0},
+          "bar": {"won": 0, "lost": 1},
+        },
+      })
+
+      self.mainLogger.info ("Reorg and resending of winner statement...")
+      winnerStmtBlk = self.rpc.xaya.getbestblockhash ()
+      self.rpc.xaya.invalidateblock (winnerStmtBlk)
+      state = foo.getCurrentState ()
+      self.assertEqual (state["current"]["state"]["parsed"]["phase"],
+                        "finished")
+      self.assertEqual (state["current"]["state"]["parsed"]["winner"], 0)
+      # As above, we also resend the winner statement move at the moment.
+      self.expectPendingMoves ("foo", ["w", "w"])
+      self.generate (1)
+      self.expectGameState ({
+        "channels": {},
+        "gamestats": {
+          "foo": {"won": 1, "lost": 0},
+          "bar": {"won": 0, "lost": 1},
+        },
+      })
+
+
+if __name__ == "__main__":
+  ReogTest ().main ()

--- a/ships/channeltest/tx_fail.py
+++ b/ships/channeltest/tx_fail.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python
+# Copyright (C) 2019 The Xaya developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+"""
+Tests what happens if name_update's triggered from a channel daemon fail.
+"""
+
+from shipstest import ShipsTest
+
+
+class TxFailTest (ShipsTest):
+
+  def run (self):
+    myAddr = self.rpc.xaya.getnewaddress ()
+    self.rpc.xaya.generatetoaddress (10, myAddr)
+    self.generate (150)
+
+    # Create a test channel with two participants.
+    self.mainLogger.info ("Creating test channel...")
+    channelId = self.openChannel (["foo", "bar"])
+
+    # Start up the two channel daemons.
+    self.mainLogger.info ("Starting channel daemons...")
+    with self.runChannelDaemon (channelId, "foo") as foo, \
+         self.runChannelDaemon (channelId, "bar") as bar:
+
+      daemons = [foo, bar]
+
+      self.mainLogger.info ("Running initialisation sequence...")
+      foo.rpc._notify.setposition ("""
+        xxxx..xx
+        ........
+        xxx.xxx.
+        ........
+        xx.xx.xx
+        ........
+        ........
+        ........
+      """)
+      bar.rpc._notify.setposition ("""
+        ........
+        ........
+        ........
+        xxxx..xx
+        ........
+        xxx.xxx.
+        ........
+        xx.xx.xx
+      """)
+      _, state = self.waitForPhase (daemons, ["shoot"])
+
+      # Make sure it is foo's turn.  If not, miss a shot with bar.
+      if state["current"]["state"]["whoseturn"] == 1:
+        bar.rpc._notify.shoot (row=7, column=0)
+        _, state = self.waitForPhase (daemons, ["shoot"])
+      self.assertEqual (state["current"]["state"]["whoseturn"], 0)
+
+      # File a dispute with locked wallet.  That should just silently fail.
+      self.mainLogger.info ("Trying dispute that fails...")
+      self.lock ()
+      bar.rpc._notify.filedispute ()
+      self.expectPendingMoves ("bar", [])
+      self.generate (1)
+      state = bar.getCurrentState ()
+      assert "dispute" not in state
+      self.unlock ()
+
+      # Let bar file a dispute against foo.
+      self.mainLogger.info ("Filing a dispute whose resolution fails...")
+      bar.rpc._notify.filedispute ()
+      self.generate (1)
+      state = foo.getCurrentState ()
+      self.assertEqual (state["dispute"], {
+        "whoseturn": 0,
+        "canresolve": False,
+        "height": self.rpc.xaya.getblockcount (),
+      })
+
+      # Send a new move, but lock the wallet so that the resolution
+      # transaction will not succeed.
+      self.lock ()
+      foo.rpc._notify.shoot (row=7, column=0)
+
+      # Unlock the wallet.  Then the resolution transaction should be
+      # retried when another block comes in.
+      self.mainLogger.info ("Resolving it with unlocked wallet...")
+      self.unlock ()
+      self.expectPendingMoves ("foo", [])
+      self.generate (1)
+      state = foo.getCurrentState ()
+      self.assertEqual (state["dispute"], {
+        "whoseturn": 0,
+        "canresolve": True,
+        "height": self.rpc.xaya.getblockcount () - 1,
+      })
+      self.expectPendingMoves ("foo", ["r"])
+      self.generate (1)
+      _, state = self.waitForPhase (daemons, ["shoot"])
+      assert "dispute" not in state
+
+      # Let foo lose the game.  We lock the wallet, so that the winner
+      # statement of bar cannot get sent initially.
+      self.mainLogger.info ("Winner statement fails...")
+      self.lock ()
+      foo.rpc._notify.revealposition ()
+      self.waitForPhase (daemons, ["finished"])
+
+      # Now unlock the wallet.  Then the next block should re-trigger an update
+      # and we should get the move in.
+      self.mainLogger.info ("Winner statement retrial succeeds...")
+      self.unlock ()
+      self.expectPendingMoves ("bar", [])
+      self.generate (1)
+      state = bar.getCurrentState ()
+      self.assertEqual (state["current"]["state"]["parsed"]["winner"], 1)
+      self.expectPendingMoves ("bar", ["w"])
+      self.generate (1)
+      state = foo.getCurrentState ()
+      self.assertEqual (state["existsonchain"], False)
+      self.expectGameState ({
+        "channels": {},
+        "gamestats": {
+          "foo": {"won": 0, "lost": 1},
+          "bar": {"won": 1, "lost": 0},
+        },
+      })
+
+  def generate (self, n):
+    """
+    Mines n blocks, but to an address not owned by the test wallet.
+    This ensures that we keep control over locked/unlocked outputs as
+    needed in this test, and not new outputs get added when mining blocks.
+    """
+
+    notMine = "cdpSgeapVR8ZgRkqA8zF3fDJ2NgaUqm2pu"
+    self.rpc.xaya.generatetoaddress (n, notMine)
+
+  def lock (self):
+    """
+    Locks all UTXO's in the wallet, so that no name_update transactions
+    can be made temporarily.  This does not affect signing messages.
+    """
+
+    outputs = self.rpc.xaya.listunspent ()
+    self.rpc.xaya.lockunspent (False, outputs)
+
+  def unlock (self):
+    """
+    Unlocks all outputs in the wallet, so that name_update's can be done
+    again successfully.
+    """
+
+    self.rpc.xaya.lockunspent (True)
+
+
+if __name__ == "__main__":
+  TxFailTest ().main ()

--- a/xayagametest/game.py
+++ b/xayagametest/game.py
@@ -33,6 +33,7 @@ class Node ():
     self.log = logging.getLogger ("xayagametest.gamenode")
     self.datadir = os.path.join (basedir, "gamenode")
     self.port = port
+    self.rpcurl = "http://localhost:%d" % self.port
     self.binary = binary
 
     self.log.info ("Creating fresh data directory for the game node in %s"
@@ -86,8 +87,7 @@ class Node ():
     be used if multiple threads need to send RPCs in parallel.
     """
 
-    return jsonrpclib.Server ("http://localhost:%d" % self.port)
-
+    return jsonrpclib.Server (self.rpcurl)
 
   def logMatches (self, expr, times=None):
     """

--- a/xayagametest/testcase.py
+++ b/xayagametest/testcase.py
@@ -115,6 +115,7 @@ class XayaGameTest (object):
     try:
       self.startGameDaemon ()
       try:
+        self.setup ()
         self.run ()
         self.mainLogger.info ("Test succeeded")
         success = True
@@ -126,6 +127,7 @@ class XayaGameTest (object):
         self.mainLogger.exception ("Test failed")
         self.log.info ("Not cleaning up base directory %s" % self.basedir)
       finally:
+        self.shutdown ()
         self.stopGameDaemon ()
     finally:
       self.stopXayaDaemon ()
@@ -136,6 +138,25 @@ class XayaGameTest (object):
 
     if not success:
       sys.exit ("Test failed")
+
+  def setup (self):
+    """
+    This method does nothing, but it can be overridden by subclasses to
+    provide custom setup functionality.  That is run after setting up the
+    base environment (e.g. Xaya Core RPC) but before the actual test
+    logic in each test's run() method.
+    """
+
+    pass
+
+  def shutdown (self):
+    """
+    This method does nothing, but it can be overridden by subclasses.
+    It gets called when the test run is done and can be used to clean
+    up resources.
+    """
+
+    pass
 
   def run (self):
     self.mainLogger.warning (


### PR DESCRIPTION
This adds a framework for running channel daemons in integration tests, and adds exhaustive tests for various edge cases for Xayaships.  We test basic games but also what happens if a move sent from the channel daemon fails due to a locked wallet, and how the channel daemon handles on-chain reorgs.

With this, all of #70 is done.