### PR TITLE
Expose more block data for pending processing

### DIFF
--- a/mover/gametest/pending.py
+++ b/mover/gametest/pending.py
@@ -55,16 +55,15 @@ class PendingMovesTest (MoverTest):
         }
     })
 
-    # Mine two blocks, which we will detach later and then reorg back to
-    # the chain.  For now, this should clear the mempool.
+    # Mine a block, which we will detach later and then reorg
+    # back to the chain.  For now, this should clear the mempool.
     self.generate (1)
     reorgBlock = self.rpc.xaya.getbestblockhash ()
-    self.generate (1)
     newState = self.getGameState ()
     self.assertEqual (newState, {"players": {
-      "a": {"x": -2, "y": 1, "dir": "left", "steps": 1},
-      "b": {"x": 0, "y": -3, "dir": "down", "steps": 2},
-      "c": {"x": 0, "y": 2},
+      "a": {"x": -1, "y": 1, "dir": "left", "steps": 2},
+      "b": {"x": 0, "y": -2, "dir": "down", "steps": 3},
+      "c": {"x": 0, "y": 1, "dir": "up", "steps": 1},
     }})
     self.assertEqual (self.getPendingState (), {})
 

--- a/xayagame/game.cpp
+++ b/xayagame/game.cpp
@@ -269,7 +269,7 @@ Game::BlockAttach (const std::string& id, const Json::Value& data,
 
   if (state == State::UP_TO_DATE && pending != nullptr)
     {
-      pending->ProcessAttachedBlock (storage->GetCurrentGameState (), height);
+      pending->ProcessAttachedBlock (storage->GetCurrentGameState (), data);
       NotifyPendingStateChange ();
     }
 }
@@ -365,8 +365,7 @@ Game::BlockDetach (const std::string& id, const Json::Value& data,
       const unsigned height = data["block"]["height"].asUInt ();
       CHECK_GT (height, 0);
 
-      pending->ProcessDetachedBlock (storage->GetCurrentGameState (),
-                                     height - 1, data);
+      pending->ProcessDetachedBlock (storage->GetCurrentGameState (), data);
       NotifyPendingStateChange ();
     }
 }
@@ -385,11 +384,10 @@ Game::PendingMove (const std::string& id, const Json::Value& data)
   if (state == State::UP_TO_DATE)
     {
       uint256 hash;
-      unsigned height;
-      CHECK (storage->GetCurrentBlockHashWithHeight (hash, height));
+      CHECK (storage->GetCurrentBlockHash (hash));
 
       CHECK (pending != nullptr);
-      pending->ProcessMove (storage->GetCurrentGameState (), height, data);
+      pending->ProcessMove (storage->GetCurrentGameState (), data);
       NotifyPendingStateChange ();
     }
   else

--- a/xayagame/sqlitegame_tests.cpp
+++ b/xayagame/sqlitegame_tests.cpp
@@ -329,10 +329,6 @@ protected:
   Clear () override
   {
     pending = Json::Value (Json::objectValue);
-
-    const auto state = ChatGame::GetState (AccessConfirmedState ());
-    for (const auto& entry : state)
-      pending[entry.first] = Json::Value (Json::arrayValue);
   }
 
   void
@@ -341,6 +337,11 @@ protected:
     const std::string name = mv["name"].asString ();
     if (!pending.isMember (name))
       pending[name] = Json::Value (Json::arrayValue);
+
+    const auto state = ChatGame::GetState (AccessConfirmedState ());
+    for (const auto& entry : state)
+      if (!pending.isMember (entry.first))
+        pending[entry.first] = Json::Value (Json::arrayValue);
 
     for (const auto& val : mv["move"])
       pending[name].append (val.asString ());
@@ -1215,14 +1216,6 @@ TEST_F (SQLitePendingMoveTests, Works)
   AttachBlock (game, BlockHash (11), ChatGame::Moves ({
     {"domob", "new"},
   }));
-
-  /* Verify the initial state is set up correctly based on the database.  */
-  EXPECT_EQ (proc.ToJson (), ParseJson (R"(
-    {
-      "domob": [],
-      "foo": []
-    }
-  )"));
 
   const auto moves = ChatGame::Moves ({
     {"foo", "baz"},


### PR DESCRIPTION
Instead of just the confirmed block height, expose the full block metadata (the `block` field of the ZMQ notification) to the pending move processor.  This allows it to e.g. also get a (rough) idea of what the next block time might be (at which to evaluate the pending moves).

In order to have this information, we keep an in-memory cache of the last attached blocks.  Only if the last block is known based on that queue will pending moves be processed.  This leads to some situations in which they will be ignored, e.g. when the node has just been started up or a long reorg has finished.  But those situations will not be often in practice, and will most likely be situations in which pending moves would not be super meaningful anyway.  Returning an empty set of pending moves is always a "valid" thing to do anyway, as there is no guarantee of knowing about any in the mempool anyway.