### PR TITLE
Integrate pending moves with SQLiteGame and shipsd

### DIFF
--- a/gamechannel/chaintochannel_tests.cpp
+++ b/gamechannel/chaintochannel_tests.cpp
@@ -183,6 +183,8 @@ public:
 
   MOCK_METHOD0 (stop, void ());
   MOCK_METHOD0 (getcurrentstate, Json::Value ());
+  MOCK_METHOD0 (getpendingstate, Json::Value ());
+  MOCK_METHOD1 (waitforpendingchange, Json::Value (int));
 
 };
 

--- a/gamechannel/channelgame_tests.cpp
+++ b/gamechannel/channelgame_tests.cpp
@@ -4,6 +4,8 @@
 
 #include "channelgame.hpp"
 
+#include "protoutils.hpp"
+#include "stateproof.hpp"
 #include "testgame.hpp"
 
 #include <xayautil/hash.hpp>
@@ -38,11 +40,11 @@ class ChannelGameTests : public TestGameFixture
 
 private:
 
-  proto::ChannelMetadata meta;
-
   ChannelsTable tbl;
 
 protected:
+
+  proto::ChannelMetadata meta;
 
   ChannelGameTests ()
     : tbl(game)
@@ -404,6 +406,202 @@ TEST_F (ResolutionTests, ResolvesToNoTurnState)
 
   EXPECT_EQ (ch->GetLatestState (), "100 6");
   EXPECT_FALSE (ch->HasDispute ());
+}
+
+/* ************************************************************************** */
+
+/**
+ * Fake implementation of PendingMoves for our test game.
+ */
+class TestPendingMoves : public ChannelGame::PendingMoves
+{
+
+protected:
+
+  /**
+   * We need to implement AddPendingMove so that we can instantiate this
+   * class.  This method will never be called, though, as we just call the
+   * methods from ChannelGame::PendingMoves directly to test them.  (We do not
+   * even have a move format defined for the test game at all.)
+   */
+  void
+  AddPendingMove (const Json::Value& mv) override
+  {
+    LOG (FATAL) << "AddPendingMove is not implemented";
+  }
+
+public:
+
+  explicit TestPendingMoves (TestGame& g)
+    : PendingMoves(g)
+  {}
+
+  using ChannelGame::PendingMoves::Clear;
+  using ChannelGame::PendingMoves::AddPendingStateProof;
+
+};
+
+class PendingMovesTests : public ChannelGameTests
+{
+
+protected:
+
+  TestPendingMoves proc;
+
+  PendingMovesTests ()
+    : proc(game)
+  {
+    proc.InitialiseGameContext (Chain::MAIN, "add",
+                                &mockXayaServer.GetClient ());
+  }
+
+  /**
+   * Expects that the pending state has exactly the given states for
+   * all the channels.  IDs are passed as strings that are hashed (similar
+   * to CreateChannel).
+   *
+   * Since we cannot provide the exact "expected" representation of the
+   * base64-encoded StateProof, we instead modify the JSON that is compared
+   * in the end so as to only compare the represented state.  That is good
+   * enough for our purposes.
+   */
+  void
+  ExpectPendingChannels (const std::map<std::string, std::string>& expected)
+  {
+    Json::Value expectedJson(Json::objectValue);
+    for (const auto& entry : expected)
+      {
+        const uint256 id = SHA256::Hash (entry.first);
+
+        Json::Value val(Json::objectValue);
+        val["id"] = id.ToHex ();
+        val["state"] = entry.second;
+
+        auto p = game.rules.ParseState (id, meta, entry.second);
+        CHECK (p != nullptr);
+        val["turncount"] = p->TurnCount ();
+
+        expectedJson[id.ToHex ()] = val;
+      }
+
+    auto actual = proc.ToJson ()["channels"];
+    ASSERT_TRUE (actual.isObject ());
+    for (auto& entry : actual)
+      {
+        proto::StateProof proof;
+        ASSERT_TRUE (ProtoFromBase64 (entry["proof"].asString (), proof));
+        entry.removeMember ("proof");
+        entry["state"] = UnverifiedProofEndState (proof);
+      }
+
+    EXPECT_EQ (actual, expectedJson);
+  }
+
+};
+
+TEST_F (PendingMovesTests, InvalidStateProof)
+{
+  auto ch = CreateChannel ("test", "0 1");
+  proc.AddPendingStateProof (*ch, ParseStateProof (R"(
+    initial_state:
+      {
+        data: "42 5"
+      }
+  )"));
+  ExpectPendingChannels ({});
+}
+
+TEST_F (PendingMovesTests, InvalidProtoVersion)
+{
+  auto ch = CreateChannel ("test", "0 1");
+  proc.AddPendingStateProof (*ch, ParseStateProof (R"(
+    initial_state:
+      {
+        data: "42 5"
+        signatures: "sgn0"
+        signatures: "sgn1"
+        for_testing_version: "foo"
+      }
+  )"));
+  ExpectPendingChannels ({});
+}
+
+TEST_F (PendingMovesTests, NotLater)
+{
+  auto ch1 = CreateChannel ("foo", "0 1");
+  proc.AddPendingStateProof (*ch1, ParseStateProof (R"(
+    initial_state:
+      {
+        data: "42 5"
+        signatures: "sgn0"
+        signatures: "sgn1"
+      }
+  )"));
+  auto ch2 = CreateChannel ("bar", "10 2");
+
+  /* The following two pending moves are valid, but do not have later turns
+     than the existing pending (ch1) or on-chain (ch2) state.  */
+  proc.AddPendingStateProof (*ch1, ParseStateProof (R"(
+    initial_state:
+      {
+        data: "55 5"
+        signatures: "sgn0"
+        signatures: "sgn1"
+      }
+  )"));
+  proc.AddPendingStateProof (*ch2, ParseStateProof (R"(
+    initial_state:
+      {
+        data: "42 2"
+        signatures: "sgn0"
+        signatures: "sgn1"
+      }
+  )"));
+
+  ExpectPendingChannels ({
+    {"foo", "42 5"},
+  });
+}
+
+TEST_F (PendingMovesTests, AddingAndClear)
+{
+  auto ch1 = CreateChannel ("foo", "0 1");
+  proc.AddPendingStateProof (*ch1, ParseStateProof (R"(
+    initial_state:
+      {
+        data: "42 5"
+        signatures: "sgn0"
+        signatures: "sgn1"
+      }
+  )"));
+  auto ch2 = CreateChannel ("bar", "10 2");
+
+  /* The following two pending moves are valid and have later turn counts than
+     the existing pending (ch1) or on-chain (ch2) state.  */
+  proc.AddPendingStateProof (*ch1, ParseStateProof (R"(
+    initial_state:
+      {
+        data: "55 6"
+        signatures: "sgn0"
+        signatures: "sgn1"
+      }
+  )"));
+  proc.AddPendingStateProof (*ch2, ParseStateProof (R"(
+    initial_state:
+      {
+        data: "42 3"
+        signatures: "sgn0"
+        signatures: "sgn1"
+      }
+  )"));
+
+  ExpectPendingChannels ({
+    {"foo", "55 6"},
+    {"bar", "42 3"},
+  });
+
+  proc.Clear ();
+  ExpectPendingChannels ({});
 }
 
 /* ************************************************************************** */

--- a/gamechannel/gsprpc.cpp
+++ b/gamechannel/gsprpc.cpp
@@ -34,6 +34,13 @@ ChannelGspRpcServer::getcurrentstate ()
 }
 
 Json::Value
+ChannelGspRpcServer::getpendingstate ()
+{
+  LOG (INFO) << "RPC method called: getpendingstate";
+  return game.GetPendingJsonState ();
+}
+
+Json::Value
 ChannelGspRpcServer::getchannel (const std::string& channelId)
 {
   LOG (INFO) << "RPC method called: getchannel " << channelId;
@@ -45,6 +52,13 @@ ChannelGspRpcServer::waitforchange (const std::string& knownBlock)
 {
   LOG (INFO) << "RPC method called: waitforchange " << knownBlock;
   return GameRpcServer::DefaultWaitForChange (game, knownBlock);
+}
+
+Json::Value
+ChannelGspRpcServer::waitforpendingchange (const int oldVersion)
+{
+  LOG (INFO) << "RPC method called: waitforpendingchange " << oldVersion;
+  return game.WaitForPendingChange (oldVersion);
 }
 
 Json::Value

--- a/gamechannel/gsprpc.hpp
+++ b/gamechannel/gsprpc.hpp
@@ -44,8 +44,10 @@ public:
 
   virtual void stop () override;
   virtual Json::Value getcurrentstate () override;
+  virtual Json::Value getpendingstate () override;
   virtual Json::Value getchannel (const std::string& channelId) override;
   virtual std::string waitforchange (const std::string& knownBlock) override;
+  virtual Json::Value waitforpendingchange (int oldVersion) override;
 
   /**
    * Implements the standard getchannel method.  This can be used by

--- a/gamechannel/rpc-stubs/gsp.json
+++ b/gamechannel/rpc-stubs/gsp.json
@@ -9,13 +9,23 @@
     "returns": {}
   },
   {
+    "name": "getpendingstate",
+    "params": {},
+    "returns": {}
+  },
+  {
     "name": "getchannel",
     "params": [ "channel id" ],
     "returns": {}
   },
   {
     "name": "waitforchange",
-    "params": [ "known block" ],
+    "params": ["known block"],
     "returns": ""
+  },
+  {
+    "name": "waitforpendingchange",
+    "params": [42],
+    "returns": {}
   }
 ]

--- a/ships/gametest/Makefile.am
+++ b/ships/gametest/Makefile.am
@@ -7,6 +7,7 @@ REGTESTS = \
   channel_management.py \
   disputes.py \
   getchannel.py \
+  pending.py \
   reorg.py \
   winner_statement.py
 

--- a/ships/gametest/pending.py
+++ b/ships/gametest/pending.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python
+# Copyright (C) 2019 The Xaya developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+"""
+Tests the tracking of pending disputes/resolutions in the GSP.
+"""
+
+from shipstest import ShipsTest
+
+import time
+
+
+class PendingTest (ShipsTest):
+
+  def expectPendingChannels (self, expected):
+    """
+    Expects that the pending state contains data about the given
+    channels.  expected is a dictionary mapping channel IDs (as hex)
+    to the expected turn counts.
+    """
+
+    time.sleep (0.1)
+
+    pending = self.getPendingState ()
+    assert "channels" in pending
+
+    actual = {}
+    for key, val in pending["channels"].iteritems ():
+      actual[key] = val["turncount"]
+
+    self.assertEqual (actual, expected)
+
+  def run (self):
+    self.generate (110)
+
+    # Create a test channel with two participants.
+    self.mainLogger.info ("Opening a test channel...")
+    addr1 = self.rpc.xaya.getnewaddress ()
+    addr2 = self.rpc.xaya.getnewaddress ()
+    cid = self.openChannel (["foo", "bar"], [addr1, addr2])
+    self.expectChannelState (cid, "first commitment", None)
+
+    # Open a dispute and check the pending state.
+    self.mainLogger.info ("Filing a dispute...")
+    state = self.getStateProof (cid, """
+      turn: 1
+      position_hashes: "foo"
+      seed_hash_0: "bar"
+    """)
+    self.sendMove ("xyz", {"d": {"id": cid, "state": state}})
+    self.expectPendingChannels ({cid: 2})
+
+    # Send a resolution move as well.
+    self.mainLogger.info ("Resolving the dispute...")
+    state = self.getStateProof (cid, """
+      winner: 1
+      turn: 0
+    """)
+    self.sendMove ("xyz", {"r": {"id": cid, "state": state}})
+    self.expectPendingChannels ({cid: 4})
+
+    # Mine the moves, which should clear the mempool again.
+    self.mainLogger.info ("Mining the pending transactions...")
+    self.generate (1)
+    self.expectPendingChannels ({})
+
+
+if __name__ == "__main__":
+  PendingTest ().main ()

--- a/ships/logic.hpp
+++ b/ships/logic.hpp
@@ -112,6 +112,41 @@ protected:
 
 };
 
+/**
+ * PendingMoveProcessor for Xayaships.  This just passes StateProofs recovered
+ * from pending disputes and resolutions to ChannelGame::PendingMoves.
+ */
+class ShipsPending : public xaya::ChannelGame::PendingMoves
+{
+
+private:
+
+  /**
+   * Tries to process a pending dispute or resolution move.
+   */
+  void HandleDisputeResolution (const Json::Value& obj);
+
+  /**
+   * Processes a new move, but does not call AccessConfirmedState.  This is
+   * used in tests, so that we can get away without setting up a consistent
+   * current state in the database.
+   */
+  void AddPendingMoveUnsafe (const Json::Value& mv);
+
+  friend class PendingTests;
+
+protected:
+
+  void AddPendingMove (const Json::Value& mv) override;
+
+public:
+
+  ShipsPending (ShipsLogic& g)
+    : PendingMoves(g)
+  {}
+
+};
+
 } // namespace ships
 
 #endif // XAYASHIPS_LOGIC_HPP

--- a/ships/main-gsp.cpp
+++ b/ships/main-gsp.cpp
@@ -36,6 +36,9 @@ DEFINE_string (datadir, "",
                "base data directory for game data (will be extended by the"
                " game ID and chain)");
 
+DEFINE_bool (pending_moves, true,
+             "whether or not pending moves should be tracked");
+
 } // anonymous namespace
 
 int
@@ -73,6 +76,10 @@ main (int argc, char** argv)
   ships::ShipsLogic rules;
   xaya::ChannelGspInstanceFactory instanceFact(rules);
   config.InstanceFactory = &instanceFact;
+
+  ships::ShipsPending pending(rules);
+  if (FLAGS_pending_moves)
+    config.PendingMoves = &pending;
 
   const int res = xaya::SQLiteMain (config, "xs", rules);
   google::protobuf::ShutdownProtobufLibrary ();

--- a/xayagame/pendingmoves.hpp
+++ b/xayagame/pendingmoves.hpp
@@ -74,7 +74,10 @@ protected:
   const GameStateData& GetConfirmedState () const;
 
   /**
-   * Clears the state, so it corresponds to an empty mempool.
+   * Clears the state, so it corresponds to an empty mempool.  This is called
+   * whenever the confirmed on-chain state changes.  It may also be called
+   * when the confirmed state did not change but the pending state needs to
+   * be rebuilt due to some other reason.
    */
   virtual void Clear () = 0;
 


### PR DESCRIPTION
Another step towards #43:  This adds a special `PendingMoveProcessor` for `SQLiteGame`, which exposes the current state as SQLite database to the callbacks.

We then integrate basic pending-move support with `shipsd` and `ChannelGame`:  When dispute or resolution moves are seen, we extract the `StateProof` and keep track of the latest pending (valid) state for each channel.  This allows us to integration-test the SQLite integration, and we will also be able to read those moves from a channel daemon and thus potentially speed up getting back to real-time game play when a move was lost and a dispute filed.