### PR TITLE
Implement "WaitForChange" for pending moves

### DIFF
--- a/xayagame/gamerpcserver.cpp
+++ b/xayagame/gamerpcserver.cpp
@@ -37,6 +37,13 @@ GameRpcServer::waitforchange (const std::string& knownBlock)
   return DefaultWaitForChange (game, knownBlock);
 }
 
+Json::Value
+GameRpcServer::waitforpendingchange (const int oldVersion)
+{
+  LOG (INFO) << "RPC method called: waitforpendingchange " << oldVersion;
+  return game.WaitForPendingChange (oldVersion);
+}
+
 std::string
 GameRpcServer::DefaultWaitForChange (const Game& g,
                                      const std::string& knownBlock)
@@ -50,7 +57,7 @@ GameRpcServer::DefaultWaitForChange (const Game& g,
   uint256 newBlock;
   g.WaitForChange (oldBlock, newBlock);
 
-  /* If there is no best block so far, return JSON null.  */
+  /* If there is no best block so far, return empty string.  */
   if (newBlock.IsNull ())
     return "";
 

--- a/xayagame/gamerpcserver.hpp
+++ b/xayagame/gamerpcserver.hpp
@@ -43,6 +43,7 @@ public:
   virtual Json::Value getcurrentstate () override;
   virtual Json::Value getpendingstate () override;
   virtual std::string waitforchange (const std::string& knownBlock) override;
+  virtual Json::Value waitforpendingchange (int oldVersion) override;
 
   /**
    * Implements the standard waitforchange RPC method independent of a

--- a/xayagame/rpc-stubs/game.json
+++ b/xayagame/rpc-stubs/game.json
@@ -15,7 +15,12 @@
   },
   {
     "name": "waitforchange",
-    "params": [ "known block" ],
+    "params": ["known block"],
     "returns": ""
+  },
+  {
+    "name": "waitforpendingchange",
+    "params": [42],
+    "returns": {}
   }
 ]


### PR DESCRIPTION
This adds new methods `Game::WaitForPendingChange` and the RPC `waitforpendingchange` based on it.  With them, clients can do long-polling for receiving updates on changes to the state of pending moves.

This is the third step towards finalising #43.