### PR TITLE
Better tracking of pending / confirmed game-channel moves

### DIFF
--- a/gamechannel/channelmanager.cpp
+++ b/gamechannel/channelmanager.cpp
@@ -348,30 +348,34 @@ ChannelManager::TriggerAutoMoves ()
   ProcessStateUpdate (true);
 }
 
-void
+uint256
 ChannelManager::FileDispute ()
 {
   LOG (INFO) << "Trying to file a dispute for channel " << channelId.ToHex ();
   std::lock_guard<std::mutex> lock(mut);
 
+  uint256 txidNull;
+  txidNull.SetNull ();
+
   if (!exists)
     {
       LOG (WARNING) << "The channel does not exist on chain";
-      return;
+      return txidNull;
     }
   if (dispute != nullptr)
     {
       LOG (WARNING) << "There is already a dispute for the channel";
-      return;
+      return txidNull;
     }
   if (!pendingDispute.IsNull ())
     {
       LOG (WARNING) << "There may already be a pending dispute";
-      return;
+      return txidNull;
     }
 
   CHECK (onChainSender != nullptr);
   pendingDispute = onChainSender->SendDispute (boardStates.GetStateProof ());
+  return pendingDispute;
 }
 
 void

--- a/gamechannel/channelmanager.hpp
+++ b/gamechannel/channelmanager.hpp
@@ -61,12 +61,13 @@ private:
     unsigned count;
 
     /**
-     * True if we already tried to send a resolution for the last known
-     * on-chain block.
+     * The transaction ID of a sent resolution.  When there is no pending
+     * resolution transaction, this is null.
      */
-    bool pendingResolution;
+    uint256 pendingResolution;
 
-    DisputeData () = default;
+    DisputeData ();
+
     DisputeData (const DisputeData&) = default;
     DisputeData& operator= (const DisputeData&) = default;
 
@@ -157,10 +158,10 @@ private:
   std::unique_ptr<DisputeData> dispute;
 
   /**
-   * Set to true if we already tried to file a pending dispute for the last
-   * known block height.
+   * The transaction ID of a dispute move we sent (if any).  Set to null
+   * if there is none.
    */
-  bool pendingDispute = false;
+  uint256 pendingDispute;
 
   /**
    * Tries to apply a local move to the current state.  Returns true if

--- a/gamechannel/channelmanager.hpp
+++ b/gamechannel/channelmanager.hpp
@@ -275,9 +275,10 @@ public:
   void TriggerAutoMoves ();
 
   /**
-   * Requests to file a dispute with the current state.
+   * Requests to file a dispute with the current state.  Returns the txid
+   * of the sent move (or null if sending failed).
    */
-  void FileDispute ();
+  uint256 FileDispute ();
 
   /**
    * Disables processing of updates in the future.  This should be called

--- a/gamechannel/channelmanager_tests.cpp
+++ b/gamechannel/channelmanager_tests.cpp
@@ -520,40 +520,40 @@ using FileDisputeTests = ChannelManagerTests;
 
 TEST_F (FileDisputeTests, Successful)
 {
-  ExpectMoves (1, "dispute");
+  const auto txid = ExpectMoves (1, "dispute");
   ProcessOnChain ("0 0", ValidProof ("10 5"), 0);
-  cm.FileDispute ();
+  EXPECT_EQ (cm.FileDispute (), txid);
 }
 
 TEST_F (FileDisputeTests, ChannelDoesNotExist)
 {
   ExpectMoves (0, "dispute");
   ProcessOnChainNonExistant ();
-  cm.FileDispute ();
+  EXPECT_TRUE (cm.FileDispute ().IsNull ());
 }
 
 TEST_F (FileDisputeTests, HasOtherDispute)
 {
   ExpectMoves (0, "dispute");
   ProcessOnChain ("0 0", ValidProof ("10 5"), 10);
-  cm.FileDispute ();
+  EXPECT_TRUE (cm.FileDispute ().IsNull ());
 }
 
 TEST_F (FileDisputeTests, AlreadyPending)
 {
-  ExpectMoves (1, "dispute");
+  const auto txid = ExpectMoves (1, "dispute");
   ProcessOnChain ("0 0", ValidProof ("10 5"), 0);
-  cm.FileDispute ();
-  cm.FileDispute ();
+  EXPECT_EQ (cm.FileDispute (), txid);
+  EXPECT_TRUE (cm.FileDispute ().IsNull ());
 }
 
 TEST_F (FileDisputeTests, RetryAfterBlock)
 {
-  ExpectMoves (2, "dispute");
+  const auto txid = ExpectMoves (2, "dispute");
   ProcessOnChain ("0 0", ValidProof ("10 5"), 0);
-  cm.FileDispute ();
+  EXPECT_EQ (cm.FileDispute (), txid);
   ProcessOnChain ("0 0", ValidProof ("10 5"), 0);
-  cm.FileDispute ();
+  EXPECT_EQ (cm.FileDispute (), txid);
 }
 
 /* ************************************************************************** */

--- a/gamechannel/channelmanager_tests.cpp
+++ b/gamechannel/channelmanager_tests.cpp
@@ -121,7 +121,8 @@ protected:
   MockOffChainBroadcast offChain;
 
   ChannelManagerTests ()
-    : onChain("game id", channelId, "player", rpcWallet, game.channel),
+    : onChain("game id", channelId, "player",
+              rpcClient, rpcWallet, game.channel),
       offChain(cm)
   {
     cm.SetMoveSender (onChain);

--- a/gamechannel/daemon.cpp
+++ b/gamechannel/daemon.cpp
@@ -31,7 +31,7 @@ ChannelDaemon::XayaBasedInstances::XayaBasedInstances (ChannelDaemon& d,
     xayaRpc(xayaClient, jsonrpc::JSONRPC_CLIENT_V1),
     xayaWallet(xayaClient, jsonrpc::JSONRPC_CLIENT_V1),
     cm(d.rules, d.channel, xayaRpc, xayaWallet, d.channelId, d.playerName),
-    sender(d.gameId, d.channelId, d.playerName, xayaWallet, d.channel)
+    sender(d.gameId, d.channelId, d.playerName, xayaRpc, xayaWallet, d.channel)
 {
   cm.SetMoveSender (sender);
 }

--- a/gamechannel/movesender.cpp
+++ b/gamechannel/movesender.cpp
@@ -13,8 +13,10 @@ namespace xaya
 
 MoveSender::MoveSender (const std::string& gId,
                         const uint256& chId, const std::string& nm,
-                        XayaWalletRpcClient& w, OpenChannel& oc)
-  : rpc(w), game(oc), channelId(chId), playerName("p/" + nm), gameId(gId)
+                        XayaRpcClient& r, XayaWalletRpcClient& w,
+                        OpenChannel& oc)
+  : rpc(r), wallet(w), game(oc), channelId(chId),
+    playerName("p/" + nm), gameId(gId)
 {
   jsonWriterBuilder["commentStyle"] = "None";
   jsonWriterBuilder["indentation"] = "";
@@ -35,7 +37,7 @@ MoveSender::SendMove (const Json::Value& mv)
           << "Sending move: name_update " << playerName
           << "\n" << strValue;
 
-      const std::string txidHex = rpc.name_update (playerName, strValue);
+      const std::string txidHex = wallet.name_update (playerName, strValue);
       LOG (INFO) << "Success, name txid = " << txidHex;
 
       CHECK (res.FromHex (txidHex));
@@ -59,6 +61,35 @@ uint256
 MoveSender::SendResolution (const proto::StateProof& proof)
 {
   return SendMove (game.ResolutionMove (channelId, proof));
+}
+
+bool
+MoveSender::IsPending (const uint256& txid) const
+{
+  /* Note that we could optimise this by requesting just name_pending for
+     the MoveSender's player name.  For now, there are two reasons why we
+     don't do that:  First, Xaya Core's (and Namecoin's) name_pending
+     implementation goes through the full mempool anyway instead of using
+     its index of mempool names; so while we would save some transfer of
+     data and processing here, we would still access the whole mempool
+     at some point.  And second, if we defined name_pending as accepting
+     a string argument in the RPC stubs, we couldn't call the general form
+     anymore; that might be useful in other places.
+
+     But in case Namecoin gets updated to use the indices for name_pending
+     and perhaps to allow an empty name to signal "no filtering" (instead of
+     just a null value), we could change the implementation here without
+     any impact on clients.  */
+  const auto pending = rpc.name_pending ();
+
+  for (const auto& p : pending)
+    if (p["txid"].asString () == txid.ToHex ())
+      {
+        CHECK_EQ (p["name"], playerName);
+        return true;
+      }
+
+  return false;
 }
 
 } // namespace xaya

--- a/gamechannel/movesender.cpp
+++ b/gamechannel/movesender.cpp
@@ -49,16 +49,16 @@ MoveSender::SendMove (const Json::Value& mv)
   return res;
 }
 
-void
+uint256
 MoveSender::SendDispute (const proto::StateProof& proof)
 {
-  SendMove (game.DisputeMove (channelId, proof));
+  return SendMove (game.DisputeMove (channelId, proof));
 }
 
-void
+uint256
 MoveSender::SendResolution (const proto::StateProof& proof)
 {
-  SendMove (game.ResolutionMove (channelId, proof));
+  return SendMove (game.ResolutionMove (channelId, proof));
 }
 
 } // namespace xaya

--- a/gamechannel/movesender.hpp
+++ b/gamechannel/movesender.hpp
@@ -8,6 +8,7 @@
 #include "openchannel.hpp"
 #include "proto/stateproof.pb.h"
 
+#include <xayagame/rpc-stubs/xayarpcclient.h>
 #include <xayagame/rpc-stubs/xayawalletrpcclient.h>
 #include <xayautil/uint256.hpp>
 
@@ -33,8 +34,11 @@ class MoveSender
 
 private:
 
+  /** Xaya RPC connection to use.  */
+  XayaRpcClient& rpc;
+
   /** Xaya wallet RPC that we use.  */
-  XayaWalletRpcClient& rpc;
+  XayaWalletRpcClient& wallet;
 
   /** OpenChannel instance for building moves.  */
   OpenChannel& game;
@@ -58,7 +62,8 @@ public:
 
   explicit MoveSender (const std::string& gId,
                        const uint256& chId, const std::string& nm,
-                       XayaWalletRpcClient& w, OpenChannel& oc);
+                       XayaRpcClient& r, XayaWalletRpcClient& w,
+                       OpenChannel& oc);
 
   MoveSender () = delete;
   MoveSender (const MoveSender&) = delete;
@@ -85,6 +90,14 @@ public:
    * transaction ID (or null if the transaction failed).
    */
   uint256 SendResolution (const proto::StateProof& proof);
+
+  /**
+   * Checks if a name_update transaction from this MoveSender with the
+   * given txid is in the node's mempool.  This can be used to check if
+   * an equivalent move is still pending before requesting to send
+   * another one.
+   */
+  bool IsPending (const uint256& txid) const;
 
 };
 

--- a/gamechannel/movesender.hpp
+++ b/gamechannel/movesender.hpp
@@ -60,8 +60,6 @@ public:
                        const uint256& chId, const std::string& nm,
                        XayaWalletRpcClient& w, OpenChannel& oc);
 
-  virtual ~MoveSender () = default;
-
   MoveSender () = delete;
   MoveSender (const MoveSender&) = delete;
   void operator= (const MoveSender&) = delete;
@@ -77,14 +75,16 @@ public:
   uint256 SendMove (const Json::Value& mv);
 
   /**
-   * Sends a dispute based on the given state proof.
+   * Sends a dispute based on the given state proof.  Returns the transaction
+   * ID (or null if the transaction failed).
    */
-  virtual void SendDispute (const proto::StateProof& proof);
+  uint256 SendDispute (const proto::StateProof& proof);
 
   /**
-   * Sends a resolution based on the given state proof.
+   * Sends a resolution based on the given state proof.  Returns the
+   * transaction ID (or null if the transaction failed).
    */
-  virtual void SendResolution (const proto::StateProof& proof);
+  uint256 SendResolution (const proto::StateProof& proof);
 
 };
 

--- a/ships/channel.hpp
+++ b/ships/channel.hpp
@@ -58,6 +58,12 @@ private:
   xaya::uint256 seed0;
 
   /**
+   * Set to the txid of the submitted "close by winner statement" move,
+   * if we sent one already.  Otherwise null.
+   */
+  xaya::uint256 txidClose;
+
+  /**
    * Returns the index that the current player has for the given state.
    */
   int GetPlayerIndex (const ShipsBoardState& state) const;
@@ -76,9 +82,7 @@ private:
 
 public:
 
-  explicit ShipsChannel (XayaWalletRpcClient& w, const std::string& nm)
-    : wallet(w), playerName(nm)
-  {}
+  explicit ShipsChannel (XayaWalletRpcClient& w, const std::string& nm);
 
   ShipsChannel (const ShipsChannel&) = delete;
   void operator= (const ShipsChannel&) = delete;

--- a/ships/channelrpc.cpp
+++ b/ships/channelrpc.cpp
@@ -89,11 +89,16 @@ ShipsChannelRpcServer::revealposition ()
     LOG (ERROR) << "Cannot reveal position if it is not set yet";
 }
 
-void
+std::string
 ShipsChannelRpcServer::filedispute ()
 {
   LOG (INFO) << "RPC method called: filedispute";
-  daemon.GetChannelManager ().FileDispute ();
+  const xaya::uint256 txid = daemon.GetChannelManager ().FileDispute ();
+
+  if (txid.IsNull ())
+    return "";
+
+  return txid.ToHex ();
 }
 
 Json::Value

--- a/ships/channelrpc.hpp
+++ b/ships/channelrpc.hpp
@@ -71,7 +71,7 @@ public:
   void setposition (const std::string& str) override;
   void shoot (int column, int row) override;
   void revealposition () override;
-  void filedispute () override;
+  std::string filedispute () override;
 
 };
 

--- a/ships/channeltest/Makefile.am
+++ b/ships/channeltest/Makefile.am
@@ -4,6 +4,7 @@ AM_TESTS_ENVIRONMENT = \
 REGTESTS = \
   disputes.py \
   full_game.py \
+  pending.py \
   reorg.py \
   tx_fail.py \
   waitforchange.py

--- a/ships/channeltest/disputes.py
+++ b/ships/channeltest/disputes.py
@@ -60,7 +60,13 @@ class DisputesTest (ShipsTest):
       # Let bar file a dispute against foo.
       self.mainLogger.info ("Filing and resolving a dispute...")
       bar.rpc._notify.filedispute ()
+      pending = self.rpc.xaya.name_pending ("p/bar")
+      self.assertEqual (len (pending), 1)
+      self.assertEqual (bar.getCurrentState ()["pending"], {
+        "dispute": pending[0]["txid"],
+      })
       self.generate (2)
+      self.assertEqual (bar.getCurrentState ()["pending"], {})
       state = foo.getCurrentState ()
       self.assertEqual (state["dispute"], {
         "whoseturn": 0,
@@ -77,9 +83,15 @@ class DisputesTest (ShipsTest):
         "height": self.rpc.xaya.getblockcount () - 1,
       })
       self.expectPendingMoves ("foo", ["r"])
+      pending = self.rpc.xaya.name_pending ("p/foo")
+      self.assertEqual (len (pending), 1)
+      self.assertEqual (state["pending"], {
+        "resolution": pending[0]["txid"],
+      })
       self.generate (1)
       _, state = self.waitForPhase (daemons, ["shoot"])
       assert "dispute" not in state
+      self.assertEqual (foo.getCurrentState ()["pending"], {})
 
       # Simulate a dispute based on a "lost" broadcast message.  It will be
       # resolved immediately (without user interaction) when the dispute

--- a/ships/channeltest/disputes.py
+++ b/ships/channeltest/disputes.py
@@ -59,11 +59,12 @@ class DisputesTest (ShipsTest):
 
       # Let bar file a dispute against foo.
       self.mainLogger.info ("Filing and resolving a dispute...")
-      bar.rpc._notify.filedispute ()
-      pending = self.rpc.xaya.name_pending ("p/bar")
-      self.assertEqual (len (pending), 1)
+      txid = bar.rpc.filedispute ()
+      self.assertEqual (bar.rpc.filedispute (), "")
+      pendingTxids = self.expectPendingMoves ("bar", ["d"])
+      self.assertEqual (pendingTxids, [txid])
       self.assertEqual (bar.getCurrentState ()["pending"], {
-        "dispute": pending[0]["txid"],
+        "dispute": txid,
       })
       self.generate (2)
       self.assertEqual (bar.getCurrentState ()["pending"], {})
@@ -99,7 +100,7 @@ class DisputesTest (ShipsTest):
       self.mainLogger.info ("Resolving dispute from missed broadcast...")
       self.broadcast.setMuted (True)
       foo.rpc._notify.shoot (row=7, column=1)
-      bar.rpc._notify.filedispute ()
+      bar.rpc.filedispute ()
 
       self.broadcast.setMuted (False)
       self.generate (1)
@@ -116,7 +117,7 @@ class DisputesTest (ShipsTest):
       assert "dispute" not in state
 
       self.mainLogger.info ("Closing channel due to dispute...")
-      bar.rpc._notify.filedispute ()
+      bar.rpc.filedispute ()
       self.generate (10)
       state = foo.getCurrentState ()
       self.assertEqual (state["dispute"], {

--- a/ships/channeltest/pending.py
+++ b/ships/channeltest/pending.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python
+# Copyright (C) 2019 The Xaya developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+"""
+Tests the handling of pending moves (disputes and resolutions).
+"""
+
+from shipstest import ShipsTest
+
+
+class PendingTest (ShipsTest):
+
+  def run (self):
+    self.generate (110)
+
+    # Create a test channel with two participants.
+    self.mainLogger.info ("Creating test channel...")
+    channelId = self.openChannel (["foo", "bar"])
+
+    # Start up the two channel daemons.
+    self.mainLogger.info ("Starting channel daemons...")
+    with self.runChannelDaemon (channelId, "foo") as foo, \
+         self.runChannelDaemon (channelId, "bar") as bar:
+
+      daemons = [foo, bar]
+
+      self.mainLogger.info ("Running initialisation sequence...")
+      foo.rpc._notify.setposition ("""
+        xxxx..xx
+        ........
+        xxx.xxx.
+        ........
+        xx.xx.xx
+        ........
+        ........
+        ........
+      """)
+      bar.rpc._notify.setposition ("""
+        ........
+        ........
+        ........
+        xxxx..xx
+        ........
+        xxx.xxx.
+        ........
+        xx.xx.xx
+      """)
+      _, state = self.waitForPhase (daemons, ["shoot"])
+
+      # Make sure it is foo's turn.  If not, miss a shot with bar.
+      if state["current"]["state"]["whoseturn"] == 1:
+        bar.rpc._notify.shoot (row=7, column=0)
+        _, state = self.waitForPhase (daemons, ["shoot"])
+      self.assertEqual (state["current"]["state"]["whoseturn"], 0)
+
+      # We want to verify what happens if a dispute does not get mined
+      # immediately and is still pending after a new block.  For this,
+      # we first mine a block, detach it, then send the move, and then
+      # reattach that block.
+      self.mainLogger.info ("Testing pending disputes...")
+      self.generate (1)
+      blk = self.rpc.xaya.getbestblockhash ()
+      self.rpc.xaya.invalidateblock (blk)
+      txid = bar.rpc.filedispute ()
+      self.assertEqual (self.expectPendingMoves ("bar", ["d"]), [txid])
+      self.rpc.xaya.reconsiderblock (blk)
+      self.assertEqual (bar.rpc.filedispute (), "")
+      self.assertEqual (self.expectPendingMoves ("bar", ["d"]), [txid])
+      self.assertEqual (bar.getCurrentState ()["pending"], {
+        "dispute": txid,
+      })
+      self.generate (1)
+      self.expectPendingMoves ("bar", [])
+      self.assertEqual (bar.getCurrentState ()["pending"], {})
+
+      # Now verify what happens in the same situation with a resolution.
+      self.mainLogger.info ("Testing pending resolution...")
+      self.generate (1)
+      blk = self.rpc.xaya.getbestblockhash ()
+      self.rpc.xaya.invalidateblock (blk)
+      foo.rpc._notify.shoot (row=7, column=0)
+      txids = self.expectPendingMoves ("foo", ["r"])
+      self.rpc.xaya.reconsiderblock (blk)
+      self.assertEqual (self.expectPendingMoves ("foo", ["r"]), txids)
+      self.assertEqual (foo.getCurrentState ()["pending"], {
+        "resolution": txids[0],
+      })
+      self.generate (1)
+      self.expectPendingMoves ("foo", [])
+      self.assertEqual (foo.getCurrentState ()["pending"], {})
+
+
+if __name__ == "__main__":
+  PendingTest ().main ()

--- a/ships/channeltest/reorg.py
+++ b/ships/channeltest/reorg.py
@@ -152,13 +152,14 @@ class ReogTest (ShipsTest):
         "height": self.rpc.xaya.getblockcount (),
       })
 
-      # Currently, the channel daemon always resends, even if the
-      # previous move is still in the mempool.  For fixing this, see
-      # https://github.com/xaya/libxayagame/issues/65.  Hence, we should
-      # get *two* resolution moves.  If this issue gets fixed at some point,
-      # we should do two tests:  When the original move remains in the
-      # mempool, then no additional one should be sent.  If it is not anymore
-      # (e.g. because of a long reorg), then a *new* one should be sent.
+      # A resolution is not resent if the previous transaction remained in
+      # the mempool.  But in our case here, we actually resolved the dispute
+      # and thus cleared the pending flag, and only then "reopened" it due
+      # to the reorg.  For this case, at least the current implementation
+      # sends a second resolution.  (To fix this, we would have to keep
+      # track of previous resolutions even if their corresponding disputes
+      # have been cleared already, which seems not worth the trouble for
+      # the little extra potential benefit in some edge cases.)
       self.expectPendingMoves ("foo", ["r", "r"])
       self.generate (1)
       state = foo.getCurrentState ()

--- a/ships/channeltest/reorg.py
+++ b/ships/channeltest/reorg.py
@@ -128,7 +128,7 @@ class ReogTest (ShipsTest):
       # player who resolved should still make sure it gets into the chain
       # again (since they obviously still know a better state).
       self.mainLogger.info ("Reorg of a resolution move...")
-      bar.rpc._notify.filedispute ()
+      bar.rpc.filedispute ()
       self.expectPendingMoves ("bar", ["d"])
       self.generate (1)
       state = foo.getCurrentState ()
@@ -165,7 +165,7 @@ class ReogTest (ShipsTest):
       assert "dispute" not in state
 
       self.mainLogger.info ("Letting the game end with a dispute...")
-      bar.rpc._notify.filedispute ()
+      bar.rpc.filedispute ()
       self.expectPendingMoves ("bar", ["d"])
       self.generate (11)
       self.expectGameState ({

--- a/ships/channeltest/tx_fail.py
+++ b/ships/channeltest/tx_fail.py
@@ -60,7 +60,7 @@ class TxFailTest (ShipsTest):
       # File a dispute with locked wallet.  That should just silently fail.
       self.mainLogger.info ("Trying dispute that fails...")
       self.lock ()
-      bar.rpc._notify.filedispute ()
+      self.assertEqual (bar.rpc.filedispute (), "")
       self.expectPendingMoves ("bar", [])
       self.assertEqual (bar.getCurrentState ()["pending"], {})
       self.generate (1)
@@ -70,7 +70,7 @@ class TxFailTest (ShipsTest):
 
       # Let bar file a dispute against foo.
       self.mainLogger.info ("Filing a dispute whose resolution fails...")
-      bar.rpc._notify.filedispute ()
+      bar.rpc.filedispute ()
       self.generate (1)
       state = foo.getCurrentState ()
       self.assertEqual (state["dispute"], {

--- a/ships/channeltest/tx_fail.py
+++ b/ships/channeltest/tx_fail.py
@@ -62,6 +62,7 @@ class TxFailTest (ShipsTest):
       self.lock ()
       bar.rpc._notify.filedispute ()
       self.expectPendingMoves ("bar", [])
+      self.assertEqual (bar.getCurrentState ()["pending"], {})
       self.generate (1)
       state = bar.getCurrentState ()
       assert "dispute" not in state
@@ -88,6 +89,7 @@ class TxFailTest (ShipsTest):
       self.mainLogger.info ("Resolving it with unlocked wallet...")
       self.unlock ()
       self.expectPendingMoves ("foo", [])
+      self.assertEqual (foo.getCurrentState ()["pending"], {})
       self.generate (1)
       state = foo.getCurrentState ()
       self.assertEqual (state["dispute"], {

--- a/ships/channeltest/waitforchange.py
+++ b/ships/channeltest/waitforchange.py
@@ -144,7 +144,7 @@ class WaitForChangeTest (ShipsTest):
       # (because blocks trigger updates in general).
       self.mainLogger.info ("On-chain updates...")
       cnt = waiter.getNumCalls ()
-      bar.rpc._notify.filedispute ()
+      bar.rpc.filedispute ()
       time.sleep (0.1)
       self.assertEqual (waiter.getNumCalls (), cnt)
       self.generate (1)

--- a/ships/gametest/shipstest.py
+++ b/ships/gametest/shipstest.py
@@ -118,6 +118,8 @@ class ShipsTest (channeltest.TestCase):
     Expects that the given player has exactly a certain number
     and type (as per the top-level move value field) of moves
     pending in the mempool.
+
+    Returns the txids of the pending moves.
     """
 
     self.log.info ("Expecting pending moves for %s: %s" % (name, types))
@@ -131,6 +133,8 @@ class ShipsTest (channeltest.TestCase):
       actualTypes.append (mvKeys[0])
 
     self.assertEqual (actualTypes, types)
+
+    return [p["txid"] for p in pending]
 
   def waitForPhase (self, daemons, phases):
     """

--- a/ships/rpc-stubs/channel.json
+++ b/ships/rpc-stubs/channel.json
@@ -32,6 +32,7 @@
   },
   {
     "name": "filedispute",
-    "params": {}
+    "params": {},
+    "returns": "txid"
   }
 ]

--- a/xayagame/rpc-stubs/xaya.json
+++ b/xayagame/rpc-stubs/xaya.json
@@ -56,5 +56,10 @@
         "message": "message"
       },
     "returns": {}
+  },
+  {
+    "name": "name_pending",
+    "params": {},
+    "returns": []
   }
 ]

--- a/xayagame/testutils.cpp
+++ b/xayagame/testutils.cpp
@@ -57,6 +57,7 @@ MockXayaRpcServer::MockXayaRpcServer (jsonrpc::AbstractServerConnector& conn)
   EXPECT_CALL (*this, getblockheader (_)).Times (0);
   EXPECT_CALL (*this, game_sendupdates (_, _)).Times (0);
   EXPECT_CALL (*this, verifymessage (_, _, _)).Times (0);
+  EXPECT_CALL (*this, name_pending ()).Times (0);
 }
 
 MockXayaWalletRpcServer::MockXayaWalletRpcServer (

--- a/xayagame/testutils.hpp
+++ b/xayagame/testutils.hpp
@@ -86,6 +86,8 @@ public:
                                             const std::string& message,
                                             const std::string& signature));
 
+  MOCK_METHOD0 (name_pending, Json::Value ());
+
 };
 
 /**


### PR DESCRIPTION
This set of changes implements better tracking of pending (or confirmed) move transactions sent from a channel daemon.  We expose `name_pending` on the associated Xaya Core node, so that we can check if a transaction got confirmed or not when new blocks come in.  We only resent resolutions / disputes / Xayaships winner statements when the previous transaction is gone from the mempool.

Note that there is still an edge case that is not handled perfectly:  If a resolution move was confirmed but then that block is detached, we resend it even if the previous transaction got put back into the mempool.  Solving this "correctly" would be very hard, as we would have to keep track of resolution transactions even if their associated disputes have been cleared in the mean time.  Thus it seems not worth the extra trouble to "fix" this edge case; having a second resolution move is not a big issue anyway (except for the costs associated to the move), and should happen rarely in practice.

Fixes #65.