### PR TITLE
Make context available for SQLite InitialiseState

### DIFF
--- a/xayagame/game.hpp
+++ b/xayagame/game.hpp
@@ -113,6 +113,15 @@ private:
   State state = State::UNKNOWN;
 
   /**
+   * The game's genesis height, if known already.  We cache that from the
+   * first call to GetInitialState, so that we can avoid calling it all
+   * over again on each block before we reach the genesis height.
+   */
+  unsigned genesisHeight;
+  /** The game's genesis hash, if already known (zero otherwise).  */
+  uint256 genesisHash;
+
+  /**
    * While the state is PREGENESIS, this holds the block hash of the game's
    * initial state to which we are catching up.  For CATCHING_UP, this is
    * the TOBLOCK returned from game_sendupdates.


### PR DESCRIPTION
With this change, we initialise the SQLite game state (i.e. call `SQLiteGame::InitialiseState`) from the original `GetInitialStateInternal` callback.  (Previously, it could have been called through `EnsureCurrentState` from getting the state.)

This ensures that we have a context (e.g. including random numbers) available for the callback.

For this to work, we also need to restructure the corresponding code in `Game` a bit - since `GetInitialState` then also has side-effects on the external state in the database, we must call that *before* clearing the storage.  (And since the function may now be more expensive, we should cache the genesis height after the first call and never re-call it again until we reached that height and are actually initialising the game.)