### PR TITLE
General code for tracking pending moves in a GSP

### DIFF
--- a/xayagame/Makefile.am
+++ b/xayagame/Makefile.am
@@ -35,6 +35,7 @@ libxayagame_la_SOURCES = \
   heightcache.cpp \
   lmdbstorage.cpp \
   mainloop.cpp \
+  pendingmoves.cpp \
   pruningqueue.cpp \
   signatures.cpp \
   sqlitegame.cpp \
@@ -50,6 +51,7 @@ xayagame_HEADERS = \
   heightcache.hpp \
   lmdbstorage.hpp \
   mainloop.hpp \
+  pendingmoves.hpp \
   pruningqueue.hpp \
   signatures.hpp \
   sqlitegame.hpp \
@@ -92,6 +94,7 @@ tests_SOURCES = \
   heightcache_tests.cpp \
   lmdbstorage_tests.cpp \
   mainloop_tests.cpp \
+  pendingmoves_tests.cpp \
   pruningqueue_tests.cpp \
   signatures_tests.cpp \
   sqlitegame_tests.cpp \

--- a/xayagame/defaultmain.cpp
+++ b/xayagame/defaultmain.cpp
@@ -165,6 +165,9 @@ DefaultMain (const GameDaemonConfiguration& config, const std::string& gameId,
 
       game->SetGameLogic (rules);
 
+      if (config.PendingMoves != nullptr)
+        game->SetPendingMoveProcessor (*config.PendingMoves);
+
       if (config.EnablePruning >= 0)
         game->EnablePruning (config.EnablePruning);
 
@@ -232,6 +235,9 @@ SQLiteMain (const GameDaemonConfiguration& config, const std::string& gameId,
       game->SetStorage (rules.GetStorage ());
 
       game->SetGameLogic (rules);
+
+      if (config.PendingMoves != nullptr)
+        game->SetPendingMoveProcessor (*config.PendingMoves);
 
       if (config.EnablePruning >= 0)
         game->EnablePruning (config.EnablePruning);

--- a/xayagame/defaultmain.hpp
+++ b/xayagame/defaultmain.hpp
@@ -7,6 +7,7 @@
 
 #include "game.hpp"
 #include "gamelogic.hpp"
+#include "pendingmoves.hpp"
 #include "sqlitegame.hpp"
 #include "storage.hpp"
 
@@ -204,6 +205,12 @@ struct GameDaemonConfiguration
    * data directory.
    */
   std::string DataDirectory;
+
+  /**
+   * If set to non-null, then this PendingMoveProcessor instance is associated
+   * to the Game.
+   */
+  PendingMoveProcessor* PendingMoves = nullptr;
 
   /**
    * Factory class for customed instances of certain optional classes

--- a/xayagame/game.cpp
+++ b/xayagame/game.cpp
@@ -326,6 +326,22 @@ Game::BlockDetach (const std::string& id, const Json::Value& data,
 }
 
 void
+Game::PendingMove (const std::string& id, const Json::Value& data)
+{
+  CHECK_EQ (id, gameId);
+  VLOG (2) << "Pending move:\n" << data;
+
+  uint256 txid;
+  CHECK (txid.FromHex (data["txid"].asString ()));
+  VLOG (1) << "Processing pending move " << txid.ToHex ();
+
+  std::lock_guard<std::mutex> lock(mut);
+
+  /* FIXME: Actual implementation, forwarding the data to a PendingMoveProcessor
+     (if we have it).  */
+}
+
+void
 Game::ConnectRpcClient (jsonrpc::IClientConnector& conn)
 {
   std::lock_guard<std::mutex> lock(mut);

--- a/xayagame/game.hpp
+++ b/xayagame/game.hpp
@@ -8,6 +8,7 @@
 #include "gamelogic.hpp"
 #include "heightcache.hpp"
 #include "mainloop.hpp"
+#include "pendingmoves.hpp"
 #include "pruningqueue.hpp"
 #include "storage.hpp"
 #include "transactionmanager.hpp"
@@ -132,6 +133,9 @@ private:
 
   /** The game rules in use.  */
   GameLogic* rules = nullptr;
+
+  /** The processor for pending moves, if any.  */
+  PendingMoveProcessor* pending = nullptr;
 
   /**
    * Desired size for batches of atomic transactions while the game is
@@ -279,13 +283,20 @@ public:
   void SetGameLogic (GameLogic& gl);
 
   /**
+   * Sets the processor for pending moves.  Setting one is optional; if no
+   * processor is set of pending move notifications are not enabled in the
+   * connected Xaya Core, then no pending state will be available.
+   */
+  void SetPendingMoveProcessor (PendingMoveProcessor& p);
+
+  /**
    * Enables (or changes) pruning with the given number of blocks to keep.
    * Must be called after the storage is set already.
    */
   void EnablePruning (unsigned nBlocks);
 
   /**
-   * Detects the ZMQ endpoint by calling getzmqnotifications on the Xaya
+   * Detects the ZMQ endpoint(s) by calling getzmqnotifications on the Xaya
    * daemon.  Returns false if pubgameblocks is not enabled.
    */
   bool DetectZmqEndpoint ();

--- a/xayagame/game.hpp
+++ b/xayagame/game.hpp
@@ -340,6 +340,15 @@ public:
   Json::Value GetCurrentJsonState () const;
 
   /**
+   * Returns a JSON object that contains data about the current state
+   * of pending moves as JSON.
+   *
+   * If no PendingMoveProcessor is attached or if pending moves are disabled
+   * in the Xaya Core notifications, then this raises a JSON-RPC error.
+   */
+  Json::Value GetPendingJsonState () const;
+
+  /**
    * Blocks the calling thread until a change to the game state has
    * (potentially) been made.  This can be used to implement long-polling
    * RPC methods, e.g. for front-ends.  Note that this function may return

--- a/xayagame/game.hpp
+++ b/xayagame/game.hpp
@@ -159,6 +159,7 @@ private:
                     bool seqMismatch) override;
   void BlockDetach (const std::string& id, const Json::Value& data,
                     bool seqMismatch) override;
+  void PendingMove (const std::string& id, const Json::Value& data) override;
 
   /**
    * Adds this game's ID to the tracked games of the core daemon.

--- a/xayagame/game_tests.cpp
+++ b/xayagame/game_tests.cpp
@@ -10,6 +10,7 @@
 
 #include "rpc-stubs/xayarpcserverstub.h"
 
+#include <xayautil/hash.hpp>
 #include <xayautil/uint256.hpp>
 
 #include <json/json.h>
@@ -283,6 +284,56 @@ public:
 
 };
 
+/**
+ * Processor for pending moves of our test game.  The JSON state returned
+ * for the pending moves is just a JSON object where names are mapped to
+ * the latest value in a move (i.e. what the value would be when all
+ * transactions are confirmed).
+ *
+ * In addition to the names, we also add the current state as string
+ * to the JSON object with key "state".
+ */
+class TestPendingMoves : public PendingMoveProcessor
+{
+
+private:
+
+  /** The currently built up JSON object.  */
+  Json::Value data;
+
+protected:
+
+  void
+  Clear () override
+  {
+    data = Json::Value (Json::objectValue);
+    data["state"] = GetConfirmedState ();
+  }
+
+  void
+  AddPendingMove (const Json::Value& mv) override
+  {
+    data["state"] = GetConfirmedState ();
+
+    const std::string nm = mv["name"].asString ();
+    const std::string val = mv["move"].asString ();
+    data[nm] = val;
+  }
+
+public:
+
+  TestPendingMoves ()
+    : data(Json::objectValue)
+  {}
+
+  Json::Value
+  ToJson () const override
+  {
+    return data;
+  }
+
+};
+
 /* ************************************************************************** */
 
 class GameTests : public GameTestWithBlockchain
@@ -386,7 +437,7 @@ TEST_F (ChainDetectionTests, Reconnection)
 
 using DetectZmqEndpointTests = GameTests;
 
-TEST_F (DetectZmqEndpointTests, Success)
+TEST_F (DetectZmqEndpointTests, BlocksWithoutPending)
 {
   const Json::Value notifications = ParseJson (R"(
     [
@@ -404,6 +455,27 @@ TEST_F (DetectZmqEndpointTests, Success)
   g.ConnectRpcClient (httpClient);
   ASSERT_TRUE (g.DetectZmqEndpoint ());
   EXPECT_EQ (GetZmqEndpoint (g), "address");
+  EXPECT_EQ (GetZmqEndpointPending (g), "");
+}
+
+TEST_F (DetectZmqEndpointTests, BlocksAndPending)
+{
+  const Json::Value notifications = ParseJson (R"(
+    [
+      {"type": "pubgameblocks", "address": "address blocks"},
+      {"type": "pubgamepending", "address": "address pending"}
+    ]
+  )");
+
+  EXPECT_CALL (mockXayaServer, getzmqnotifications ())
+      .WillOnce (Return (notifications));
+
+  Game g(GAME_ID);
+  mockXayaServer.SetBestBlock (0, BlockHash (0));
+  g.ConnectRpcClient (httpClient);
+  ASSERT_TRUE (g.DetectZmqEndpoint ());
+  EXPECT_EQ (GetZmqEndpoint (g), "address blocks");
+  EXPECT_EQ (GetZmqEndpointPending (g), "address pending");
 }
 
 TEST_F (DetectZmqEndpointTests, NotSet)
@@ -496,7 +568,8 @@ protected:
 
   /**
    * Converts a string in the game-state format to a series of moves as they
-   * would appear in the block notification.
+   * would appear in the block notification.  The txid of the move is derived
+   * by hashing the name.
    */
   static Json::Value
   Moves (const std::string& str)
@@ -508,7 +581,9 @@ protected:
       {
         Json::Value obj(Json::objectValue);
         obj["name"] = str.substr (i, 1);
-        obj["move"] = str.substr (i + 1, 1);
+        const std::string val = str.substr (i + 1, 1);
+        obj["move"] = val;
+        obj["txid"] = SHA256::Hash (val).ToHex ();
         moves.append (obj);
       }
 
@@ -1109,6 +1184,113 @@ TEST_F (SyncingTests, MissedAttachWhileCatchingUp)
                    Moves ("a2c3"), NO_SEQ_MISMATCH);
   EXPECT_EQ (GetState (g), State::UP_TO_DATE);
   ExpectGameState (BlockHash (12), "a2b1c3");
+}
+
+/* ************************************************************************** */
+
+class PendingMoveUpdateTests : public SyncingTests
+{
+
+protected:
+
+  TestPendingMoves proc;
+
+  PendingMoveUpdateTests ()
+  {
+    g.SetPendingMoveProcessor (proc);
+  }
+
+  /**
+   * Sets up the mempool that should be returned by the mock server.
+   * The txid's are constructed by hashing the given strings.
+   */
+  void
+  SetMempool (const std::vector<std::string>& vals)
+  {
+    Json::Value mempool(Json::arrayValue);
+    for (const auto& v : vals)
+      mempool.append (SHA256::Hash (v).ToHex ());
+
+    EXPECT_CALL (mockXayaServer, getrawmempool ())
+        .WillRepeatedly (Return (mempool));
+  }
+
+};
+
+TEST_F (PendingMoveUpdateTests, CatchingUp)
+{
+  EXPECT_CALL (mockXayaServer, game_sendupdates (GAME_GENESIS_HASH, GAME_ID))
+      .WillOnce (Return (SendupdatesResponse (BlockHash (12), "reqtoken")));
+
+  mockXayaServer.SetBestBlock (12, BlockHash (12));
+  ReinitialiseState (g);
+  EXPECT_EQ (GetState (g), State::CATCHING_UP);
+  ExpectGameState (TestGame::GenesisBlockHash (), "");
+
+  CallBlockAttach (g, "reqtoken",
+                   TestGame::GenesisBlockHash (), BlockHash (11), 11,
+                   Moves ("a0b1"), NO_SEQ_MISMATCH);
+  EXPECT_EQ (GetState (g), State::CATCHING_UP);
+  ExpectGameState (BlockHash (11), "a0b1");
+
+  CallBlockDetach (g, "reqtoken",
+                   TestGame::GenesisBlockHash (), BlockHash (11), 11,
+                   NO_SEQ_MISMATCH);
+  EXPECT_EQ (GetState (g), State::CATCHING_UP);
+  ExpectGameState (TestGame::GenesisBlockHash (), "");
+
+  CallPendingMove (g, Moves ("ax")[0]);
+
+  /* No updates should have been processed at all.  */
+  EXPECT_EQ (proc.ToJson (), ParseJson ("{}"));
+}
+
+TEST_F (PendingMoveUpdateTests, PendingMoves)
+{
+  const auto mv = Moves ("axbyaz");
+  for (const auto& mv : Moves ("axbyaz"))
+    CallPendingMove (g, mv);
+
+  EXPECT_EQ (proc.ToJson (), ParseJson (R"({
+    "state": "",
+    "a": "z",
+    "b": "y"
+  })"));
+}
+
+TEST_F (PendingMoveUpdateTests, BlockAttach)
+{
+  SetMempool ({"y"});
+
+  for (const auto& mv : Moves ("axby"))
+    CallPendingMove (g, mv);
+
+  AttachBlock (g, BlockHash (11), Moves ("a0b1"));
+  EXPECT_EQ (GetState (g), State::UP_TO_DATE);
+  ExpectGameState (BlockHash (11), "a0b1");
+
+  EXPECT_EQ (proc.ToJson (), ParseJson (R"({
+    "state": "a0b1",
+    "b": "y"
+  })"));
+}
+
+TEST_F (PendingMoveUpdateTests, BlockDetach)
+{
+  SetMempool ({"x"});
+
+  AttachBlock (g, BlockHash (11), Moves ("ax"));
+  EXPECT_EQ (GetState (g), State::UP_TO_DATE);
+  ExpectGameState (BlockHash (11), "ax");
+
+  DetachBlock (g);
+  EXPECT_EQ (GetState (g), State::UP_TO_DATE);
+  ExpectGameState (TestGame::GenesisBlockHash (), "");
+
+  EXPECT_EQ (proc.ToJson (), ParseJson (R"({
+    "state": "",
+    "a": "x"
+  })"));
 }
 
 /* ************************************************************************** */

--- a/xayagame/gamerpcserver.cpp
+++ b/xayagame/gamerpcserver.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018 The Xaya developers
+// Copyright (C) 2018-2019 The Xaya developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -21,6 +21,13 @@ GameRpcServer::getcurrentstate ()
 {
   LOG (INFO) << "RPC method called: getcurrentstate";
   return game.GetCurrentJsonState ();
+}
+
+Json::Value
+GameRpcServer::getpendingstate ()
+{
+  LOG (INFO) << "RPC method called: getpendingstate";
+  return game.GetPendingJsonState ();
 }
 
 std::string

--- a/xayagame/gamerpcserver.hpp
+++ b/xayagame/gamerpcserver.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018 The Xaya developers
+// Copyright (C) 2018-2019 The Xaya developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -41,6 +41,7 @@ public:
 
   virtual void stop () override;
   virtual Json::Value getcurrentstate () override;
+  virtual Json::Value getpendingstate () override;
   virtual std::string waitforchange (const std::string& knownBlock) override;
 
   /**

--- a/xayagame/pendingmoves.cpp
+++ b/xayagame/pendingmoves.cpp
@@ -1,0 +1,157 @@
+// Copyright (C) 2019 The Xaya developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "pendingmoves.hpp"
+
+#include <glog/logging.h>
+
+namespace xaya
+{
+
+/**
+ * Helper class to set/unset the current-state context in a PendingMoveProcessor
+ * using RAII.
+ */
+class PendingMoveProcessor::ContextSetter
+{
+
+private:
+
+  /** The corresponding PendingMoveProcessor instance.  */
+  PendingMoveProcessor& proc;
+
+public:
+
+  /**
+   * Sets the context based on the current state.
+   */
+  explicit ContextSetter (PendingMoveProcessor& p, const GameStateData& s)
+    : proc(p)
+  {
+    CHECK (proc.ctx == nullptr);
+    proc.ctx = std::make_unique<CurrentState> (s);
+  }
+
+  /**
+   * Unsets the context.
+   */
+  ~ContextSetter ()
+  {
+    CHECK (proc.ctx != nullptr);
+    proc.ctx.reset ();
+  }
+
+};
+
+const GameStateData&
+PendingMoveProcessor::GetConfirmedState () const
+{
+  CHECK (ctx != nullptr) << "No callback is running at the moment";
+  return ctx->state;
+}
+
+void
+PendingMoveProcessor::Reset ()
+{
+  const auto mempool = GetXayaRpc ().getrawmempool ();
+  VLOG (1)
+      << "Rebuilding pending move state with " << mempool.size ()
+      << " transactions in the (full) mempool...";
+
+  Clear ();
+  std::map<uint256, Json::Value> newPending;
+  for (const auto& txidStr : mempool)
+    {
+      uint256 txid;
+      CHECK (txidStr.isString ());
+      CHECK (txid.FromHex (txidStr.asString ()));
+
+      const auto mit = pending.find (txid);
+      if (mit == pending.end ())
+        continue;
+
+      newPending.emplace (txid, mit->second);
+      AddPendingMove (mit->second);
+    }
+
+  VLOG (1)
+      << "Sync with real mempool reduced size of pending moves from "
+      << pending.size () << " to " << newPending.size ();
+  pending = std::move (newPending);
+}
+
+namespace
+{
+
+/**
+ * Extracts the txid of a move JSON object as uint256.
+ */
+uint256
+GetMoveTxid (const Json::Value& mv)
+{
+  const auto& txidVal = mv["txid"];
+  CHECK (txidVal.isString ());
+
+  uint256 txid;
+  CHECK (txid.FromHex (txidVal.asString ()));
+
+  return txid;
+}
+
+} // anonymous namespace
+
+void
+PendingMoveProcessor::ProcessAttachedBlock (const GameStateData& state)
+{
+  VLOG (1) << "Updating pending state for attached block...";
+
+  ContextSetter setter(*this, state);
+  Reset ();
+}
+
+void
+PendingMoveProcessor::ProcessDetachedBlock (const GameStateData& state,
+                                            const Json::Value& blockData)
+{
+  /* We want to insert moves from the detached block into our map of
+     known moves, so that we can process them in case they are later on still
+     in Xaya Core's mempool.  */
+  const auto& mvArray = blockData["moves"];
+  CHECK (mvArray.isArray ());
+  for (const auto& mv : mvArray)
+    {
+      const uint256 txid = GetMoveTxid (mv);
+      pending.emplace (txid, mv);
+    }
+
+  VLOG (1)
+      << "Updating pending state for detached block "
+      << blockData["block"]["hash"].asString () << ": "
+      << mvArray.size () << " moves unconfirmed";
+  VLOG (2) << "Block data: " << blockData;
+
+  ContextSetter setter(*this, state);
+  Reset ();
+}
+
+void
+PendingMoveProcessor::ProcessMove (const GameStateData& state,
+                                   const Json::Value& mv)
+{
+  const uint256 txid = GetMoveTxid (mv);
+  VLOG (1) << "Processing pending move: " << txid.ToHex ();
+  VLOG (2) << "Full data: " << mv;
+
+  const auto inserted = pending.emplace (txid, mv);
+  if (!inserted.second)
+    {
+      VLOG (1) << "The move is already known";
+      return;
+    }
+
+  ContextSetter setter(*this, state);
+  AddPendingMove (mv);
+}
+
+} // namespace xaya

--- a/xayagame/pendingmoves.hpp
+++ b/xayagame/pendingmoves.hpp
@@ -1,0 +1,133 @@
+// Copyright (C) 2019 The Xaya developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef XAYAGAME_PENDINGMOVES_HPP
+#define XAYAGAME_PENDINGMOVES_HPP
+
+#include "gamelogic.hpp"
+#include "storage.hpp"
+
+#include <xayautil/uint256.hpp>
+
+#include <json/json.h>
+
+#include <memory>
+#include <map>
+
+namespace xaya
+{
+
+/**
+ * Processor for pending moves in the game.  This can be subclassed with
+ * actual logic (and storage of data) as needed by games.  They can then
+ * implement whatever processing they need to keep track of a "pending state"
+ * based on the current mempool.
+ */
+class PendingMoveProcessor : public GameProcessorWithContext
+{
+
+private:
+
+  /**
+   * Data about the "current state" accessible to the callbacks while they
+   * are being executed.
+   */
+  struct CurrentState
+  {
+
+    /** The current confirmed game state.  */
+    const GameStateData& state;
+
+    explicit CurrentState (const GameStateData& s)
+      : state(s)
+    {}
+
+  };
+
+  /**
+   * All currently known pending moves, indexed by their txid.  This is used
+   * to check whether a new move is already known, and also to retrieve the
+   * actual data when we sync with getrawmempool.
+   */
+  std::map<uint256, Json::Value> pending;
+
+  /** While a callback is running, the state context.  */
+  std::unique_ptr<CurrentState> ctx;
+
+  /**
+   * Resets the internal state, by clearing and then rebuilding from the
+   * list of pending moves, and syncing them with getrawmempool.  This assumes
+   * that the state context is already set up.
+   */
+  void Reset ();
+
+  class ContextSetter;
+
+protected:
+
+  /**
+   * Returns the currently confirmed on-chain game state.  This must only
+   * be called while a callback (Clear or AddPendingMove) is currently
+   * running.
+   */
+  const GameStateData& GetConfirmedState () const;
+
+  /**
+   * Clears the state, so it corresponds to an empty mempool.
+   */
+  virtual void Clear () = 0;
+
+  /**
+   * Adds a new pending move to the current pending state in this instance.
+   * mv contains the full move data as JSON.
+   *
+   * Between calls to Clear, this is called at most once for any particular
+   * transaction.  If one move is built on another (i.e. spending the other's
+   * name), then it is usually passed to AddPendingMove later.
+   *
+   * During exceptional situations (e.g. reorgs), it may happen that
+   * conflicting, out-of-order or already confirmed moves are passed here.
+   * Implementations must be able to handle that gracefully, although the
+   * resulting pending state may be "wrong".
+   */
+  virtual void AddPendingMove (const Json::Value& mv) = 0;
+
+public:
+
+  PendingMoveProcessor () = default;
+
+  /**
+   * Processes a newly attached block.  This checks the current mempool
+   * of Xaya Core and then rebuilds the pending state based on known moves
+   * that are still in the mempool.
+   */
+  void ProcessAttachedBlock (const GameStateData& state);
+
+  /**
+   * Processes a detached block.  This clears the pending state and rebuilds
+   * it from Xaya Core's mempool (including re-added transactions from
+   * the block that was just detached).
+   *
+   * state must be the confirmed game-state *after* the block has been
+   * detached already (i.e. the state before, not "at", the block).
+   */
+  void ProcessDetachedBlock (const GameStateData& state,
+                             const Json::Value& blockData);
+
+  /**
+   * Processes a newly received pending move.
+   */
+  void ProcessMove (const GameStateData& state, const Json::Value& mv);
+
+  /**
+   * Returns a JSON representation of the current state.  This is exposed
+   * by the GSP's RPC server for use by frontends (and the likes).
+   */
+  virtual Json::Value ToJson () const = 0;
+
+};
+
+} // namespace xaya
+
+#endif // XAYAGAME_PENDINGMOVES_HPP

--- a/xayagame/pendingmoves_tests.cpp
+++ b/xayagame/pendingmoves_tests.cpp
@@ -1,0 +1,274 @@
+// Copyright (C) 2019 The Xaya developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "pendingmoves.hpp"
+
+#include "testutils.hpp"
+
+#include <xayautil/hash.hpp>
+
+#include <jsonrpccpp/client/connectors/httpclient.h>
+#include <jsonrpccpp/server/connectors/httpserver.h>
+
+#include <glog/logging.h>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+namespace xaya
+{
+namespace
+{
+
+using testing::Return;
+
+/**
+ * A simple implementation of a pending move processor.  Moves are expected
+ * to be just strings, and we keep track of an ordered list of those strings
+ * for each name (as a JSON array).
+ */
+class MessageArrayPendingMoves : public PendingMoveProcessor
+{
+
+private:
+
+  /**
+   * The current data as JSON object.  It has two fields:  The "names"
+   * field holds an object mapping names to their arrays, and the "confirmed"
+   * field stores the current game-state string.  The latter is useful to
+   * test exposure of the confirmed state to the pending processor.
+   */
+  Json::Value data;
+
+protected:
+
+  void
+  Clear () override
+  {
+    data = Json::Value (Json::objectValue);
+    data["confirmed"] = GetConfirmedState ();
+    data["names"] = Json::Value (Json::objectValue);
+  }
+
+  void
+  AddPendingMove (const Json::Value& mv) override
+  {
+    const std::string name = mv["name"].asString ();
+    const std::string msg = mv["move"].asString ();
+
+    auto& names = data["names"];
+    CHECK (names.isObject ());
+    if (!names.isMember (name))
+      names[name] = Json::Value (Json::arrayValue);
+
+    names[name].append (msg);
+
+    data["confirmed"] = GetConfirmedState ();
+  }
+
+public:
+
+  MessageArrayPendingMoves ()
+    : data(Json::objectValue)
+  {
+    data["names"] = Json::Value (Json::objectValue);
+  }
+
+  Json::Value
+  ToJson () const override
+  {
+    return data;
+  }
+
+};
+
+/**
+ * Constructs a move JSON for the given name and value.  The txid is computed
+ * by hashing the value.
+ */
+Json::Value
+MoveJson (const std::string& nm, const std::string& val)
+{
+  Json::Value res(Json::objectValue);
+  res["txid"] = SHA256::Hash (val).ToHex ();
+  res["name"] = nm;
+  res["move"] = val;
+
+  return res;
+}
+
+/**
+ * Constructs a block JSON for the given list of moves.
+ */
+Json::Value
+BlockJson (const std::vector<Json::Value>& moves)
+{
+  Json::Value mvJson(Json::arrayValue);
+  for (const auto& mv : moves)
+    mvJson.append (mv);
+
+  Json::Value res(Json::objectValue);
+  res["moves"] = mvJson;
+
+  return res;
+}
+
+class PendingMovesTests : public testing::Test
+{
+
+private:
+
+  jsonrpc::HttpServer httpServer;
+  jsonrpc::HttpClient httpClient;
+
+  MockXayaRpcServer mockXayaServer;
+  XayaRpcClient rpcClient;
+
+protected:
+
+  MessageArrayPendingMoves proc;
+
+  PendingMovesTests ()
+    : httpServer(MockXayaRpcServer::HTTP_PORT),
+      httpClient(MockXayaRpcServer::HTTP_URL),
+      mockXayaServer(httpServer),
+      rpcClient(httpClient)
+  {
+    proc.InitialiseGameContext (Chain::MAIN, "game id", &rpcClient);
+
+    mockXayaServer.StartListening ();
+  }
+
+  ~PendingMovesTests ()
+  {
+    mockXayaServer.StopListening ();
+  }
+
+  /**
+   * Sets the mempool to return from the mock server.  The txid's are created
+   * by hashing the provided strings (corresponding to "value" in MoveJson).
+   */
+  void
+  SetMempool (const std::vector<std::string>& values)
+  {
+    Json::Value txids(Json::arrayValue);
+    for (const auto& v : values)
+      txids.append (SHA256::Hash (v).ToHex ());
+
+    EXPECT_CALL (mockXayaServer, getrawmempool ())
+        .WillRepeatedly (Return (txids));
+  }
+
+};
+
+/* ************************************************************************** */
+
+TEST_F (PendingMovesTests, AddingMoves)
+{
+  proc.ProcessMove ("state", MoveJson ("foo", "bar"));
+  proc.ProcessMove ("state", MoveJson ("foo", "baz"));
+  proc.ProcessMove ("state", MoveJson ("foo", "bar"));
+  proc.ProcessMove ("state", MoveJson ("abc", "def"));
+  proc.ProcessMove ("state", MoveJson ("abc", "def"));
+
+  EXPECT_EQ (proc.ToJson (), ParseJson (R"({
+    "confirmed": "state",
+    "names":
+      {
+        "abc": ["def"],
+        "foo": ["bar", "baz"]
+      }
+  })"));
+}
+
+TEST_F (PendingMovesTests, AttachedBlock)
+{
+  proc.ProcessMove ("old", MoveJson ("foo", "c"));
+  proc.ProcessMove ("old", MoveJson ("foo", "b"));
+  proc.ProcessMove ("old", MoveJson ("foo", "a"));
+  proc.ProcessMove ("old", MoveJson ("bar", "x"));
+  proc.ProcessMove ("old", MoveJson ("baz", "y"));
+
+  SetMempool ({"b", "c", "y", "z"});
+  proc.ProcessAttachedBlock ("new");
+
+  EXPECT_EQ (proc.ToJson (), ParseJson (R"({
+    "confirmed": "new",
+    "names":
+      {
+        "foo": ["b", "c"],
+        "baz": ["y"]
+      }
+  })"));
+}
+
+TEST_F (PendingMovesTests, DetachedBlock)
+{
+  proc.ProcessMove ("new", MoveJson ("foo", "b"));
+  proc.ProcessMove ("new", MoveJson ("bar", "x"));
+
+  SetMempool ({"a", "b", "x", "y", "z"});
+  proc.ProcessDetachedBlock ("old", BlockJson (
+    {
+      MoveJson ("foo", "a"),
+      MoveJson ("baz", "y"),
+    }));
+
+  /* This should be ignored, as we have it already.  */
+  proc.ProcessMove ("old", MoveJson ("foo", "a"));
+
+  EXPECT_EQ (proc.ToJson (), ParseJson (R"({
+    "confirmed": "old",
+    "names":
+      {
+        "foo": ["a", "b"],
+        "bar": ["x"],
+        "baz": ["y"]
+      }
+  })"));
+}
+
+TEST_F (PendingMovesTests, OneBlockReorg)
+{
+  /* This test verifies what happens in the "typical" situation of a
+     one-block-reorg (orphan block), assuming that notifications are sent
+     in order (as they would if one socket is used for ZMQ blocks and
+     pending moves).  While this should be covered by the tests before,
+     it makes sense to verify this important situation also explicitly.  */
+
+  proc.ProcessMove ("new 1", MoveJson ("foo", "b"));
+  proc.ProcessMove ("new 1", MoveJson ("bar", "x"));
+
+  SetMempool ({"a", "b", "x", "y"});
+  proc.ProcessDetachedBlock ("old", BlockJson (
+    {
+      MoveJson ("foo", "a"),
+      MoveJson ("baz", "y"),
+    }));
+
+  proc.ProcessMove ("old", MoveJson ("foo", "a"));
+  proc.ProcessMove ("baz", MoveJson ("baz", "y"));
+
+  EXPECT_EQ (proc.ToJson (), ParseJson (R"({
+    "confirmed": "old",
+    "names":
+      {
+        "foo": ["a", "b"],
+        "bar": ["x"],
+        "baz": ["y"]
+      }
+  })"));
+
+  SetMempool ({});
+  proc.ProcessAttachedBlock ("new 2");
+
+  EXPECT_EQ (proc.ToJson (), ParseJson (R"({
+    "confirmed": "new 2",
+    "names": {}
+  })"));
+}
+
+/* ************************************************************************** */
+
+} // anonymous namespace
+} // namespace xaya

--- a/xayagame/rpc-stubs/game.json
+++ b/xayagame/rpc-stubs/game.json
@@ -9,6 +9,11 @@
     "returns": {}
   },
   {
+    "name": "getpendingstate",
+    "params": {},
+    "returns": {}
+  },
+  {
     "name": "waitforchange",
     "params": [ "known block" ],
     "returns": ""

--- a/xayagame/rpc-stubs/xaya.json
+++ b/xayagame/rpc-stubs/xaya.json
@@ -58,6 +58,11 @@
     "returns": {}
   },
   {
+    "name": "getrawmempool",
+    "params": {},
+    "returns": []
+  },
+  {
     "name": "name_pending",
     "params": {},
     "returns": []

--- a/xayagame/testutils.cpp
+++ b/xayagame/testutils.cpp
@@ -117,6 +117,12 @@ GameTestFixture::CallBlockDetach (Game& g, const std::string& reqToken,
 }
 
 void
+GameTestFixture::CallPendingMove (Game& g, const Json::Value& mv) const
+{
+  g.PendingMove (gameId, mv);
+}
+
+void
 GameTestWithBlockchain::SetStartingBlock (const uint256& hash)
 {
   blockHashes = {hash};

--- a/xayagame/testutils.cpp
+++ b/xayagame/testutils.cpp
@@ -57,6 +57,7 @@ MockXayaRpcServer::MockXayaRpcServer (jsonrpc::AbstractServerConnector& conn)
   EXPECT_CALL (*this, getblockheader (_)).Times (0);
   EXPECT_CALL (*this, game_sendupdates (_, _)).Times (0);
   EXPECT_CALL (*this, verifymessage (_, _, _)).Times (0);
+  EXPECT_CALL (*this, getrawmempool ()).Times (0);
   EXPECT_CALL (*this, name_pending ()).Times (0);
 }
 

--- a/xayagame/testutils.hpp
+++ b/xayagame/testutils.hpp
@@ -201,6 +201,12 @@ protected:
     return g.zmq.addrBlocks;
   }
 
+  static std::string
+  GetZmqEndpointPending (const Game& g)
+  {
+    return g.zmq.addrPending;
+  }
+
   static State
   GetState (const Game& g)
   {
@@ -234,7 +240,7 @@ protected:
   }
 
   /**
-   * Calls BlockAttach on the given game instance.  The function takes care
+   * Calls BlockAttach on the given Game instance.  The function takes care
    * of setting up the blockData JSON object correctly based on the building
    * blocks given here.
    */
@@ -244,13 +250,18 @@ protected:
                         const Json::Value& moves, const bool seqMismatch) const;
 
   /**
-   * Calls BlockDetach on the given game instance, setting up the blockData
+   * Calls BlockDetach on the given Game instance, setting up the blockData
    * object correctly.
    */
   void CallBlockDetach (Game& g, const std::string& reqToken,
                         const uint256& parentHash, const uint256& blockHash,
                         unsigned height,
                         const Json::Value& moves, const bool seqMismatch) const;
+
+  /**
+   * Calls PendingMove on the given Game instance.
+   */
+  void CallPendingMove (Game& g, const Json::Value& data) const;
 
 };
 

--- a/xayagame/testutils.hpp
+++ b/xayagame/testutils.hpp
@@ -86,6 +86,7 @@ public:
                                             const std::string& message,
                                             const std::string& signature));
 
+  MOCK_METHOD0 (getrawmempool, Json::Value ());
   MOCK_METHOD0 (name_pending, Json::Value ());
 
 };

--- a/xayagame/testutils.hpp
+++ b/xayagame/testutils.hpp
@@ -197,7 +197,7 @@ protected:
   static std::string
   GetZmqEndpoint (const Game& g)
   {
-    return g.zmq.addr;
+    return g.zmq.addrBlocks;
   }
 
   static State

--- a/xayagame/zmqsubscriber.hpp
+++ b/xayagame/zmqsubscriber.hpp
@@ -52,6 +52,13 @@ public:
   virtual void BlockDetach (const std::string& gameId,
                             const Json::Value& data, bool seqMismatch) = 0;
 
+  /**
+   * Callback for pending moves added to the mempool.  Since pending moves
+   * are best effort only, we do not care about sequence number mismatches.
+   */
+  virtual void PendingMove (const std::string& gameId,
+                            const Json::Value& data) = 0;
+
 };
 
 /**
@@ -63,8 +70,11 @@ class ZmqSubscriber
 
 private:
 
-  /** The ZMQ endpoint to connect to.  */
-  std::string addr;
+  /** The ZMQ endpoint to connect to for block updates.  */
+  std::string addrBlocks;
+  /** The ZMQ endpoint to connect to for pending moves.  */
+  std::string addrPending;
+
   /** The ZMQ context that is used by the this instance.  */
   zmq::context_t ctx;
   /**
@@ -126,13 +136,11 @@ public:
   void SetEndpoint (const std::string& address);
 
   /**
-   * Returns whether the endpoint is set.
+   * Sets the ZMW endpoint that will be used to receive pending moves.
+   * Unlike SetEndpoint, this is optional.  If not set, then the ZMQ
+   * thread will simply not listen to pending moves.
    */
-  bool
-  IsEndpointSet () const
-  {
-    return !addr.empty ();
-  }
+  void SetEndpointForPending (const std::string& address);
 
   /**
    * Adds a new listener for the given game ID.  Must not be called when

--- a/xayagame/zmqsubscriber.hpp
+++ b/xayagame/zmqsubscriber.hpp
@@ -158,6 +158,15 @@ public:
   }
 
   /**
+   * Returns true if notifications for pending moves are enabled.
+   */
+  bool
+  IsPendingEnabled () const
+  {
+    return !addrPending.empty ();
+  }
+
+  /**
    * Starts the ZMQ subscriber in a new thread.  Must only be called after
    * the ZMQ endpoint has been configured, and must not be called when
    * ZMQ is already running.

--- a/xayagame/zmqsubscriber.hpp
+++ b/xayagame/zmqsubscriber.hpp
@@ -17,6 +17,7 @@
 #include <string>
 #include <thread>
 #include <unordered_map>
+#include <vector>
 
 namespace xaya
 {
@@ -66,8 +67,13 @@ private:
   std::string addr;
   /** The ZMQ context that is used by the this instance.  */
   zmq::context_t ctx;
-  /** The ZMQ socket used to subscribe to the Xaya daemon, if connected.  */
-  std::unique_ptr<zmq::socket_t> socket;
+  /**
+   * The ZMQ sockets used to subscribe to the Xaya daemon, if connected.
+   * If we have multiple addresses we listen to (e.g. different ones for
+   * blocks and pending moves), then this contains multiple sockets that
+   * are read in a multiplexed fashion using zmq::poll.
+   */
+  std::vector<std::unique_ptr<zmq::socket_t>> sockets;
 
   /** Game IDs and associated listeners.  */
   std::unordered_multimap<std::string, ZmqListener*> listeners;

--- a/xayagame/zmqsubscriber_tests.cpp
+++ b/xayagame/zmqsubscriber_tests.cpp
@@ -123,7 +123,7 @@ protected:
     zmq.shouldStop = true;
 
     threadToWaitFor.join ();
-    zmq.socket.reset ();
+    zmq.sockets.clear ();
   }
 
 };


### PR DESCRIPTION
This set of changes adds core support for tracking pending moves in a GSP (as described in #43).  It defines an abstract class `PendingMoveProcessor`, which games can subclass if they want to do game-specific processing of a "pending state".  If this feature is enabled, then libxayagame will listen to the `zmqgamepending` notifications sent from Xaya Core and keep the pending state updated as well as is possible.

Note that with these changes in, there are still some things to do that will come later:  Support in mover and integration tests with it, a `waitforchange` equivalent for the pending state, and support for `SQLiteGame` with integration in Xayaships.