### PR TITLE
Utility template for mocked server + HTTP server/client

### DIFF
--- a/gamechannel/rollingstate_tests.cpp
+++ b/gamechannel/rollingstate_tests.cpp
@@ -46,7 +46,7 @@ protected:
   RollingState state;
 
   RollingStateTests ()
-    : state(game.rules, rpcClient, channelId)
+    : state(game.rules, mockXayaServer.GetClient (), channelId)
   {
     meta1.set_reinit ("reinit 1");
     meta1.add_participants ()->set_address ("addr 0");

--- a/gamechannel/testgame.hpp
+++ b/gamechannel/testgame.hpp
@@ -15,12 +15,7 @@
 #include <xayagame/testutils.hpp>
 #include <xayautil/uint256.hpp>
 
-#include <xayagame/rpc-stubs/xayarpcclient.h>
-#include <xayagame/rpc-stubs/xayawalletrpcclient.h>
-
 #include <json/json.h>
-#include <jsonrpccpp/client/connectors/httpclient.h>
-#include <jsonrpccpp/server/connectors/httpserver.h>
 
 #include <gtest/gtest.h>
 
@@ -146,21 +141,10 @@ public:
 class TestGameFixture : public testing::Test
 {
 
-private:
-
-  jsonrpc::HttpServer httpServer;
-  jsonrpc::HttpClient httpClient;
-
-  jsonrpc::HttpServer httpServerWallet;
-  jsonrpc::HttpClient httpClientWallet;
-
 protected:
 
-  MockXayaRpcServer mockXayaServer;
-  XayaRpcClient rpcClient;
-
-  MockXayaWalletRpcServer mockXayaWallet;
-  XayaWalletRpcClient rpcWallet;
+  HttpRpcServer<MockXayaRpcServer> mockXayaServer;
+  HttpRpcServer<MockXayaWalletRpcServer> mockXayaWallet;
 
   TestGame game;
 
@@ -169,11 +153,6 @@ protected:
    * in-memory database and sets up the schema on it.
    */
   TestGameFixture ();
-
-  /**
-   * The destructor shuts down the mock Xaya server.
-   */
-  ~TestGameFixture ();
 
   /**
    * Returns the raw database handle of the test game.

--- a/gamechannel/testgame_tests.cpp
+++ b/gamechannel/testgame_tests.cpp
@@ -58,7 +58,7 @@ protected:
     const auto po = game.rules.ParseState (channelId, meta, old);
     CHECK (po != nullptr);
 
-    return po->ApplyMove (rpcClient, mv, newState);
+    return po->ApplyMove (mockXayaServer.GetClient (), mv, newState);
   }
 
 };

--- a/ships/logic_tests.cpp
+++ b/ships/logic_tests.cpp
@@ -273,7 +273,7 @@ TEST_F (CreateChannelTests, FailsForTxidCollision)
 {
   /* Turn off the mock server.  We don't need it, and it complicates the
      death test due to extra threads.  */
-  mockXayaServer.StopListening ();
+  mockXayaServer->StopListening ();
 
   const auto data = ParseJson (R"(
     {"c": {"addr": "address"}}
@@ -586,8 +586,8 @@ protected:
     const std::string hashed
         = xaya::GetChannelSignatureMessage (channelId, meta,
                                             "winnerstatement", data);
-    EXPECT_CALL (mockXayaServer, verifymessage ("", hashed,
-                                                xaya::EncodeBase64 (sgn)))
+    EXPECT_CALL (*mockXayaServer,
+                 verifymessage ("", hashed, xaya::EncodeBase64 (sgn)))
         .WillOnce (Return (res));
   }
 
@@ -781,13 +781,13 @@ protected:
     Json::Value signatureOk(Json::objectValue);
     signatureOk["valid"] = true;
     signatureOk["address"] = "addr 0";
-    EXPECT_CALL (mockXayaServer, verifymessage ("", _,
-                                                xaya::EncodeBase64 ("sgn 0")))
+    EXPECT_CALL (*mockXayaServer,
+                 verifymessage ("", _, xaya::EncodeBase64 ("sgn 0")))
         .WillRepeatedly (Return (signatureOk));
 
     signatureOk["address"] = "addr 1";
-    EXPECT_CALL (mockXayaServer, verifymessage ("", _,
-                                                xaya::EncodeBase64 ("sgn 1")))
+    EXPECT_CALL (*mockXayaServer,
+                 verifymessage ("", _, xaya::EncodeBase64 ("sgn 1")))
         .WillRepeatedly (Return (signatureOk));
 
     /* Explicitly add stats rows so we can use ExpectStatsRow even if there

--- a/ships/testutils.cpp
+++ b/ships/testutils.cpp
@@ -26,22 +26,12 @@ ParseJson (const std::string& str)
 }
 
 InMemoryLogicFixture::InMemoryLogicFixture ()
-  : httpServer(xaya::MockXayaRpcServer::HTTP_PORT),
-    httpClient(xaya::MockXayaRpcServer::HTTP_URL),
-    mockXayaServer(httpServer),
-    rpcClient(httpClient)
 {
   game.Initialise (":memory:");
-  game.InitialiseGameContext (xaya::Chain::MAIN, "xs", &rpcClient);
+  game.InitialiseGameContext (xaya::Chain::MAIN, "xs",
+                              &mockXayaServer.GetClient ());
   game.GetStorage ().Initialise ();
   /* The initialisation above already sets up the database schema.  */
-
-  mockXayaServer.StartListening ();
-}
-
-InMemoryLogicFixture::~InMemoryLogicFixture ()
-{
-  mockXayaServer.StopListening ();
 }
 
 sqlite3*

--- a/ships/testutils.hpp
+++ b/ships/testutils.hpp
@@ -12,8 +12,6 @@
 #include <xayagame/rpc-stubs/xayarpcclient.h>
 
 #include <json/json.h>
-#include <jsonrpccpp/client/connectors/httpclient.h>
-#include <jsonrpccpp/server/connectors/httpserver.h>
 
 #include <gtest/gtest.h>
 
@@ -37,15 +35,9 @@ Json::Value ParseJson (const std::string& str);
 class InMemoryLogicFixture : public testing::Test
 {
 
-private:
-
-  jsonrpc::HttpServer httpServer;
-  jsonrpc::HttpClient httpClient;
-
 protected:
 
-  xaya::MockXayaRpcServer mockXayaServer;
-  XayaRpcClient rpcClient;
+  xaya::HttpRpcServer<xaya::MockXayaRpcServer> mockXayaServer;
 
   ShipsLogic game;
 
@@ -54,11 +46,6 @@ protected:
    * in-memory database and sets up the schema on it.
    */
   InMemoryLogicFixture ();
-
-  /**
-   * The destructor shuts down the mock Xaya server.
-   */
-  ~InMemoryLogicFixture ();
 
   /**
    * Returns the raw database handle of the test game.

--- a/xayagame/testutils.hpp
+++ b/xayagame/testutils.hpp
@@ -155,9 +155,10 @@ private:
 
 public:
 
-  HttpRpcServer ()
+  template <typename... Args>
+    HttpRpcServer (Args&... args)
     : httpServer(MockServer::HTTP_PORT),
-      srv(httpServer),
+      srv(httpServer, args...),
       httpClient(MockServer::HTTP_URL),
       rpcClient(httpClient)
   {
@@ -196,7 +197,7 @@ public:
   /**
    * Returns the HTTP client connector.
    */
-  jsonrpc::IClientConnector&
+  jsonrpc::HttpClient&
   GetClientConnector ()
   {
     return httpClient;


### PR DESCRIPTION
This introduces the `HttpRpcServer` template, which wraps a mocked RPC server together with its corresponding `HttpClient`, `HttpServer` and the RPC client.  By doing that, we can avoid the need to have all those instances lying around manually in various tests, as well as the need to start/stop the server explicitly from constructors and destructors of test fixtures.

This resolves #82.