### PR TITLE
Implement compression functions in xayautil

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ for the configuration and/or build to be successful:
   [`4f24acaf4c6737cd07d40a02edad0a56147e0713`](https://github.com/cinemast/libjson-rpc-cpp/commit/4f24acaf4c6737cd07d40a02edad0a56147e0713).
 - [`ZeroMQ C++ bindings`](http://zeromq.org/bindings:cpp):
   Available in the Debian package `libzmq3-dev`.
+- [`zlib`](https://zlib.net):
+  Available in Debian as `zlib1g-dev`.
 - [SQLite3](https://www.sqlite.org/) with the
   [session extension](https://www.sqlite.org/sessionintro.html).
   In Debian, the `libsqlite3-dev` package can be installed.

--- a/configure.ac
+++ b/configure.ac
@@ -36,6 +36,7 @@ AX_PKG_CHECK_MODULES([PROTOBUF], [protobuf])
 
 # Private dependencies of the library itself.
 AX_PKG_CHECK_MODULES([GLOG], [], [libglog])
+AX_PKG_CHECK_MODULES([ZLIB], [], [zlib])
 AX_PKG_CHECK_MODULES([OPENSSL], [], [openssl])
 AX_PKG_CHECK_MODULES([ZMQ], [], [libzmq])
 

--- a/xayautil/Makefile.am
+++ b/xayautil/Makefile.am
@@ -3,29 +3,34 @@ xayautildir = $(includedir)/xayautil
 
 pkgconfig_DATA = libxayautil.pc
 
-libxayautil_la_CXXFLAGS = $(OPENSSL_CFLAGS) $(GLOG_CFLAGS)
-libxayautil_la_LIBADD = $(OPENSSL_LIBS) $(GLOG_LIBS)
+libxayautil_la_CXXFLAGS = $(ZLIB_CFLAGS) $(OPENSSL_CFLAGS) $(GLOG_CFLAGS)
+libxayautil_la_LIBADD = $(ZLIB_LIBS) $(OPENSSL_LIBS) $(GLOG_LIBS)
 libxayautil_la_SOURCES = \
   base64.cpp \
+  compression.cpp \
   cryptorand.cpp \
   hash.cpp \
   random.cpp \
   uint256.cpp
 xayautil_HEADERS = \
   base64.hpp \
+  compression.hpp \
   cryptorand.hpp \
   hash.hpp \
   random.hpp \
   uint256.hpp
+noinst_HEADERS = \
+  compression_internal.hpp
 
 check_PROGRAMS = tests
 TESTS = tests
 
-tests_CXXFLAGS = $(GLOG_CFLAGS) $(GTEST_CFLAGS)
+tests_CXXFLAGS = $(ZLIB_CFLAGS) $(GLOG_CFLAGS) $(GTEST_CFLAGS)
 tests_LDADD = $(builddir)/libxayautil.la \
-  $(GLOG_LIBS) $(GTEST_LIBS)
+  $(ZLIB_LIBS) $(GLOG_LIBS) $(GTEST_LIBS)
 tests_SOURCES = \
   base64_tests.cpp \
+  compression_tests.cpp \
   cryptorand_tests.cpp \
   hash_tests.cpp \
   random_tests.cpp \

--- a/xayautil/compression.cpp
+++ b/xayautil/compression.cpp
@@ -1,0 +1,98 @@
+// Copyright (C) 2019 The Xaya developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "compression_internal.hpp"
+
+namespace xaya
+{
+
+namespace
+{
+
+/** Maximum window size in bits used for the consensus-compression.  */
+constexpr int WINDOW_BITS = 15;
+
+/** Compression level we use.  */
+constexpr int LEVEL = 9;
+
+/**
+ * Utility class wrapping a z_stream instance used for inflating data.
+ */
+class InflateStream : public BasicZlibStream
+{
+
+public:
+
+  /**
+   * Initialises the inflate struct with our parameters.
+   */
+  InflateStream ()
+  {
+    const auto res = inflateInit2 (&stream, -WINDOW_BITS);
+    CHECK_EQ (res, Z_OK) << "Inflate init error " << res << ": " << GetError ();
+  }
+
+  /**
+   * Frees the allocated stream state.
+   */
+  ~InflateStream ()
+  {
+    const auto res = inflateEnd (&stream);
+    CHECK_EQ (res, Z_OK) << "Inflate end error " << res << ": " << GetError ();
+  }
+
+  /**
+   * Performs the actual uncompression step of data.
+   */
+  bool
+  Uncompress (const std::string& input, const size_t maxOutputSize,
+              std::string& output)
+  {
+    SetInput (input);
+    SetOutputSize (maxOutputSize);
+
+    const auto res = inflate (&stream, Z_FINISH);
+    switch (res)
+      {
+      case Z_STREAM_END:
+        CHECK_EQ (stream.total_in, input.size ());
+        output = ExtractOutput ();
+        return true;
+
+      case Z_BUF_ERROR:
+        VLOG (1)
+            << "Uncompress produced too much output data; processed "
+            << stream.total_in << " input bytes of the total " << input.size ();
+        return false;
+
+      case Z_NEED_DICT:
+      case Z_DATA_ERROR:
+        VLOG (1) << "Invalid data provided to uncompress: " << GetError ();
+        return false;
+
+      default:
+        LOG (FATAL) << "Inflate error " << res << ": " << GetError ();
+      }
+  }
+
+};
+
+} // anonymous namespace
+
+std::string
+CompressData (const std::string& data)
+{
+  DeflateStream compressor(-WINDOW_BITS, LEVEL);
+  return compressor.Compress (data);
+}
+
+bool
+UncompressData (const std::string& input, const size_t maxOutputSize,
+                std::string& output)
+{
+  InflateStream uncompressor;
+  return uncompressor.Uncompress (input, maxOutputSize, output);
+}
+
+} // namespace xaya

--- a/xayautil/compression.hpp
+++ b/xayautil/compression.hpp
@@ -1,0 +1,50 @@
+// Copyright (C) 2019 The Xaya developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef XAYAUTIL_COMPRESSION_HPP
+#define XAYAUTIL_COMPRESSION_HPP
+
+#include <cstddef>
+#include <string>
+
+namespace xaya
+{
+
+/**
+ * Tries to compress the given byte-string, returning the output bytes.
+ * This uses a specific compression format (raw deflate with windowBits set
+ * to 15), which is guaranteed to be accepted by UncompressData.
+ *
+ * Note that compression should be used only selectively in games, i.e. in
+ * situations where e.g. compressing the move data makes a clear difference
+ * for instance to fit inside the 2k value limit.  It should not be used
+ * "just to optimise" the data size, since general compression of transaction
+ * data is best handled by Xaya Core itself rather than individual games
+ * (and can then be done in a non-consensus-relevant way, which is more
+ * robust and safer).
+ */
+std::string CompressData (const std::string& data);
+
+/**
+ * Tries to uncompress the given byte-string, returning the original data.
+ * If the input data is invalid or the output size is larger than maxOutputSize,
+ * this function returns false instead (indicating an error).
+ *
+ * By setting a specific, explicit maxOutputSize, we ensure that maliciously
+ * crafted data cannot be used to DoS a node on memory (i.e. "zip bomb").
+ * Thus users should ensure they pass a reasonable and not insanely large
+ * value for this parameter, as fits to the application in question.  The value
+ * used here is then relevant for consensus!
+ *
+ * This tries to decompress the data as raw deflate stream with windowBits
+ * set to 15.  It is guaranteed to stay stable (in particular also with
+ * respect to what data exactly it accepts as valid), so that consensus can
+ * rely on success or failure of the function.
+ */
+bool UncompressData (const std::string& input, size_t maxOutputSize,
+                     std::string& output);
+
+} // namespace xaya
+
+#endif // XAYAUTIL_COMPRESSION_HPP

--- a/xayautil/compression_internal.hpp
+++ b/xayautil/compression_internal.hpp
@@ -1,0 +1,181 @@
+// Copyright (C) 2019 The Xaya developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+/* This file contains internal implementation details for compression.cpp,
+   but so that they can be shared also with the testing logic.  */
+
+#ifndef XAYAUTIL_COMPRESSION_INTERNAL_HPP
+#define XAYAUTIL_COMPRESSION_INTERNAL_HPP
+
+#include "compression.hpp"
+
+#include <glog/logging.h>
+
+#include <zlib.h>
+
+namespace xaya
+{
+
+namespace
+{
+
+/** Memory-usage level we use.  */
+constexpr int MEM_LEVEL = 9;
+
+/**
+ * Basic wrapper class around a z_stream.  It does not do anything except
+ * set up the allocator functions to Z_NULL in the constructor.
+ */
+class BasicZlibStream
+{
+
+private:
+
+  /** Value to hold the output data.  */
+  std::string output;
+
+protected:
+
+  /** The underlying zlib stream struct.  */
+  z_stream stream;
+
+  BasicZlibStream ()
+  {
+    stream.zalloc = Z_NULL;
+    stream.zfree = Z_NULL;
+    stream.opaque = Z_NULL;
+  }
+
+  /**
+   * Returns the last error message from the stream, handling NULL (no error)
+   * correctly.
+   */
+  std::string
+  GetError () const
+  {
+    if (stream.msg == nullptr)
+      return "<none>";
+    return stream.msg;
+  }
+
+  /**
+   * Fills in the input in the stream struct to reference the memory
+   * (and length) of the given byte string.
+   */
+  void
+  SetInput (const std::string& input)
+  {
+    const Bytef* inputBuf = reinterpret_cast<const Bytef*> (input.data ());
+    stream.next_in = const_cast<Bytef*> (inputBuf);
+    stream.avail_in = input.size ();
+  }
+
+  /**
+   * Sets the size of the output buffer, and points the stream to it.
+   */
+  void
+  SetOutputSize (const size_t sz)
+  {
+    output.resize (sz);
+    stream.next_out = reinterpret_cast<Bytef*> (&output[0]);
+    stream.avail_out = output.size ();
+  }
+
+  /**
+   * Returns the output with correct length (as per the stream's total_out)
+   * as a string.
+   */
+  std::string
+  ExtractOutput ()
+  {
+    CHECK_LE (stream.total_out, output.size ());
+
+    std::string res = std::move (output);
+    res.resize (stream.total_out);
+
+    return res;
+  }
+
+};
+
+/**
+ * Utility class wrapping z_stream for deflation.  This handles initialisation
+ * and destruction of the stream struct (and its associated data) through RAII.
+ */
+class DeflateStream : public BasicZlibStream
+{
+
+public:
+
+  /**
+   * Initialises the deflate struct with some default parameters and the
+   * given other parameters.  The custom parameters are used to construct
+   * test data in the unit test.  The main implementation always sets them
+   * to specific constants.
+   */
+  explicit DeflateStream (const int windowBits, const int level)
+  {
+    const auto res = deflateInit2 (&stream, level, Z_DEFLATED, windowBits,
+                                   MEM_LEVEL, Z_DEFAULT_STRATEGY);
+    CHECK_EQ (res, Z_OK) << "Deflate init error " << res << ": " << GetError ();
+  }
+
+  /**
+   * Frees the allocated stream state.
+   */
+  ~DeflateStream ()
+  {
+    const auto res = deflateEnd (&stream);
+    CHECK_EQ (res, Z_OK) << "Deflate end error " << res << ": " << GetError ();
+  }
+
+  /**
+   * Sets a dictionary for the compression.  This is only used for testing,
+   * in order to construct data that requires a dictionary for inflation.
+   */
+  void
+  SetDictionary (const std::string& dict)
+  {
+    LOG (WARNING)
+        << "Setting a dictionary for compression, this data will not"
+           " be accepted by the consensus uncompress function";
+    const Bytef* data = reinterpret_cast<const Bytef*> (dict.data ());
+    const auto res = deflateSetDictionary (&stream, data, dict.size ());
+    CHECK_EQ (res, Z_OK)
+        << "Set dictionary error " << res << ": " << GetError ();
+  }
+
+  /**
+   * Performs the actual compression of input data, using our stream.
+   * This function must be called only once on the instance.
+   */
+  std::string
+  Compress (const std::string& data)
+  {
+    uInt dictLength;
+    auto res = deflateGetDictionary (&stream, Z_NULL, &dictLength);
+    CHECK_EQ (res, Z_OK)
+        << "Get dictionary length error " << res << ": " << GetError ();
+
+    SetInput (data);
+    SetOutputSize (deflateBound (&stream, data.size ()));
+
+    res = deflate (&stream, Z_FINISH);
+    CHECK_EQ (res, Z_STREAM_END)
+        << "Deflate error " << res << ": " << GetError ();
+    CHECK_EQ (stream.total_in, dictLength + data.size ());
+
+    std::string output = ExtractOutput ();
+    VLOG (2) << "Compressed " << data.size () << " bytes to " << output.size ();
+
+    return output;
+  }
+
+};
+
+} // anonymous namespace
+
+} // namespace xaya
+
+#endif // XAYAUTIL_COMPRESSION_INTERNAL_HPP

--- a/xayautil/compression_tests.cpp
+++ b/xayautil/compression_tests.cpp
@@ -1,0 +1,138 @@
+// Copyright (C) 2019 The Xaya developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "compression_internal.hpp"
+
+#include <gtest/gtest.h>
+
+#include <vector>
+
+namespace xaya
+{
+namespace
+{
+
+class CompressionTests : public testing::Test
+{
+
+protected:
+
+  /**
+   * Uncompresses data and expects it to be valid, matching the given
+   * original input string.
+   */
+  static void
+  ExpectValidUncompress (const std::string& compressed, const size_t maxSize,
+                         const std::string& expected)
+  {
+    std::string actual;
+    ASSERT_TRUE (UncompressData (compressed, maxSize, actual));
+    EXPECT_EQ (actual, expected);
+  }
+
+  /**
+   * Tries to uncompress with the given data and expects it to fail.
+   */
+  static void
+  ExpectInvalidUncompress (const std::string& compressed, const size_t maxSize)
+  {
+    std::string output;
+    EXPECT_FALSE (UncompressData (compressed, maxSize, output));
+  }
+
+};
+
+TEST_F (CompressionTests, RoundTrip)
+{
+  std::string longString;
+  for (unsigned i = 0; i < 1'000'000; ++i)
+    longString.append ("abcdef");
+
+  const std::vector<std::string> tests =
+    {
+      "", "123", u8"äöü",
+      R"({"tactics":{"actions":[{"foo":10},{"bar":42}]}})",
+      std::string ("foo\0bar", 7),
+      longString,
+    };
+
+  for (const auto& str : tests)
+    {
+      const std::string compressed = CompressData (str);
+      ExpectValidUncompress (compressed, str.size (), str);
+    }
+}
+
+TEST_F (CompressionTests, MaxOutputSize)
+{
+  const std::string input = "foobar";
+  const std::string compressed = CompressData (input);
+
+  ExpectValidUncompress (compressed, input.size (), input);
+  ExpectValidUncompress (compressed, 1'000'000, input);
+  ExpectInvalidUncompress (compressed, input.size () - 1);
+}
+
+TEST_F (CompressionTests, InvalidData)
+{
+  ExpectInvalidUncompress ("not valid compressed data", 100);
+}
+
+TEST_F (CompressionTests, CompressionLevelZero)
+{
+  const std::string input = "foobar";
+
+  DeflateStream compressor(-15, 0);
+  const std::string compressed = compressor.Compress (input);
+
+  ExpectValidUncompress (compressed, input.size (), input);
+}
+
+TEST_F (CompressionTests, SmallerWindowSize)
+{
+  const std::string input = "foobar";
+
+  DeflateStream compressor(-10, 9);
+  const std::string compressed = compressor.Compress (input);
+
+  ExpectValidUncompress (compressed, input.size (), input);
+}
+
+/* It would be cool to test also that data encoded with a *larger* window size
+   is rejected by UncompressData, but this is not easily possible as the chosen
+   value of 15 is the largest that zlib allows anyway at the moment.  */
+
+TEST_F (CompressionTests, WithDictionary)
+{
+  const std::string input = "123xyz foobar";
+
+  DeflateStream compressor(-15, 9);
+  compressor.SetDictionary ("foobar");
+  const std::string compressed = compressor.Compress (input);
+
+  ExpectInvalidUncompress (compressed, input.size ());
+}
+
+TEST_F (CompressionTests, ZlibFormat)
+{
+  const std::string input = "foobar";
+
+  DeflateStream compressor(15, 9);
+  const std::string compressed = compressor.Compress (input);
+
+  ExpectInvalidUncompress (compressed, input.size ());
+}
+
+TEST_F (CompressionTests, GzipFormat)
+{
+  const std::string input = "foobar";
+
+  DeflateStream compressor(15 + 16, 9);
+  const std::string compressed = compressor.Compress (input);
+
+  ExpectInvalidUncompress (compressed, input.size ());
+}
+
+} // anonymous namespace
+} // namespace xaya


### PR DESCRIPTION
This adds a pair of functions `CompressData` and `UncompressData` to xayautils.  These functions can be used to apply simple compression (raw deflate) if needed by games, while they are specifically designed to make sure the uncompress logic will be stable with respect to what data it accepts and rejects in order to maintain consensus.