### PR TITLE
Decouple database from SQLiteGame

### DIFF
--- a/gamechannel/chaintochannel_tests.cpp
+++ b/gamechannel/chaintochannel_tests.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 The Xaya developers
+// Copyright (C) 2019-2020 The Xaya developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -72,9 +72,9 @@ public:
 
   explicit TestGspServer (jsonrpc::AbstractServerConnector& conn,
                           const uint256& id, const proto::ChannelMetadata& m,
-                          TestGame& g)
+                          SQLiteDatabase& db, TestGame& g)
     : ChannelGspRpcServerStub(conn), channelId(id), meta(m),
-      game(g), tbl(game)
+      game(g), tbl(db)
   {
     EXPECT_CALL (*this, stop ()).Times (0);
     EXPECT_CALL (*this, getcurrentstate ()).Times (0);
@@ -198,7 +198,7 @@ protected:
 
   ChainToChannelFeederTests ()
     : feeder(gspServer.GetClient (), cm),
-      gspServer(channelId, meta, game)
+      gspServer(channelId, meta, GetDb (), game)
   {
     gspServer.GetClientConnector ().SetTimeout (RPC_TIMEOUT_MS);
   }

--- a/gamechannel/channelgame.cpp
+++ b/gamechannel/channelgame.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 The Xaya developers
+// Copyright (C) 2019-2020 The Xaya developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -17,9 +17,9 @@ namespace xaya
 {
 
 void
-ChannelGame::SetupGameChannelsSchema (sqlite3* db)
+ChannelGame::SetupGameChannelsSchema (SQLiteDatabase& db)
 {
-  InternalSetupGameChannelsSchema (db);
+  InternalSetupGameChannelsSchema (*db);
 }
 
 bool

--- a/gamechannel/channelgame.hpp
+++ b/gamechannel/channelgame.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 The Xaya developers
+// Copyright (C) 2019-2020 The Xaya developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -33,7 +33,7 @@ protected:
    * Sets up the game-channel-related database schema.  This method should be
    * called from the overridden SetupSchema method.
    */
-  void SetupGameChannelsSchema (sqlite3* db);
+  void SetupGameChannelsSchema (SQLiteDatabase& db);
 
   /**
    * Processes a request (e.g. sent in a move) to open a dispute at the

--- a/gamechannel/channelgame_tests.cpp
+++ b/gamechannel/channelgame_tests.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 The Xaya developers
+// Copyright (C) 2019-2020 The Xaya developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -47,7 +47,7 @@ protected:
   proto::ChannelMetadata meta;
 
   ChannelGameTests ()
-    : tbl(game)
+    : tbl(GetDb ())
   {
     meta.add_participants ()->set_address ("addr0");
     meta.add_participants ()->set_address ("addr1");

--- a/gamechannel/database.hpp
+++ b/gamechannel/database.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 The Xaya developers
+// Copyright (C) 2019-2020 The Xaya developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -10,6 +10,7 @@
 #include "proto/metadata.pb.h"
 #include "proto/stateproof.pb.h"
 
+#include <xayagame/sqlitestorage.hpp>
 #include <xayautil/uint256.hpp>
 
 #include <sqlite3.h>
@@ -18,8 +19,6 @@
 
 namespace xaya
 {
-
-class ChannelGame;
 
 /**
  * Wrapper class around the state of one channel in the database.  This
@@ -32,8 +31,8 @@ class ChannelData
 
 private:
 
-  /** The underlying ChannelGame, through which we access the database.  */
-  ChannelGame& game;
+  /** The underlying database.  */
+  SQLiteDatabase& db;
 
   /** The ID of this channel.  */
   uint256 id;
@@ -65,12 +64,12 @@ private:
   /**
    * Constructs a new instance for the given ID.
    */
-  explicit ChannelData (ChannelGame& g, const uint256& i);
+  explicit ChannelData (SQLiteDatabase& db, const uint256& i);
 
   /**
    * Constructs an instance based on the given result row.
    */
-  explicit ChannelData (ChannelGame& g, sqlite3_stmt* row);
+  explicit ChannelData (SQLiteDatabase& db, sqlite3_stmt* row);
 
   friend class ChannelsTable;
 
@@ -135,16 +134,16 @@ class ChannelsTable
 
 private:
 
-  /** The underlying ChannelGame instance, through which we access the db.  */
-  ChannelGame& game;
+  /** The underlying database instance.  */
+  SQLiteDatabase& db;
 
 public:
 
   /** Movable handle to a channel instance.  */
   using Handle = std::unique_ptr<ChannelData>;
 
-  explicit ChannelsTable (ChannelGame& g)
-    : game(g)
+  explicit ChannelsTable (SQLiteDatabase& d)
+    : db(d)
   {}
 
   ChannelsTable () = delete;

--- a/gamechannel/database_tests.cpp
+++ b/gamechannel/database_tests.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 The Xaya developers
+// Copyright (C) 2019-2020 The Xaya developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -25,7 +25,7 @@ protected:
   proto::ChannelMetadata meta;
 
   ChannelDbTests ()
-    : tbl(game)
+    : tbl(GetDb ())
   {}
 
 };

--- a/gamechannel/gamestatejson_tests.cpp
+++ b/gamechannel/gamestatejson_tests.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 The Xaya developers
+// Copyright (C) 2019-2020 The Xaya developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -86,7 +86,7 @@ protected:
   proto::ChannelMetadata meta2;
 
   GameStateJsonTests ()
-    : tbl(game)
+    : tbl(GetDb ())
   {
     CHECK (TextFormat::ParseFromString (R"(
       participants:

--- a/gamechannel/gsprpc.cpp
+++ b/gamechannel/gsprpc.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018 The Xaya developers
+// Copyright (C) 2018-2020 The Xaya developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -71,9 +71,9 @@ ChannelGspRpcServer::DefaultGetChannel (const Game& g, ChannelGame& chg,
                                      "channel ID is not a valid uint256");
 
   return chg.GetCustomStateData (g, "channel",
-    [&chg, &id] (sqlite3* db)
+    [&chg, &id] (const SQLiteDatabase& db)
       {
-        ChannelsTable tbl(chg);
+        ChannelsTable tbl(const_cast<SQLiteDatabase&> (db));
         auto h = tbl.GetById (id);
 
         if (h == nullptr)

--- a/gamechannel/schema_tests.cpp
+++ b/gamechannel/schema_tests.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 The Xaya developers
+// Copyright (C) 2019-2020 The Xaya developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -24,8 +24,8 @@ TEST_F (SchemaTests, Valid)
 
 TEST_F (SchemaTests, TwiceOk)
 {
-  InternalSetupGameChannelsSchema (GetDb ());
-  InternalSetupGameChannelsSchema (GetDb ());
+  InternalSetupGameChannelsSchema (*GetDb ());
+  InternalSetupGameChannelsSchema (*GetDb ());
 }
 
 } // anonymous namespace

--- a/gamechannel/testgame.cpp
+++ b/gamechannel/testgame.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 The Xaya developers
+// Copyright (C) 2019-2020 The Xaya developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -246,7 +246,7 @@ TestGameFixture::TestGameFixture ()
   /* The initialisation above already sets up the database schema.  */
 }
 
-sqlite3*
+SQLiteDatabase&
 TestGameFixture::GetDb ()
 {
   return game.GetDatabaseForTesting ();

--- a/gamechannel/testgame.cpp
+++ b/gamechannel/testgame.cpp
@@ -202,7 +202,7 @@ AdditionChannel::MaybeOnChainMove (const ParsedBoardState& state,
 }
 
 void
-TestGame::SetupSchema (sqlite3* db)
+TestGame::SetupSchema (SQLiteDatabase& db)
 {
   SetupGameChannelsSchema (db);
 }
@@ -214,19 +214,19 @@ TestGame::GetInitialStateBlock (unsigned& height, std::string& hashHex) const
 }
 
 void
-TestGame::InitialiseState (sqlite3* db)
+TestGame::InitialiseState (SQLiteDatabase& db)
 {
   LOG (FATAL) << "TestGame::InitialiseState is not implemented";
 }
 
 void
-TestGame::UpdateState (sqlite3* db, const Json::Value& blockData)
+TestGame::UpdateState (SQLiteDatabase& db, const Json::Value& blockData)
 {
   LOG (FATAL) << "TestGame::UpdateState is not implemented";
 }
 
 Json::Value
-TestGame::GetStateAsJson (sqlite3* db)
+TestGame::GetStateAsJson (const SQLiteDatabase& db)
 {
   LOG (FATAL) << "TestGame::GetStateAsJson is not implemented";
 }

--- a/gamechannel/testgame.hpp
+++ b/gamechannel/testgame.hpp
@@ -113,12 +113,12 @@ class TestGame : public ChannelGame
 
 protected:
 
-  void SetupSchema (sqlite3* db) override;
+  void SetupSchema (SQLiteDatabase& db) override;
   void GetInitialStateBlock (unsigned& height,
                              std::string& hashHex) const override;
-  void InitialiseState (sqlite3* db) override;
-  void UpdateState (sqlite3* db, const Json::Value& blockData) override;
-  Json::Value GetStateAsJson (sqlite3* db) override;
+  void InitialiseState (SQLiteDatabase& db) override;
+  void UpdateState (SQLiteDatabase& db, const Json::Value& blockData) override;
+  Json::Value GetStateAsJson (const SQLiteDatabase& db) override;
 
   const BoardRules& GetBoardRules () const override;
 

--- a/gamechannel/testgame.hpp
+++ b/gamechannel/testgame.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 The Xaya developers
+// Copyright (C) 2019-2020 The Xaya developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -12,6 +12,7 @@
 #include "proto/metadata.pb.h"
 #include "proto/stateproof.pb.h"
 
+#include <xayagame/sqlitestorage.hpp>
 #include <xayagame/testutils.hpp>
 #include <xayautil/uint256.hpp>
 
@@ -157,7 +158,7 @@ protected:
   /**
    * Returns the raw database handle of the test game.
    */
-  sqlite3* GetDb ();
+  SQLiteDatabase& GetDb ();
 
   /**
    * Sets up the mock server to validate *any* message with the given

--- a/ships/gamestatejson.cpp
+++ b/ships/gamestatejson.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 The Xaya developers
+// Copyright (C) 2019-2020 The Xaya developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -9,14 +9,16 @@
 
 #include <sqlite3.h>
 
+#include <glog/logging.h>
+
 namespace ships
 {
 
 Json::Value
-GameStateJson::GetFullJson ()
+GameStateJson::GetFullJson () const
 {
   Json::Value stats(Json::objectValue);
-  auto* stmt = rules.PrepareStatement (R"(
+  auto* stmt = db.PrepareRo (R"(
     SELECT `name`, `won`, `lost`
       FROM `game_stats`
   )");
@@ -41,8 +43,8 @@ GameStateJson::GetFullJson ()
   Json::Value res(Json::objectValue);
   res["gamestats"] = stats;
 
-  xaya::ChannelsTable tbl(rules);
-  res["channels"] = xaya::AllChannelsGameStateJson (tbl, rules.boardRules);
+  xaya::ChannelsTable tbl(const_cast<xaya::SQLiteDatabase&> (db));
+  res["channels"] = xaya::AllChannelsGameStateJson (tbl, rules);
 
   return res;
 }

--- a/ships/gamestatejson.hpp
+++ b/ships/gamestatejson.hpp
@@ -1,11 +1,13 @@
-// Copyright (C) 2019 The Xaya developers
+// Copyright (C) 2019-2020 The Xaya developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #ifndef XAYASHIPS_GAMESTATEJSON_HPP
 #define XAYASHIPS_GAMESTATEJSON_HPP
 
-#include "logic.hpp"
+#include "board.hpp"
+
+#include <xayagame/sqlitestorage.hpp>
 
 #include <json/json.h>
 
@@ -21,13 +23,16 @@ class GameStateJson
 
 private:
 
-  /** The underlying Xayaships logic instance.  */
-  ShipsLogic& rules;
+  /** The underlying database instance.  */
+  const xaya::SQLiteDatabase& db;
+
+  /** Our board rules.  */
+  const ShipsBoardRules& rules;
 
 public:
 
-  GameStateJson (ShipsLogic& r)
-    : rules(r)
+  GameStateJson (const xaya::SQLiteDatabase& d, const ShipsBoardRules& r)
+    : db(d), rules(r)
   {}
 
   GameStateJson () = delete;
@@ -37,7 +42,7 @@ public:
   /**
    * Extracts the full current state as JSON.
    */
-  Json::Value GetFullJson ();
+  Json::Value GetFullJson () const;
 
 };
 

--- a/ships/gamestatejson_tests.cpp
+++ b/ships/gamestatejson_tests.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 The Xaya developers
+// Copyright (C) 2019-2020 The Xaya developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -54,7 +54,7 @@ protected:
 
 TEST_F (GameStateJsonTests, GameStats)
 {
-  CHECK_EQ (sqlite3_exec (GetDb (), R"(
+  CHECK_EQ (sqlite3_exec (*GetDb (), R"(
     INSERT INTO `game_stats`
       (`name`, `won`, `lost`) VALUES ('foo', 10, 2), ('bar', 5, 5)
   )", nullptr, nullptr, nullptr), SQLITE_OK);

--- a/ships/gamestatejson_tests.cpp
+++ b/ships/gamestatejson_tests.cpp
@@ -47,7 +47,7 @@ protected:
   GameStateJson gsj;
 
   GameStateJsonTests ()
-    : tbl(game), gsj(game)
+    : tbl(GetDb ()), gsj(GetDb (), GetBoardRules ())
   {}
 
 };

--- a/ships/logic.hpp
+++ b/ships/logic.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 The Xaya developers
+// Copyright (C) 2019-2020 The Xaya developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -10,6 +10,7 @@
 #include <gamechannel/boardrules.hpp>
 #include <gamechannel/channelgame.hpp>
 #include <gamechannel/proto/metadata.pb.h>
+#include <xayagame/sqlitestorage.hpp>
 #include <xayautil/uint256.hpp>
 
 #include <json/json.h>
@@ -42,35 +43,40 @@ private:
    * Tries to process a "create channel" move, if the JSON object describes
    * a valid one.
    */
-  void HandleCreateChannel (const Json::Value& obj, const std::string& name,
+  void HandleCreateChannel (xaya::SQLiteDatabase& db,
+                            const Json::Value& obj, const std::string& name,
                             const xaya::uint256& txid);
 
   /**
    * Tries to process a "join channel" move.
    */
-  void HandleJoinChannel (const Json::Value& obj, const std::string& name,
+  void HandleJoinChannel (xaya::SQLiteDatabase& db,
+                          const Json::Value& obj, const std::string& name,
                           const xaya::uint256& txid);
 
   /**
    * Tries to process an "abort channel" move.
    */
-  void HandleAbortChannel (const Json::Value& obj, const std::string& name);
+  void HandleAbortChannel (xaya::SQLiteDatabase& db,
+                           const Json::Value& obj, const std::string& name);
 
   /**
    * Tries to process a channel close with winner statement.
    */
-  void HandleCloseChannel (const Json::Value& obj);
+  void HandleCloseChannel (xaya::SQLiteDatabase& db,
+                           const Json::Value& obj);
 
   /**
    * Tries to process a dispute/resolution move.
    */
-  void HandleDisputeResolution (const Json::Value& obj, unsigned height,
+  void HandleDisputeResolution (xaya::SQLiteDatabase& db,
+                                const Json::Value& obj, unsigned height,
                                 bool isDispute);
 
   /**
    * Processes all expired disputes, force-closing the channels.
    */
-  void ProcessExpiredDisputes (unsigned height);
+  void ProcessExpiredDisputes (xaya::SQLiteDatabase& db, unsigned height);
 
   /**
    * Updates the game stats in the global database state for a channel that
@@ -78,7 +84,8 @@ private:
    * (remove) the channel itself from the database; it just updates the
    * game_stats table.
    */
-  void UpdateStats (const xaya::proto::ChannelMetadata& meta, int winner);
+  void UpdateStats (xaya::SQLiteDatabase& db,
+                    const xaya::proto::ChannelMetadata& meta, int winner);
 
   /**
    * Binds a TEXT SQLite parameter to a string.  This is a utility method that
@@ -98,17 +105,20 @@ private:
 
 protected:
 
-  const xaya::BoardRules& GetBoardRules () const override;
-
-  void SetupSchema (sqlite3* db) override;
+  void SetupSchema (xaya::SQLiteDatabase& db) override;
 
   void GetInitialStateBlock (unsigned& height,
                              std::string& hashHex) const override;
-  void InitialiseState (sqlite3* db) override;
+  void InitialiseState (xaya::SQLiteDatabase& db) override;
 
-  void UpdateState (sqlite3* db, const Json::Value& blockData) override;
+  void UpdateState (xaya::SQLiteDatabase& db,
+                    const Json::Value& blockData) override;
 
-  Json::Value GetStateAsJson (sqlite3* db) override;
+  Json::Value GetStateAsJson (const xaya::SQLiteDatabase& db) override;
+
+public:
+
+  const xaya::BoardRules& GetBoardRules () const override;
 
 };
 
@@ -124,14 +134,16 @@ private:
   /**
    * Tries to process a pending dispute or resolution move.
    */
-  void HandleDisputeResolution (const Json::Value& obj);
+  void HandleDisputeResolution (xaya::SQLiteDatabase& db,
+                                const Json::Value& obj);
 
   /**
    * Processes a new move, but does not call AccessConfirmedState.  This is
    * used in tests, so that we can get away without setting up a consistent
    * current state in the database.
    */
-  void AddPendingMoveUnsafe (const Json::Value& mv);
+  void AddPendingMoveUnsafe (const xaya::SQLiteDatabase& db,
+                             const Json::Value& mv);
 
   friend class PendingTests;
 

--- a/ships/logic.hpp
+++ b/ships/logic.hpp
@@ -40,27 +40,6 @@ private:
   ShipsBoardRules boardRules;
 
   /**
-   * Tries to process a "create channel" move, if the JSON object describes
-   * a valid one.
-   */
-  void HandleCreateChannel (xaya::SQLiteDatabase& db,
-                            const Json::Value& obj, const std::string& name,
-                            const xaya::uint256& txid);
-
-  /**
-   * Tries to process a "join channel" move.
-   */
-  void HandleJoinChannel (xaya::SQLiteDatabase& db,
-                          const Json::Value& obj, const std::string& name,
-                          const xaya::uint256& txid);
-
-  /**
-   * Tries to process an "abort channel" move.
-   */
-  void HandleAbortChannel (xaya::SQLiteDatabase& db,
-                           const Json::Value& obj, const std::string& name);
-
-  /**
    * Tries to process a channel close with winner statement.
    */
   void HandleCloseChannel (xaya::SQLiteDatabase& db,
@@ -84,8 +63,9 @@ private:
    * (remove) the channel itself from the database; it just updates the
    * game_stats table.
    */
-  void UpdateStats (xaya::SQLiteDatabase& db,
-                    const xaya::proto::ChannelMetadata& meta, int winner);
+  static void UpdateStats (xaya::SQLiteDatabase& db,
+                           const xaya::proto::ChannelMetadata& meta,
+                           int winner);
 
   /**
    * Binds a TEXT SQLite parameter to a string.  This is a utility method that
@@ -93,11 +73,6 @@ private:
    */
   static void BindStringParam (sqlite3_stmt* stmt, int ind,
                                const std::string& str);
-
-  /* This class is not test-code, but it is basically a part of the
-     implementation of ShipsLogic itself that is just moved out to a separate
-     file / compilation unit to make the code easier to read.  */
-  friend class GameStateJson;
 
   friend class InMemoryLogicFixture;
   friend class StateUpdateTests;

--- a/ships/logic_tests.cpp
+++ b/ships/logic_tests.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 The Xaya developers
+// Copyright (C) 2019-2020 The Xaya developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -36,7 +36,7 @@ protected:
   xaya::ChannelsTable tbl;
 
   StateUpdateTests ()
-    : tbl(game)
+    : tbl(GetDb ())
   {}
 
   /**
@@ -57,7 +57,7 @@ protected:
     blockData["block"] = block;
     blockData["moves"] = moveJson;
 
-    game.UpdateState (nullptr, blockData);
+    game.UpdateState (GetDb (), blockData);
   }
 
   /**
@@ -100,7 +100,7 @@ protected:
   void
   UpdateStats (const xaya::proto::ChannelMetadata& meta, const int winner)
   {
-    game.UpdateStats (meta, winner);
+    game.UpdateStats (GetDb (), meta, winner);
   }
 
   /**
@@ -110,7 +110,7 @@ protected:
   void
   AddStatsRow (const std::string& name, const int won, const int lost)
   {
-    auto* stmt = game.PrepareStatement (R"(
+    auto* stmt = GetDb ().Prepare (R"(
       INSERT INTO `game_stats`
         (`name`, `won`, `lost`) VALUES (?1, ?2, ?3)
     )");
@@ -126,7 +126,7 @@ protected:
   void
   ExpectStatsRow (const std::string& name, const int won, const int lost)
   {
-    auto* stmt = game.PrepareStatement (R"(
+    auto* stmt = GetDb ().Prepare (R"(
       SELECT `won`, `lost`
         FROM `game_stats`
         WHERE `name` = ?1
@@ -957,7 +957,7 @@ protected:
   xaya::ChannelsTable tbl;
 
   PendingTests ()
-    : proc(game), tbl(game)
+    : proc(game), tbl(GetDb ())
   {
     proc.InitialiseGameContext (xaya::Chain::MAIN, "xs",
                                 &mockXayaServer.GetClient ());
@@ -994,7 +994,7 @@ protected:
   void
   AddPendingMove (const Json::Value& mv)
   {
-    proc.AddPendingMoveUnsafe (mv);
+    proc.AddPendingMoveUnsafe (GetDb (), mv);
   }
 
   /**

--- a/ships/schema_tests.cpp
+++ b/ships/schema_tests.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 The Xaya developers
+// Copyright (C) 2019-2020 The Xaya developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -22,7 +22,7 @@ protected:
   void
   SetupSchema ()
   {
-    game.SetupSchema (GetDb ());
+    game.SetupSchema (*GetDb ());
   }
 
 };

--- a/ships/schema_tests.cpp
+++ b/ships/schema_tests.cpp
@@ -22,7 +22,7 @@ protected:
   void
   SetupSchema ()
   {
-    game.SetupSchema (*GetDb ());
+    game.SetupSchema (GetDb ());
   }
 
 };

--- a/ships/testutils.cpp
+++ b/ships/testutils.cpp
@@ -40,4 +40,10 @@ InMemoryLogicFixture::GetDb ()
   return game.GetDatabaseForTesting ();
 }
 
+const ShipsBoardRules&
+InMemoryLogicFixture::GetBoardRules () const
+{
+  return dynamic_cast<const ShipsBoardRules&> (game.GetBoardRules ());
+}
+
 } // namespace ships

--- a/ships/testutils.cpp
+++ b/ships/testutils.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 The Xaya developers
+// Copyright (C) 2019-2020 The Xaya developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -34,7 +34,7 @@ InMemoryLogicFixture::InMemoryLogicFixture ()
   /* The initialisation above already sets up the database schema.  */
 }
 
-sqlite3*
+xaya::SQLiteDatabase&
 InMemoryLogicFixture::GetDb ()
 {
   return game.GetDatabaseForTesting ();

--- a/ships/testutils.hpp
+++ b/ships/testutils.hpp
@@ -53,6 +53,11 @@ protected:
    */
   xaya::SQLiteDatabase& GetDb ();
 
+  /**
+   * Returns our board rules.
+   */
+  const ShipsBoardRules& GetBoardRules () const;
+
 };
 
 } // namespace ships

--- a/ships/testutils.hpp
+++ b/ships/testutils.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 The Xaya developers
+// Copyright (C) 2019-2020 The Xaya developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -8,6 +8,7 @@
 #include "grid.hpp"
 #include "logic.hpp"
 
+#include <xayagame/sqlitestorage.hpp>
 #include <xayagame/testutils.hpp>
 #include <xayagame/rpc-stubs/xayarpcclient.h>
 
@@ -50,7 +51,7 @@ protected:
   /**
    * Returns the raw database handle of the test game.
    */
-  sqlite3* GetDb ();
+  xaya::SQLiteDatabase& GetDb ();
 
 };
 

--- a/xayagame/sqlitegame.hpp
+++ b/xayagame/sqlitegame.hpp
@@ -8,7 +8,7 @@
 #include "game.hpp"
 #include "gamelogic.hpp"
 #include "pendingmoves.hpp"
-#include "storage.hpp"
+#include "sqlitestorage.hpp"
 
 #include <sqlite3.h>
 
@@ -184,12 +184,12 @@ protected:
                                   const ExtractJsonFromDb& cb);
 
   /**
-   * Returns a direct handle to the underlying SQLite database.
+   * Returns a direct handle to the underlying SQLiteDatabase.
    *
    * THIS SHOULD ONLY BE USED FOR UNIT TESTS AND NOT IN PRODUCTION CODE!
    * For real code, only use the handle passed into the callbacks.
    */
-  sqlite3* GetDatabaseForTesting ();
+  SQLiteDatabase& GetDatabaseForTesting ();
 
   GameStateData GetInitialStateInternal (unsigned& height,
                                          std::string& hashHex) override;

--- a/xayagame/sqlitegame_tests.cpp
+++ b/xayagame/sqlitegame_tests.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2019 The Xaya developers
+// Copyright (C) 2018-2020 The Xaya developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -820,11 +820,11 @@ protected:
    * Queries the usernames in the database, without specifying an order.
    */
   static UserArray
-  GetUnorderedUsernames (sqlite3* db)
+  GetUnorderedUsernames (SQLiteDatabase& db)
   {
     UserArray res;
 
-    const int rc = sqlite3_exec (db, R"(
+    const int rc = sqlite3_exec (*db, R"(
       SELECT `user` FROM `chat`
     )", &SaveUserToArray, &res, nullptr);
     CHECK_EQ (rc, SQLITE_OK) << "Failed to retrieve chat users from DB";

--- a/xayagame/sqlitegame_tests.cpp
+++ b/xayagame/sqlitegame_tests.cpp
@@ -168,9 +168,9 @@ private:
 protected:
 
   void
-  SetupSchema (sqlite3* db) override
+  SetupSchema (SQLiteDatabase& db) override
   {
-    ExecuteWithNoResult (db, R"(
+    ExecuteWithNoResult (*db, R"(
       CREATE TABLE IF NOT EXISTS `chat`
           (`user` TEXT PRIMARY KEY,
            `msg` TEXT);
@@ -178,25 +178,25 @@ protected:
   }
 
   void
-  InitialiseState (sqlite3* db) override
+  InitialiseState (SQLiteDatabase& db) override
   {
     /* To verify proper intialisation, the initial state of the chat game is
        not empty but has predefined starting messages.  */
 
-    ExecuteWithNoResult (db, R"(
+    ExecuteWithNoResult (*db, R"(
       INSERT INTO `chat` (`user`, `msg`) VALUES ('domob', 'hello world')
     )");
 
     if (shouldFail)
       throw Failure ();
 
-    ExecuteWithNoResult (db, R"(
+    ExecuteWithNoResult (*db, R"(
       INSERT INTO `chat` (`user`, `msg`) VALUES ('foo', 'bar')
     )");
   }
 
   void
-  UpdateState (sqlite3* db, const Json::Value& blockData) override
+  UpdateState (SQLiteDatabase& db, const Json::Value& blockData) override
   {
     for (const auto& m : blockData["moves"])
       {
@@ -204,7 +204,7 @@ protected:
         for (const auto& v : m["move"])
           {
             const std::string value = v.asString ();
-            ExecuteWithNoResult (db, R"(
+            ExecuteWithNoResult (*db, R"(
               INSERT OR REPLACE INTO `chat` (`user`, `msg`) VALUES
             (')" + name + "', '" + value + "')");
           }
@@ -215,7 +215,7 @@ protected:
   }
 
   Json::Value
-  GetStateAsJson (sqlite3* db) override
+  GetStateAsJson (const SQLiteDatabase& db) override
   {
     const State data = GetState (db);
 
@@ -290,10 +290,10 @@ public:
    * Queries the current state as map from the database.
    */
   static State
-  GetState (sqlite3* db)
+  GetState (const SQLiteDatabase& db)
   {
     State data;
-    const int rc = sqlite3_exec (db, R"(
+    const int rc = sqlite3_exec (db.ro (), R"(
       SELECT `user`, `msg` FROM `chat`
     )", &SaveToMap, &data, nullptr);
     CHECK_EQ (rc, SQLITE_OK) << "Failed to retrieve current state from DB";
@@ -596,14 +596,14 @@ class ChatGameRequiringContext : public ChatGame
 protected:
 
   void
-  InitialiseState (sqlite3* db) override
+  InitialiseState (SQLiteDatabase& db) override
   {
     GetContext ();
     ChatGame::InitialiseState (db);
   }
 
   void
-  UpdateState (sqlite3* db, const Json::Value& blockData) override
+  UpdateState (SQLiteDatabase& db, const Json::Value& blockData) override
   {
     GetContext ();
     ChatGame::UpdateState (db, blockData);
@@ -649,9 +649,9 @@ class UniqueMessageChat : public ChatGame
 protected:
 
   void
-  SetupSchema (sqlite3* db) override
+  SetupSchema (SQLiteDatabase& db) override
   {
-    ExecuteWithNoResult (db, R"(
+    ExecuteWithNoResult (*db, R"(
       CREATE TABLE IF NOT EXISTS `chat`
           (`user` TEXT PRIMARY KEY,
            `msg` TEXT,
@@ -660,7 +660,7 @@ protected:
   }
 
   void
-  UpdateState (sqlite3* db, const Json::Value& blockData) override
+  UpdateState (SQLiteDatabase& db, const Json::Value& blockData) override
   {
     for (const auto& m : blockData["moves"])
       {
@@ -668,10 +668,10 @@ protected:
         for (const auto& v : m["move"])
           {
             const std::string msg = v.asString ();
-            ExecuteWithNoResult (db, R"(
+            ExecuteWithNoResult (*db, R"(
               DELETE FROM `chat`
                 WHERE `msg` = ')" + msg + "'");
-            ExecuteWithNoResult (db, R"(
+            ExecuteWithNoResult (*db, R"(
               INSERT OR REPLACE INTO `chat` (`user`, `msg`) VALUES
             (')" + name + "', '" + msg + "')");
           }
@@ -885,9 +885,9 @@ private:
 protected:
 
   void
-  SetupSchema (sqlite3* db) override
+  SetupSchema (SQLiteDatabase& db) override
   {
-    ExecuteWithNoResult (db, R"(
+    ExecuteWithNoResult (*db, R"(
       CREATE TABLE IF NOT EXISTS `first` (
           `id` INTEGER PRIMARY KEY,
           `name` TEXT
@@ -903,12 +903,12 @@ protected:
   }
 
   void
-  InitialiseState (sqlite3* db) override
+  InitialiseState (SQLiteDatabase& db) override
   {
     /* To verify proper intialisation, the initial state is not empty but
        has some pre-existing data and IDs.  */
 
-    ExecuteWithNoResult (db, R"(
+    ExecuteWithNoResult (*db, R"(
       INSERT INTO `first` (`id`, `name`) VALUES (2, 'domob');
       INSERT INTO `second` (`id`, `name`) VALUES (5, 'domob');
     )");
@@ -925,7 +925,7 @@ protected:
   }
 
   void
-  UpdateState (sqlite3* db, const Json::Value& blockData) override
+  UpdateState (SQLiteDatabase& db, const Json::Value& blockData) override
   {
     for (const auto& m : blockData["moves"])
       {
@@ -936,10 +936,10 @@ protected:
         std::ostringstream secondId;
         secondId << Ids ("second").GetNext ();
 
-        ExecuteWithNoResult (db, R"(
+        ExecuteWithNoResult (*db, R"(
           INSERT INTO `first` (`id`, `name`) VALUES
         ()" + firstId.str () + ", '" + name + "')");
-        ExecuteWithNoResult (db, R"(
+        ExecuteWithNoResult (*db, R"(
           INSERT INTO `second` (`id`, `name`) VALUES
         ()" + secondId.str () + ", '" + name + "')");
       }
@@ -949,16 +949,16 @@ protected:
   }
 
   Json::Value
-  GetStateAsJson (sqlite3* db) override
+  GetStateAsJson (const SQLiteDatabase& db) override
   {
     Map first;
-    int rc = sqlite3_exec (db, R"(
+    int rc = sqlite3_exec (db.ro (), R"(
       SELECT `id`, `name` FROM `first`
     )", &SaveToMap, &first, nullptr);
     CHECK_EQ (rc, SQLITE_OK) << "Failed to retrieve first table";
 
     Map second;
-    rc = sqlite3_exec (db, R"(
+    rc = sqlite3_exec (db.ro (), R"(
       SELECT `id`, `name` FROM `second`
     )", &SaveToMap, &second, nullptr);
     CHECK_EQ (rc, SQLITE_OK) << "Failed to retrieve second table";

--- a/xayagame/sqlitestorage.cpp
+++ b/xayagame/sqlitestorage.cpp
@@ -153,18 +153,18 @@ SQLiteStorage::OpenDatabase ()
   SetupSchema ();
 }
 
-sqlite3*
+SQLiteDatabase&
 SQLiteStorage::GetDatabase ()
 {
   CHECK (db != nullptr);
-  return **db;
+  return *db;
 }
 
-sqlite3_stmt*
-SQLiteStorage::PrepareStatement (const std::string& sql) const
+const SQLiteDatabase&
+SQLiteStorage::GetDatabase () const
 {
   CHECK (db != nullptr);
-  return db->Prepare (sql);
+  return *db;
 }
 
 /**

--- a/xayagame/sqlitestorage.cpp
+++ b/xayagame/sqlitestorage.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018 The Xaya developers
+// Copyright (C) 2018-2020 The Xaya developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -10,6 +10,67 @@
 
 namespace xaya
 {
+
+SQLiteDatabase::SQLiteDatabase (const std::string& file, const int flags)
+  : db(nullptr)
+{
+  const int rc = sqlite3_open_v2 (file.c_str (), &db, flags, nullptr);
+  if (rc != SQLITE_OK)
+    LOG (FATAL) << "Failed to open SQLite database: " << file;
+
+  CHECK (db != nullptr);
+  LOG (INFO) << "Opened SQLite database successfully: " << file;
+}
+
+SQLiteDatabase::~SQLiteDatabase ()
+{
+  for (const auto& stmt : preparedStatements)
+    {
+      /* sqlite3_finalize returns the error code corresponding to the last
+         evaluation of the statement, not an error code "about" finalising it.
+         Thus we want to ignore it here.  */
+      sqlite3_finalize (stmt.second);
+    }
+
+  CHECK (db != nullptr);
+  const int rc = sqlite3_close (db);
+  if (rc != SQLITE_OK)
+    LOG (ERROR) << "Failed to close SQLite database";
+}
+
+sqlite3_stmt*
+SQLiteDatabase::Prepare (const std::string& sql)
+{
+  return PrepareRo (sql);
+}
+
+sqlite3_stmt*
+SQLiteDatabase::PrepareRo (const std::string& sql) const
+{
+  CHECK (db != nullptr);
+  const auto mit = preparedStatements.find (sql);
+  if (mit != preparedStatements.end ())
+    {
+      /* sqlite3_reset returns an error code if the last execution of the
+         statement had an error.  We don't care about that here.  */
+      sqlite3_reset (mit->second);
+
+      const int rc = sqlite3_clear_bindings (mit->second);
+      if (rc != SQLITE_OK)
+        LOG (ERROR) << "Failed to reset bindings for statement: " << rc;
+
+      return mit->second;
+    }
+
+  sqlite3_stmt* res = nullptr;
+  const int rc = sqlite3_prepare_v2 (db, sql.c_str (), sql.size () + 1,
+                                     &res, nullptr);
+  if (rc != SQLITE_OK)
+    LOG (FATAL) << "Failed to prepare SQL statement: " << rc;
+
+  preparedStatements.emplace (sql, res);
+  return res;
+}
 
 namespace
 {
@@ -82,77 +143,28 @@ SQLiteStorage::SQLiteStorage (const std::string& f)
     LOG (INFO) << "Configured SQLite error handler";
 }
 
-SQLiteStorage::~SQLiteStorage ()
-{
-  CloseDatabase ();
-}
-
 void
 SQLiteStorage::OpenDatabase ()
 {
   CHECK (db == nullptr);
-  const int rc = sqlite3_open (filename.c_str (), &db);
-  if (rc != SQLITE_OK)
-    LOG (FATAL) << "Failed to open SQLite database: " << filename;
-
-  CHECK (db != nullptr);
-  LOG (INFO) << "Opened SQLite database successfully: " << filename;
+  db = std::make_unique<SQLiteDatabase> (filename,
+          SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE);
 
   SetupSchema ();
-}
-
-void
-SQLiteStorage::CloseDatabase ()
-{
-  for (const auto& stmt : preparedStatements)
-    {
-      /* sqlite3_finalize returns the error code corresponding to the last
-         evaluation of the statement, not an error code "about" finalising it.
-         Thus we want to ignore it here.  */
-      sqlite3_finalize (stmt.second);
-    }
-  preparedStatements.clear ();
-
-  CHECK (db != nullptr);
-  const int rc = sqlite3_close (db);
-  if (rc != SQLITE_OK)
-    LOG (ERROR) << "Failed to close SQLite database";
-  db = nullptr;
 }
 
 sqlite3*
 SQLiteStorage::GetDatabase ()
 {
   CHECK (db != nullptr);
-  return db;
+  return **db;
 }
 
 sqlite3_stmt*
 SQLiteStorage::PrepareStatement (const std::string& sql) const
 {
   CHECK (db != nullptr);
-  const auto mit = preparedStatements.find (sql);
-  if (mit != preparedStatements.end ())
-    {
-      /* sqlite3_reset returns an error code if the last execution of the
-         statement had an error.  We don't care about that here.  */
-      sqlite3_reset (mit->second);
-
-      const int rc = sqlite3_clear_bindings (mit->second);
-      if (rc != SQLITE_OK)
-        LOG (ERROR) << "Failed to reset bindings for statement: " << rc;
-
-      return mit->second;
-    }
-
-  sqlite3_stmt* res = nullptr;
-  const int rc = sqlite3_prepare_v2 (db, sql.c_str (), sql.size () + 1,
-                                     &res, nullptr);
-  if (rc != SQLITE_OK)
-    LOG (FATAL) << "Failed to prepare SQL statement: " << rc;
-
-  preparedStatements.emplace (sql, res);
-  return res;
+  return db->Prepare (sql);
 }
 
 /**
@@ -172,7 +184,7 @@ void
 SQLiteStorage::SetupSchema ()
 {
   LOG (INFO) << "Setting up database schema if it does not exist yet";
-  const int rc = sqlite3_exec (db, R"(
+  const int rc = sqlite3_exec (**db, R"(
     CREATE TABLE IF NOT EXISTS `xayagame_current`
         (`key` TEXT PRIMARY KEY,
          `value` BLOB);
@@ -196,7 +208,7 @@ SQLiteStorage::Initialise ()
 void
 SQLiteStorage::Clear ()
 {
-  CloseDatabase ();
+  db.reset ();
 
   if (filename == ":memory:")
     LOG (INFO)
@@ -216,7 +228,7 @@ SQLiteStorage::Clear ()
 bool
 SQLiteStorage::GetCurrentBlockHash (uint256& hash) const
 {
-  auto* stmt = PrepareStatement (R"(
+  auto* stmt = db->Prepare (R"(
     SELECT `value` FROM `xayagame_current` WHERE `key` = 'blockhash'
   )");
 
@@ -239,7 +251,7 @@ SQLiteStorage::GetCurrentBlockHash (uint256& hash) const
 GameStateData
 SQLiteStorage::GetCurrentGameState () const
 {
-  auto* stmt = PrepareStatement (R"(
+  auto* stmt = db->Prepare (R"(
     SELECT `value` FROM `xayagame_current` WHERE `key` = 'gamestate'
   )");
 
@@ -259,29 +271,31 @@ SQLiteStorage::SetCurrentGameState (const uint256& hash,
 {
   CHECK (startedTransaction);
 
-  StepWithNoResult (PrepareStatement ("SAVEPOINT `xayagame-setcurrentstate`"));
+  StepWithNoResult (db->Prepare ("SAVEPOINT `xayagame-setcurrentstate`"));
 
-  sqlite3_stmt* stmt = PrepareStatement (R"(
+  sqlite3_stmt* stmt = db->Prepare (R"(
     INSERT OR REPLACE INTO `xayagame_current` (`key`, `value`)
       VALUES ('blockhash', ?1)
   )");
   BindUint256 (stmt, 1, hash);
   StepWithNoResult (stmt);
 
-  stmt = PrepareStatement (R"(
+  stmt = db->Prepare (R"(
     INSERT OR REPLACE INTO `xayagame_current` (`key`, `value`)
       VALUES ('gamestate', ?1)
   )");
   BindStringBlob (stmt, 1, data);
   StepWithNoResult (stmt);
 
-  StepWithNoResult (PrepareStatement ("RELEASE `xayagame-setcurrentstate`"));
+  StepWithNoResult (db->Prepare (R"(
+    RELEASE `xayagame-setcurrentstate`
+  )"));
 }
 
 bool
 SQLiteStorage::GetUndoData (const uint256& hash, UndoData& data) const
 {
-  auto* stmt = PrepareStatement (R"(
+  auto* stmt = db->Prepare (R"(
     SELECT `data` FROM `xayagame_undo` WHERE `hash` = ?1
   )");
   BindUint256 (stmt, 1, hash);
@@ -304,7 +318,7 @@ SQLiteStorage::AddUndoData (const uint256& hash,
 {
   CHECK (startedTransaction);
 
-  auto* stmt = PrepareStatement (R"(
+  auto* stmt = db->Prepare (R"(
     INSERT OR REPLACE INTO `xayagame_undo` (`hash`, `data`, `height`)
       VALUES (?1, ?2, ?3)
   )");
@@ -324,7 +338,7 @@ SQLiteStorage::ReleaseUndoData (const uint256& hash)
 {
   CHECK (startedTransaction);
 
-  auto* stmt = PrepareStatement (R"(
+  auto* stmt = db->Prepare (R"(
     DELETE FROM `xayagame_undo` WHERE `hash` = ?1
   )");
 
@@ -337,7 +351,7 @@ SQLiteStorage::PruneUndoData (const unsigned height)
 {
   CHECK (startedTransaction);
 
-  auto* stmt = PrepareStatement (R"(
+  auto* stmt = db->Prepare (R"(
     DELETE FROM `xayagame_undo` WHERE `height` <= ?1
   )");
 
@@ -353,13 +367,13 @@ SQLiteStorage::BeginTransaction ()
 {
   CHECK (!startedTransaction);
   startedTransaction = true;
-  StepWithNoResult (PrepareStatement ("SAVEPOINT `xayagame-sqlitegame`"));
+  StepWithNoResult (db->Prepare ("SAVEPOINT `xayagame-sqlitegame`"));
 }
 
 void
 SQLiteStorage::CommitTransaction ()
 {
-  StepWithNoResult (PrepareStatement ("RELEASE `xayagame-sqlitegame`"));
+  StepWithNoResult (db->Prepare ("RELEASE `xayagame-sqlitegame`"));
   CHECK (startedTransaction);
   startedTransaction = false;
 }
@@ -367,7 +381,7 @@ SQLiteStorage::CommitTransaction ()
 void
 SQLiteStorage::RollbackTransaction ()
 {
-  StepWithNoResult (PrepareStatement ("ROLLBACK TO `xayagame-sqlitegame`"));
+  StepWithNoResult (db->Prepare ("ROLLBACK TO `xayagame-sqlitegame`"));
   CHECK (startedTransaction);
   startedTransaction = false;
 }

--- a/xayagame/sqlitestorage.hpp
+++ b/xayagame/sqlitestorage.hpp
@@ -28,6 +28,9 @@ class SQLiteDatabase
 
 private:
 
+  /** Whether or not we have already set the SQLite logger.  */
+  static bool loggerInitialised;
+
   /**
    * The SQLite database handle, which is owned and managed by the
    * current instance.  It will be opened in the constructor, and
@@ -165,7 +168,9 @@ protected:
 
 public:
 
-  explicit SQLiteStorage (const std::string& f);
+  explicit SQLiteStorage (const std::string& f)
+    : filename(f)
+  {}
 
   SQLiteStorage () = delete;
   SQLiteStorage (const SQLiteStorage&) = delete;

--- a/xayagame/sqlitestorage.hpp
+++ b/xayagame/sqlitestorage.hpp
@@ -147,19 +147,14 @@ protected:
   virtual void SetupSchema ();
 
   /**
-   * Returns the handle of the SQLite database.
+   * Returns the underlying SQLiteDatabase instance.
    */
-  sqlite3* GetDatabase ();
+  SQLiteDatabase& GetDatabase ();
 
   /**
-   * Prepares an SQL statement given as string and stores it in the cache,
-   * or retrieves the existing statement from the cache.  The prepared statement
-   * is also reset, so that it can be reused right away.
-   *
-   * The returned statement is managed (and, in particular, finalised) by the
-   * SQLiteStorage object, not by the caller.
+   * Returns the underlying SQLiteDatabase instance.
    */
-  sqlite3_stmt* PrepareStatement (const std::string& sql) const;
+  const SQLiteDatabase& GetDatabase () const;
 
   /**
    * Steps a given statement and expects no results (i.e. for an update).


### PR DESCRIPTION
This introduces a new class, `SQLiteDatabase`.  This is a thin wrapper around `sqlite3*` handles, but also implements the statement-preparation logic that used to be part of `SQLiteStorage` itself.

Instead of `sqlite3*`, the new `SQLiteDatabase` instances are now passed to all callbacks / subclass functions of `SQLiteGame`.  This also gets rid of the weird issue that `SQLiteGame` was used as a de-facto database handle due to it being the class that handles prepared statements.

With this, the required refactoring (especially also to actual GSPs using the code) that is a prerequisite of #95 is implemented.