### PR TITLE
Allow duplicate JSON keys when parsing from ZMQ

### DIFF
--- a/mover/gametest/Makefile.am
+++ b/mover/gametest/Makefile.am
@@ -10,6 +10,7 @@ REGTESTS = \
   basic.py \
   bind_locally.py \
   catching_up.py \
+  dupjsonkeys.py \
   pending-disabled.py \
   pending-onesocket.py \
   pending-twosockets.py \

--- a/mover/gametest/dupjsonkeys.py
+++ b/mover/gametest/dupjsonkeys.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python
+# Copyright (C) 2018-2019 The Xaya developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+"""
+Tests how the GSP behaves if there are duplicated JSON keys in moves
+from Xaya Core.  (Since univalue, as used to validate moves in Xaya Core
+and send notifications, accepts duplicated keys.)
+"""
+
+from mover import MoverTest
+
+import json
+
+
+class DupJsonKeysTest (MoverTest):
+
+  def run (self):
+    self.generate (101)
+    self.expectGameState ({"players": {}})
+
+    self.rpc.xaya.name_register ("p/test", "{}")
+    self.generate (1)
+
+    # Try a duplicated game ID in the move JSON.  In this case, the notification
+    # sent on ZMQ should just include the last value (that is what Xaya Core
+    # officially does, enforced by a test).
+    mv1 = json.dumps ({"d": "k", "n": 1})
+    mv2 = json.dumps ({"d": "j", "n": 1})
+    self.rpc.xaya.name_update ("p/test", '{"g":{"mv":%s,"mv":%s}}' % (mv1, mv2))
+    self.generate (1)
+    self.expectGameState ({"players": {
+      "test": {"x": 0, "y": -1},
+    }})
+
+    # Try sending a move where the move itself contains duplicated keys.
+    # For this situation, libxayagame dedups the key (based on JsonCpp's
+    # parsing) and returns the last value only.
+    self.move ("a", "l", 1)
+    mv = '{"d":"h","d":"l","n":1}'
+    self.rpc.xaya.name_update ("p/test", '{"g":{"mv":%s}}' % mv)
+    self.move ("z", "h", 1)
+    self.generate (1)
+    self.expectGameState ({"players": {
+      "test": {"x": 1, "y": -1},
+      "a": {"x": 1, "y": 0},
+      "z": {"x": -1, "y": 0},
+    }})
+
+
+if __name__ == "__main__":
+  DupJsonKeysTest ().main ()

--- a/xayagame/zmqsubscriber.cpp
+++ b/xayagame/zmqsubscriber.cpp
@@ -168,7 +168,11 @@ ZmqSubscriber::Listen (ZmqSubscriber* self)
   rbuilder["allowComments"] = false;
   rbuilder["strictRoot"] = true;
   rbuilder["failIfExtra"] = true;
-  rbuilder["rejectDupKeys"] = true;
+  /* Xaya Core's univalue accepts duplicate keys, so it may forward moves to
+     us that contain duplicate keys.  We need to handle them gracefully when
+     parsing.  With our options, JsonCpp will accept them, and dedup by
+     keeping only the last value.  */
+  rbuilder["rejectDupKeys"] = false;
 
   std::string topic;
   std::string payload;

--- a/xayagame/zmqsubscriber_tests.cpp
+++ b/xayagame/zmqsubscriber_tests.cpp
@@ -365,6 +365,35 @@ TEST_F (ZmqSubscriberTests, ListenerCalled)
   SendDetach (GAME_ID, payload2, 1);
 }
 
+TEST_F (ZmqSubscriberTests, JsonKeysDeduped)
+{
+  Json::Value payload;
+  std::istringstream in(R"(
+    {
+      "test": 42,
+      "nested":
+        {
+          "field": "last"
+        }
+    }
+  )");
+  in >> payload;
+  EXPECT_CALL (mockListener, BlockAttach (GAME_ID, payload, _));
+
+  const std::string topic = std::string ("game-block-attach json ") + GAME_ID;
+  SendMultipart ({topic, R"(
+    {
+      "test": 1,
+      "nested":
+        {
+          "field": "first",
+          "field": "last"
+        },
+      "test": 42
+    }
+  )", "1234"});
+}
+
 TEST_F (ZmqSubscriberTests, SequenceNumber)
 {
   Json::Value payload;


### PR DESCRIPTION
When we receive ZMQ notifications, allow duplicate JSON keys while parsing the text into JSON.  Those may be passed on from Xaya Core, which allows them as well due to univalue.

JsonCpp will then just overwrite earlier values, so the last entry for a given key will prevail.  This adds explicit tests as well, to make sure this situation works as desired and actually has this behaviour also in the future.