### PR TITLE
Unblock game-state extraction

### DIFF
--- a/xayagame/game.hpp
+++ b/xayagame/game.hpp
@@ -277,6 +277,15 @@ public:
   static constexpr int WAITFORCHANGE_ALWAYS_BLOCK = 0;
 
   /**
+   * Callback function that retrieves custom state JSON from a game state
+   * and that requires a lock on the Game instance.
+   */
+  using ExtractJsonFromStateWithLock
+    = std::function<Json::Value (const GameStateData& state,
+                                 const uint256& hash, unsigned height,
+                                 std::unique_lock<std::mutex> lock)>;
+
+  /**
    * Callback function that retrieves some custom state JSON from
    * a game state with block height information.
    */
@@ -366,6 +375,20 @@ public:
   {
     mainLoop.Stop ();
   }
+
+  /**
+   * Returns a JSON object that contains information about the current
+   * syncing state and custom information extracted by a callback from the
+   * game state.
+   *
+   * The callback will be provided with a std::unique_lock on the Game
+   * instance, so it has the ability to control the potential for
+   * parallel calls (e.g. if it needs to obtain a database snapshot
+   * before allowing other threads to modify the instance).
+   */
+  Json::Value GetCustomStateData (
+      const std::string& jsonField,
+      const ExtractJsonFromStateWithLock& cb) const;
 
   /**
    * Returns a JSON object that contains information about the current

--- a/xayagame/sqlitegame.cpp
+++ b/xayagame/sqlitegame.cpp
@@ -490,8 +490,10 @@ SQLiteGame::GetCustomStateData (
 {
   return game.GetCustomStateData (jsonField,
       [this, &cb] (const GameStateData& state, const uint256& hash,
-                   const unsigned height)
+                   const unsigned height, std::unique_lock<std::mutex> lock)
         {
+          /* Since state does not actually encapsulate the entire state (which
+             is in the global database), we need to keep the lock.  */
           EnsureCurrentState (state);
           return cb (database->GetDatabase (), hash, height);
         });

--- a/xayagame/sqlitestorage.cpp
+++ b/xayagame/sqlitestorage.cpp
@@ -324,9 +324,9 @@ SQLiteStorage::Clear ()
 }
 
 bool
-SQLiteStorage::GetCurrentBlockHash (uint256& hash) const
+SQLiteStorage::GetCurrentBlockHash (const SQLiteDatabase& db, uint256& hash)
 {
-  auto* stmt = db->Prepare (R"(
+  auto* stmt = db.PrepareRo (R"(
     SELECT `value` FROM `xayagame_current` WHERE `key` = 'blockhash'
   )");
 
@@ -344,6 +344,12 @@ SQLiteStorage::GetCurrentBlockHash (uint256& hash) const
 
   StepWithNoResult (stmt);
   return true;
+}
+
+bool
+SQLiteStorage::GetCurrentBlockHash (uint256& hash) const
+{
+  return GetCurrentBlockHash (*db, hash);
 }
 
 GameStateData

--- a/xayagame/sqlitestorage.hpp
+++ b/xayagame/sqlitestorage.hpp
@@ -229,6 +229,14 @@ protected:
    */
   static void StepWithNoResult (sqlite3_stmt* stmt);
 
+  /**
+   * Returns the current block hash (if any) for the given database connection.
+   * This method needs to be separated from the instance GetCurrentBlockHash
+   * without database argument so that it can be used with snapshots in
+   * SQLiteGame.
+   */
+  static bool GetCurrentBlockHash (const SQLiteDatabase& db, uint256& hash);
+
 public:
 
   explicit SQLiteStorage (const std::string& f)

--- a/xayagame/sqlitestorage.hpp
+++ b/xayagame/sqlitestorage.hpp
@@ -11,12 +11,16 @@
 
 #include <sqlite3.h>
 
+#include <condition_variable>
 #include <map>
 #include <memory>
+#include <mutex>
 #include <string>
 
 namespace xaya
 {
+
+class SQLiteStorage;
 
 /**
  * Wrapper around an SQLite database connection.  This object mostly holds
@@ -39,10 +43,39 @@ private:
   sqlite3* db;
 
   /**
+   * Whether or not we have WAL mode on the database.  This is required
+   * to support snapshots.  It may not be the case if we have an in-memory
+   * database.
+   */
+  bool walMode;
+
+  /** The "parent" storage if this is a read-only snapshot.  */
+  const SQLiteStorage* parent = nullptr;
+
+  /**
    * A cache of prepared statements (mapping from the SQL command to the
    * statement pointer).
    */
   mutable std::map<std::string, sqlite3_stmt*> preparedStatements;
+
+  /**
+   * Marks this is a read-only snapshot (with the given parent storage).  When
+   * called, this starts a read transaction to ensure that the current view is
+   * preserved for all future queries.  It also registers this as outstanding
+   * snapshot with the parent.
+   */
+  void SetReadonlySnapshot (const SQLiteStorage& p);
+
+  /**
+   * Returns whether or not the database is using WAL mode.
+   */
+  bool
+  IsWalMode () const
+  {
+    return walMode;
+  }
+
+  friend class SQLiteStorage;
 
 public:
 
@@ -130,10 +163,33 @@ private:
   bool startedTransaction = false;
 
   /**
+   * Number of outstanding snapshots.  This has to drop to zero before
+   * we can close the database.
+   */
+  mutable unsigned snapshots = 0;
+
+  /** Mutex for the snapshot number.  */
+  mutable std::mutex mutSnapshots;
+  /** Condition variable for waiting for snapshot unrefs.  */
+  mutable std::condition_variable cvSnapshots;
+
+  /**
    * Opens the database at filename into db.  It is an error if the
    * database is already opened.
    */
   void OpenDatabase ();
+
+  /**
+   * Closes the database, making sure to wait for all outstanding snapshots.
+   */
+  void CloseDatabase ();
+
+  /**
+   * Decrements the count of outstanding snapshots.
+   */
+  void UnrefSnapshot () const;
+
+  friend class SQLiteDatabase;
 
 protected:
 
@@ -160,6 +216,13 @@ protected:
   const SQLiteDatabase& GetDatabase () const;
 
   /**
+   * Creates a read-only snapshot of the underlying database and returns
+   * the corresponding SQLiteDatabase instance.  May return NULL if the
+   * underlying database is not using WAL mode (e.g. in-memory).
+   */
+  std::unique_ptr<SQLiteDatabase> GetSnapshot () const;
+
+  /**
    * Steps a given statement and expects no results (i.e. for an update).
    * Can also be used for statements where we expect exactly one result to
    * verify that no more are there.
@@ -171,6 +234,8 @@ public:
   explicit SQLiteStorage (const std::string& f)
     : filename(f)
   {}
+
+  ~SQLiteStorage ();
 
   SQLiteStorage () = delete;
   SQLiteStorage (const SQLiteStorage&) = delete;

--- a/xayagame/sqlitestorage_tests.cpp
+++ b/xayagame/sqlitestorage_tests.cpp
@@ -1,20 +1,25 @@
-// Copyright (C) 2018 The Xaya developers
+// Copyright (C) 2018-2020 The Xaya developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include "sqlitestorage.hpp"
 
 #include "storage_tests.hpp"
+#include "testutils.hpp"
 
 #include <gtest/gtest.h>
 
+#include <atomic>
 #include <cstdio>
 #include <memory>
+#include <thread>
 
 namespace xaya
 {
 namespace
 {
+
+/* ************************************************************************** */
 
 /**
  * Simple utility subclass of SQLiteStorage, which makes it default
@@ -37,6 +42,8 @@ INSTANTIATE_TYPED_TEST_CASE_P (SQLite, PruningStorageTests,
                                InMemorySQLiteStorage);
 INSTANTIATE_TYPED_TEST_CASE_P (SQLite, TransactingStorageTests,
                                InMemorySQLiteStorage);
+
+/* ************************************************************************** */
 
 /**
  * Tests for SQLiteStorage with a temporary on-disk database file (instead of
@@ -122,6 +129,132 @@ TEST_F (PersistentSQLiteStorageTests, ClearWithOnDiskFile)
   EXPECT_FALSE (storage.GetCurrentBlockHash (h));
   EXPECT_FALSE (storage.GetUndoData (hash, val));
 }
+
+/* ************************************************************************** */
+
+class SQLiteStorageSnapshotTests : public PersistentSQLiteStorageTests
+{
+
+protected:
+
+  class Storage : public SQLiteStorage
+  {
+
+  public:
+
+    using SQLiteStorage::SQLiteStorage;
+    using SQLiteStorage::GetDatabase;
+    using SQLiteStorage::GetSnapshot;
+
+  };
+
+  /**
+   * Expects that the current game state as seen by the given database
+   * matches the given value.  The empty value matches "no state".
+   */
+  void
+  ExpectDatabaseState (const SQLiteDatabase& db, const std::string& value)
+  {
+    auto* stmt = db.PrepareRo (R"(
+      SELECT `value`
+        FROM `xayagame_current`
+        WHERE `key` = 'gamestate'
+    )");
+
+    const int rc = sqlite3_step (stmt);
+    if (rc == SQLITE_DONE)
+      {
+        EXPECT_EQ (value, "") << "No state in the database, expected " << value;
+        return;
+      }
+    CHECK_EQ (rc, SQLITE_ROW);
+
+    const unsigned char* data = sqlite3_column_text (stmt, 0);
+    EXPECT_EQ (std::string (reinterpret_cast<const char*> (data)), value);
+
+    CHECK_EQ (sqlite3_step (stmt), SQLITE_DONE);
+  }
+
+};
+
+TEST_F (SQLiteStorageSnapshotTests, SnapshotNotSupported)
+{
+  Storage storage(":memory:");
+  storage.Initialise ();
+
+  EXPECT_EQ (storage.GetSnapshot (), nullptr);
+}
+
+TEST_F (SQLiteStorageSnapshotTests, SnapshotsAreReadonly)
+{
+  Storage storage(filename);
+  storage.Initialise ();
+
+  auto snapshot = storage.GetSnapshot ();
+  ASSERT_NE (snapshot, nullptr);
+  auto* stmt = snapshot->Prepare (R"(
+    INSERT INTO `xayagame_current`
+      (`key`, `value`) VALUES ('foo', 'bar')
+  )");
+  EXPECT_EQ (sqlite3_step (stmt), SQLITE_READONLY);
+}
+
+TEST_F (SQLiteStorageSnapshotTests, MultipleSnapshots)
+{
+  Storage storage(filename);
+  storage.Initialise ();
+
+  storage.BeginTransaction ();
+  auto s1 = storage.GetSnapshot ();
+  storage.SetCurrentGameState (hash, "first");
+  storage.CommitTransaction ();
+
+  auto s2 = storage.GetSnapshot ();
+  storage.BeginTransaction ();
+  storage.SetCurrentGameState (hash, "second");
+  auto s3 = storage.GetSnapshot ();
+  storage.CommitTransaction ();
+  auto s4 = storage.GetSnapshot ();
+
+  ExpectDatabaseState (*s1, "");
+  ExpectDatabaseState (*s2, "first");
+  ExpectDatabaseState (*s3, "first");
+  ExpectDatabaseState (*s4, "second");
+  ExpectDatabaseState (storage.GetDatabase (), "second");
+}
+
+TEST_F (SQLiteStorageSnapshotTests, CloseWaitsForOutstandingSnapshots)
+{
+  Storage storage(filename);
+  storage.Initialise ();
+
+  storage.BeginTransaction ();
+  storage.SetCurrentGameState (hash, "state");
+  storage.CommitTransaction ();
+
+  auto s1 = storage.GetSnapshot ();
+  auto s2 = storage.GetSnapshot ();
+
+  std::atomic<bool> done(false);
+  auto clearJob = std::make_unique<std::thread> ([&] ()
+    {
+      storage.Clear ();
+      done = true;
+    });
+
+  SleepSome ();
+  ExpectDatabaseState (*s1, "state");
+  ExpectDatabaseState (*s2, "state");
+  EXPECT_FALSE (done);
+
+  s1.reset ();
+  s2.reset ();
+  clearJob->join ();
+
+  ExpectDatabaseState (storage.GetDatabase (), "");
+}
+
+/* ************************************************************************** */
 
 } // anonymous namespace
 } // namespace xaya


### PR DESCRIPTION
This implements #95:  Where possible, we uncouple the "game-state extraction" logic in `GetCustomStateData` from the main lock on `Game`.  In particular for `SQLiteGame`-based GSPs, this can be done with read-only database snapshots, and allows us e.g. to run expensive operations (like all regions in Taurion) without further blocking other operations.

Note that the full-game-state method `GetCurrentJsonState` (`getcurrentstate` RPC method) does not benefit from this currently.  It doesn't matter much, though, as this method is not meant for performance-critical things anyway (only for testing / debugging).