### PR TITLE
Update usage of C++ ZMQ bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,11 @@ for the configuration and/or build to be successful:
   are not fresh enough.  They need to be built from source;
   in particular, it must be a version that includes the commit
   [`4f24acaf4c6737cd07d40a02edad0a56147e0713`](https://github.com/cinemast/libjson-rpc-cpp/commit/4f24acaf4c6737cd07d40a02edad0a56147e0713).
-- [`ZeroMQ C++ bindings`](http://zeromq.org/bindings:cpp):
-  Available in the Debian package `libzmq3-dev`.
+- [`ZeroMQ`](https://zeromq.org/) with
+  [C++ bindings](https://github.com/zeromq/cppzmq):
+  Core ZeroMQ is available in the Debian package `libzmq3-dev`.  The C++
+  bindings need to be installed from the source repository, as the version
+  in the Debian package (at least for Debain 10 "Buster") is too old.
 - [`zlib`](https://zlib.net):
   Available in Debian as `zlib1g-dev`.
 - [SQLite3](https://www.sqlite.org/) with the

--- a/configure.ac
+++ b/configure.ac
@@ -41,7 +41,9 @@ AX_PKG_CHECK_MODULES([GLOG], [], [libglog])
 # make sure we have at least this version.
 AX_PKG_CHECK_MODULES([ZLIB], [], [zlib >= 1.2.11])
 AX_PKG_CHECK_MODULES([OPENSSL], [], [openssl])
-AX_PKG_CHECK_MODULES([ZMQ], [], [libzmq])
+# We use the recv variant taking message_t& over deprecated older functions,
+# which requires at least version 4.3.1.
+AX_PKG_CHECK_MODULES([ZMQ], [], [libzmq >= 4.3.1])
 
 # Private dependencies that are not needed for libxayagame, but only for
 # the unit tests and the example binaries.

--- a/xayagame/zmqsubscriber.cpp
+++ b/xayagame/zmqsubscriber.cpp
@@ -88,7 +88,7 @@ ZmqSubscriber::ReceiveMultiparts (std::string& topic, std::string& payload,
   for (unsigned parts = 1; ; ++parts)
     {
       zmq::message_t msg;
-      CHECK (socket->recv (&msg));
+      CHECK (socket->recv (msg));
 
       switch (parts)
         {

--- a/xayagame/zmqsubscriber_tests.cpp
+++ b/xayagame/zmqsubscriber_tests.cpp
@@ -99,8 +99,12 @@ protected:
     for (size_t i = 0; i < parts.size (); ++i)
       {
         zmq::message_t msg(parts[i].begin (), parts[i].end ());
-        const bool hasMore = (i + 1 < parts.size ());
-        ASSERT_TRUE (sock.send (msg, hasMore ? ZMQ_SNDMORE : 0));
+        zmq::send_flags flags;
+        if (i + 1 < parts.size ())
+          flags = zmq::send_flags::sndmore;
+        else
+          flags = zmq::send_flags::none;
+        ASSERT_TRUE (sock.send (std::move (msg), flags));
       }
   }
 


### PR DESCRIPTION
Some functions from the C++ ZMQ bindings we were using have been deprecated in the latest versions, resulting in build errors in those cases.  In this change, we switch to the newer functions introduced and that should be used instead.

Note that this requires installing the ZeroMQ C++ bindings from source in Debian 10 "Buster", but that should be fine.

This fixes #92.