### PR TITLE
Generalised game components for default main

### DIFF
--- a/gamechannel/gsprpc.cpp
+++ b/gamechannel/gsprpc.cpp
@@ -86,11 +86,11 @@ ChannelGspRpcServer::DefaultGetChannel (const Game& g, ChannelGame& chg,
       });
 }
 
-std::unique_ptr<RpcServerInterface>
+std::unique_ptr<GameComponent>
 ChannelGspInstanceFactory::BuildRpcServer (
     Game& game, jsonrpc::AbstractServerConnector& conn)
 {
-  std::unique_ptr<RpcServerInterface> res;
+  std::unique_ptr<GameComponent> res;
   res.reset (new WrappedRpcServer<ChannelGspRpcServer> (game, chGame, conn));
   return res;
 }

--- a/gamechannel/gsprpc.hpp
+++ b/gamechannel/gsprpc.hpp
@@ -80,7 +80,7 @@ public:
     : chGame(chg)
   {}
 
-  std::unique_ptr<RpcServerInterface> BuildRpcServer (
+  std::unique_ptr<GameComponent> BuildRpcServer (
       Game& game, jsonrpc::AbstractServerConnector& conn) override;
 
 };

--- a/xayagame/defaultmain.cpp
+++ b/xayagame/defaultmain.cpp
@@ -29,6 +29,12 @@ CustomisedInstanceFactory::BuildRpcServer (
   return res;
 }
 
+std::vector<std::unique_ptr<GameComponent>>
+CustomisedInstanceFactory::BuildGameComponents (Game& game)
+{
+  return {};
+}
+
 namespace
 {
 
@@ -172,7 +178,7 @@ DefaultMain (const GameDaemonConfiguration& config, const std::string& gameId,
       if (config.EnablePruning >= 0)
         game->EnablePruning (config.EnablePruning);
 
-      std::vector<std::unique_ptr<GameComponent>> components;
+      auto components = instanceFact->BuildGameComponents (*game);
 
       auto serverConnector = CreateRpcServerConnector (config);
       if (serverConnector == nullptr)
@@ -245,7 +251,7 @@ SQLiteMain (const GameDaemonConfiguration& config, const std::string& gameId,
       if (config.EnablePruning >= 0)
         game->EnablePruning (config.EnablePruning);
 
-      std::vector<std::unique_ptr<GameComponent>> components;
+      auto components = instanceFact->BuildGameComponents (*game);
 
       auto serverConnector = CreateRpcServerConnector (config);
       if (serverConnector == nullptr)

--- a/xayagame/defaultmain.hpp
+++ b/xayagame/defaultmain.hpp
@@ -34,42 +34,41 @@ enum class RpcServerType
 };
 
 /**
- * Interace for a class that runs the game's RPC server.  We need this mainly
- * since the server classes from jsonrpccpp do not inherit from a single
- * super class which we could use instead.
+ * Interface for a general component of the game daemon that runs while
+ * the game is running.  For instance, the API RPC server, or another API.
  */
-class RpcServerInterface
+class GameComponent
 {
 
 protected:
 
-  RpcServerInterface () = default;
+  GameComponent () = default;
 
 public:
 
-  virtual ~RpcServerInterface () = default;
+  virtual ~GameComponent () = default;
 
-  RpcServerInterface (const RpcServerInterface&) = delete;
-  void operator=  (const RpcServerInterface&) = delete;
-
-  /**
-   * Starts listening on the server.
-   */
-  virtual void StartListening () = 0;
+  GameComponent (const GameComponent&) = delete;
+  void operator=  (const GameComponent&) = delete;
 
   /**
-   * Stops listening in the server.
+   * Starts the component (when the game is set up).
    */
-  virtual void StopListening () = 0;
+  virtual void Start () = 0;
+
+  /**
+   * Stops the component after the game is stopped.
+   */
+  virtual void Stop () = 0;
 
 };
 
 /**
- * Simple implementation of RpcServerInterface, that simply wraps a templated
- * actual server class.
+ * Simple implementation of GameComponent, that simply wraps a templated
+ * libjson-rpc-cpp RPC server.
  */
 template <typename T>
-  class WrappedRpcServer : public RpcServerInterface
+  class WrappedRpcServer : public GameComponent
 {
 
 private:
@@ -96,13 +95,13 @@ public:
   }
 
   void
-  StartListening () override
+  Start () override
   {
     server.StartListening ();
   }
 
   void
-  StopListening () override
+  Stop () override
   {
     server.StopListening ();
   }
@@ -129,7 +128,7 @@ public:
    * Returns an instance of the RPC server that should be used for the game.
    * By default, this method builds a standard GameRpcServer.
    */
-  virtual std::unique_ptr<RpcServerInterface> BuildRpcServer (
+  virtual std::unique_ptr<GameComponent> BuildRpcServer (
       Game& game,
       jsonrpc::AbstractServerConnector& conn);
 

--- a/xayagame/defaultmain.hpp
+++ b/xayagame/defaultmain.hpp
@@ -17,6 +17,7 @@
 
 #include <memory>
 #include <string>
+#include <vector>
 
 namespace xaya
 {
@@ -131,6 +132,13 @@ public:
   virtual std::unique_ptr<GameComponent> BuildRpcServer (
       Game& game,
       jsonrpc::AbstractServerConnector& conn);
+
+  /**
+   * Builds general components that should be run alongside the game.
+   * By default, just returns an empty list.
+   */
+  virtual std::vector<std::unique_ptr<GameComponent>> BuildGameComponents (
+      Game& game);
 
 };
 


### PR DESCRIPTION
This replaces the specific concept of custom RPC servers in the default main's with a more general `GameComponent` interface (that otherwise behaves the same).  It also allows defining additional custom game components in the instance factory,  besides just the RPC server.