### PR TITLE
Implement branching off for Random instances

### DIFF
--- a/xayautil/random.cpp
+++ b/xayautil/random.cpp
@@ -42,6 +42,26 @@ Random::Seed (const uint256& s)
   nextIndex = 0;
 }
 
+Random
+Random::BranchOff (const std::string& key) const
+{
+  CHECK (!seed.IsNull ()) << "Random instance has not been seeded";
+
+  CHECK_LT (nextIndex, uint256::NUM_BYTES);
+  std::string nextIndexByte;
+  nextIndexByte.push_back (static_cast<char> (nextIndex));
+  CHECK_EQ (nextIndexByte.size (), 1);
+
+  SHA256 hasher;
+  hasher << seed << nextIndexByte;
+  hasher << key;
+
+  Random res;
+  res.Seed (hasher.Finalise ());
+
+  return res;
+}
+
 template <>
   unsigned char
   Random::Next<unsigned char> ()

--- a/xayautil/random.cpp
+++ b/xayautil/random.cpp
@@ -48,7 +48,10 @@ template <>
 {
   CHECK (!seed.IsNull ()) << "Random instance has not been seeded";
 
-  CHECK_LE (nextIndex, uint256::NUM_BYTES);
+  CHECK_LT (nextIndex, uint256::NUM_BYTES);
+  const unsigned char res = seed.GetBlob ()[nextIndex];
+
+  ++nextIndex;
   if (nextIndex == uint256::NUM_BYTES)
     {
       SHA256 hasher;
@@ -57,8 +60,7 @@ template <>
       nextIndex = 0;
     }
 
-  const unsigned char* data = seed.GetBlob ();
-  return data[nextIndex++];
+  return res;
 }
 
 template <>

--- a/xayautil/random.cpp
+++ b/xayautil/random.cpp
@@ -19,6 +19,22 @@ Random::Random ()
   seed.SetNull ();
 }
 
+Random::Random (Random&& other)
+{
+  *this = std::move (other);
+}
+
+Random&
+Random::operator= (Random&& other)
+{
+  seed = std::move (other.seed);
+  nextIndex = other.nextIndex;
+
+  other.seed.SetNull ();
+
+  return *this;
+}
+
 void
 Random::Seed (const uint256& s)
 {

--- a/xayautil/random.hpp
+++ b/xayautil/random.hpp
@@ -57,6 +57,18 @@ public:
   void Seed (const uint256& s);
 
   /**
+   * Branches off a new Random instance.  The new instance will be seeded
+   * based on the state of this instance and the given "key" string.  The
+   * state of this instance is not affected by the branching off.
+   *
+   * This functionality can be used to split the single sequence of random
+   * bytes into a hierarchy of byte streams, so that e.g. independent
+   * computations can be run in parallel, with their own deterministic Random
+   * instance.
+   */
+  Random BranchOff (const std::string& key) const;
+
+  /**
    * Extracts the next byte or perhaps other type (e.g. uint32_t).
    */
   template <typename T>

--- a/xayautil/random.hpp
+++ b/xayautil/random.hpp
@@ -39,6 +39,15 @@ public:
    */
   Random ();
 
+  /**
+   * Random instances are movable (but not copyable).  Moving the instance
+   * transfers its state (i.e. the sequence of future random bytes) to the
+   * new target, and leaves the old one unseeded.
+   */
+  Random (Random&&);
+
+  Random& operator= (Random&&);
+
   Random (const Random&) = delete;
   void operator= (const Random&) = delete;
 

--- a/xayautil/random_tests.cpp
+++ b/xayautil/random_tests.cpp
@@ -147,5 +147,13 @@ TEST_F (RandomTests, SelectByWeight)
     }
 }
 
+TEST_F (RandomTests, Moving)
+{
+  ASSERT_EQ (rnd.Next<uint32_t> (), 0x7ca22c16);
+  Random other = std::move (rnd);
+  EXPECT_EQ (other.Next<uint32_t> (), 0x65349f6c);
+  EXPECT_DEATH (rnd.Next<unsigned char> (), "has not been seeded");
+}
+
 } // anonymous namespace
 } // namespace xaya


### PR DESCRIPTION
The new function `Random::BranchOff` will yield a separate `Random` instance that is seeded based on the current `Random`'s state and some key string (so we can branch off multiple instances at a single point in time).  The original state is not modified by this.

With this feature, we can split a single long sequence of random bytes into a hierarchy of sequences, so that e.g. operations can be run in parallel with their own deterministic `Random` instances.

This implements #88.
