### PR TITLE
Implement example GSP for non-fungible assets

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,3 +1,3 @@
 ACLOCAL_AMFLAGS = ${ACLOCAL_FLAGS} -Im4
 
-SUBDIRS = xayautil xayagame xayagametest mover gamechannel ships
+SUBDIRS = xayautil xayagame xayagametest mover nonfungible gamechannel ships

--- a/README.md
+++ b/README.md
@@ -9,6 +9,13 @@ rules of their game.
 can move around an infinite plane.  It is fully functional, although mainly
 meant as example and/or basis for more complex games.
 
+Similarly, [`nonfungible`](nonfungible/README.md) is a simple implementation
+of non-fungible assets on the Xaya platform.  It is useful as another example
+(of using the
+[SQLite integration](https://github.com/xaya/libxayagame/blob/master/xayagame/sqlitegame.hpp)),
+for testing [Democrit](https://github.com/xaya/democrit) but also as an actual
+application on Xaya for issuing and trading fungible and non-fungible tokens.
+
 This repository also contains a framework for [**game
 channels**](http://www.ledgerjournal.org/ojs/index.php/ledger/article/view/15)
 as well as [Xayaships](ships/README.md), which is an example game for

--- a/configure.ac
+++ b/configure.ac
@@ -60,6 +60,7 @@ AC_CONFIG_FILES([
   gamechannel/Makefile \
   mover/Makefile \
   mover/gametest/Makefile \
+  nonfungible/Makefile \
   ships/Makefile \
   ships/channeltest/Makefile \
   ships/gametest/Makefile \

--- a/configure.ac
+++ b/configure.ac
@@ -61,6 +61,7 @@ AC_CONFIG_FILES([
   mover/Makefile \
   mover/gametest/Makefile \
   nonfungible/Makefile \
+  nonfungible/gametest/Makefile \
   ships/Makefile \
   ships/channeltest/Makefile \
   ships/gametest/Makefile \

--- a/nonfungible/.gitignore
+++ b/nonfungible/.gitignore
@@ -1,1 +1,2 @@
 nonfungibled
+schema.cpp

--- a/nonfungible/.gitignore
+++ b/nonfungible/.gitignore
@@ -1,0 +1,1 @@
+nonfungibled

--- a/nonfungible/Makefile.am
+++ b/nonfungible/Makefile.am
@@ -14,9 +14,13 @@ libnonfungible_la_LIBADD = \
   $(top_builddir)/xayagame/libxayagame.la \
   $(JSONCPP_LIBS) $(SQLITE_LIBS) $(GLOG_LIBS)
 libnonfungible_la_SOURCES = \
+  assets.cpp \
+  dbutils.cpp \
   logic.cpp \
   schema.cpp
 noinst_HEADERS = \
+  assets.hpp \
+  dbutils.hpp \
   logic.hpp \
   schema.hpp
 
@@ -45,6 +49,7 @@ tests_LDADD = \
   $(GTEST_LIBS) \
   $(JSONCPP_LIBS) $(SQLITE_LIBS) $(GLOG_LIBS)
 tests_SOURCES = \
+  assets_tests.cpp \
   schema_tests.cpp \
   \
   testutils.cpp

--- a/nonfungible/Makefile.am
+++ b/nonfungible/Makefile.am
@@ -2,9 +2,12 @@ noinst_LTLIBRARIES = libnonfungible.la
 bin_PROGRAMS = nonfungibled
 
 EXTRA_DIST = \
+  rpc-stubs/nf.json \
   schema.sql schema_head.cpp schema_tail.cpp
 
-CLEANFILES = schema.cpp
+RPC_STUBS = rpc-stubs/nfrpcserverstub.h
+BUILT_SOURCES = $(RPC_STUBS)
+CLEANFILES = schema.cpp $(RPC_STUBS)
 
 libnonfungible_la_CXXFLAGS = \
   -I$(top_srcdir) \
@@ -22,7 +25,7 @@ libnonfungible_la_SOURCES = \
   pending.cpp \
   schema.cpp \
   statejson.cpp
-noinst_HEADERS = \
+libnonfungibleheaders = \
   assets.hpp \
   dbutils.hpp \
   logic.hpp \
@@ -41,7 +44,14 @@ nonfungibled_LDADD = \
   $(top_builddir)/xayautil/libxayautil.la \
   $(top_builddir)/xayagame/libxayagame.la \
   $(GLOG_LIBS) $(GFLAGS_LIBS)
-nonfungibled_SOURCES = main.cpp
+nonfungibled_SOURCES = main.cpp \
+  rpcserver.cpp
+nonfungibledheaders = \
+  rpcserver.hpp \
+  \
+  rpc-stubs/nfrpcserverstub.h
+
+noinst_HEADERS = $(libnonfungibleheaders) $(nonfungibledheaders)
 
 check_PROGRAMS = tests
 TESTS = tests
@@ -69,3 +79,6 @@ check_HEADERS = \
 
 schema.cpp: schema_head.cpp schema.sql schema_tail.cpp
 	cat $^ >$@
+
+rpc-stubs/nfrpcserverstub.h: $(srcdir)/rpc-stubs/nf.json
+	jsonrpcstub "$<" --cpp-server=NFRpcServerStub --cpp-server-file="$@"

--- a/nonfungible/Makefile.am
+++ b/nonfungible/Makefile.am
@@ -17,11 +17,15 @@ libnonfungible_la_SOURCES = \
   assets.cpp \
   dbutils.cpp \
   logic.cpp \
+  moveparser.cpp \
+  moveprocessor.cpp \
   schema.cpp
 noinst_HEADERS = \
   assets.hpp \
   dbutils.hpp \
   logic.hpp \
+  moveparser.hpp \
+  moveprocessor.hpp \
   schema.hpp
 
 nonfungibled_CXXFLAGS = \
@@ -50,6 +54,7 @@ tests_LDADD = \
   $(JSONCPP_LIBS) $(SQLITE_LIBS) $(GLOG_LIBS)
 tests_SOURCES = \
   assets_tests.cpp \
+  moveprocessor_tests.cpp \
   schema_tests.cpp \
   \
   testutils.cpp

--- a/nonfungible/Makefile.am
+++ b/nonfungible/Makefile.am
@@ -1,3 +1,5 @@
+SUBDIRS = gametest
+
 noinst_LTLIBRARIES = libnonfungible.la
 bin_PROGRAMS = nonfungibled
 

--- a/nonfungible/Makefile.am
+++ b/nonfungible/Makefile.am
@@ -1,6 +1,11 @@
 noinst_LTLIBRARIES = libnonfungible.la
 bin_PROGRAMS = nonfungibled
 
+EXTRA_DIST = \
+  schema.sql schema_head.cpp schema_tail.cpp
+
+CLEANFILES = schema.cpp
+
 libnonfungible_la_CXXFLAGS = \
   -I$(top_srcdir) \
   $(JSONCPP_CFLAGS) $(SQLITE_CFLAGS) $(GLOG_CFLAGS)
@@ -9,9 +14,11 @@ libnonfungible_la_LIBADD = \
   $(top_builddir)/xayagame/libxayagame.la \
   $(JSONCPP_LIBS) $(SQLITE_LIBS) $(GLOG_LIBS)
 libnonfungible_la_SOURCES = \
-  logic.cpp
+  logic.cpp \
+  schema.cpp
 noinst_HEADERS = \
-  logic.hpp
+  logic.hpp \
+  schema.hpp
 
 nonfungibled_CXXFLAGS = \
   -I$(top_srcdir) \
@@ -23,3 +30,26 @@ nonfungibled_LDADD = \
   $(top_builddir)/xayagame/libxayagame.la \
   $(GLOG_LIBS) $(GFLAGS_LIBS)
 nonfungibled_SOURCES = main.cpp
+
+check_PROGRAMS = tests
+TESTS = tests
+
+tests_CXXFLAGS = \
+  -I$(top_srcdir) \
+  $(GTEST_CFLAGS) \
+  $(JSONCPP_CFLAGS) $(SQLITE_CFLAGS) $(GLOG_CFLAGS)
+tests_LDADD = \
+  $(builddir)/libnonfungible.la \
+  $(top_builddir)/xayautil/libxayautil.la \
+  $(top_builddir)/xayagame/libxayagame.la \
+  $(GTEST_LIBS) \
+  $(JSONCPP_LIBS) $(SQLITE_LIBS) $(GLOG_LIBS)
+tests_SOURCES = \
+  schema_tests.cpp \
+  \
+  testutils.cpp
+check_HEADERS = \
+  testutils.hpp
+
+schema.cpp: schema_head.cpp schema.sql schema_tail.cpp
+	cat $^ >$@

--- a/nonfungible/Makefile.am
+++ b/nonfungible/Makefile.am
@@ -20,7 +20,8 @@ libnonfungible_la_SOURCES = \
   moveparser.cpp \
   moveprocessor.cpp \
   pending.cpp \
-  schema.cpp
+  schema.cpp \
+  statejson.cpp
 noinst_HEADERS = \
   assets.hpp \
   dbutils.hpp \
@@ -28,7 +29,8 @@ noinst_HEADERS = \
   moveparser.hpp \
   moveprocessor.hpp \
   pending.hpp \
-  schema.hpp
+  schema.hpp \
+  statejson.hpp
 
 nonfungibled_CXXFLAGS = \
   -I$(top_srcdir) \
@@ -59,6 +61,7 @@ tests_SOURCES = \
   moveprocessor_tests.cpp \
   pending_tests.cpp \
   schema_tests.cpp \
+  statejson_tests.cpp \
   \
   testutils.cpp
 check_HEADERS = \

--- a/nonfungible/Makefile.am
+++ b/nonfungible/Makefile.am
@@ -19,6 +19,7 @@ libnonfungible_la_SOURCES = \
   logic.cpp \
   moveparser.cpp \
   moveprocessor.cpp \
+  pending.cpp \
   schema.cpp
 noinst_HEADERS = \
   assets.hpp \
@@ -26,6 +27,7 @@ noinst_HEADERS = \
   logic.hpp \
   moveparser.hpp \
   moveprocessor.hpp \
+  pending.hpp \
   schema.hpp
 
 nonfungibled_CXXFLAGS = \
@@ -55,6 +57,7 @@ tests_LDADD = \
 tests_SOURCES = \
   assets_tests.cpp \
   moveprocessor_tests.cpp \
+  pending_tests.cpp \
   schema_tests.cpp \
   \
   testutils.cpp

--- a/nonfungible/Makefile.am
+++ b/nonfungible/Makefile.am
@@ -1,0 +1,25 @@
+noinst_LTLIBRARIES = libnonfungible.la
+bin_PROGRAMS = nonfungibled
+
+libnonfungible_la_CXXFLAGS = \
+  -I$(top_srcdir) \
+  $(JSONCPP_CFLAGS) $(SQLITE_CFLAGS) $(GLOG_CFLAGS)
+libnonfungible_la_LIBADD = \
+  $(top_builddir)/xayautil/libxayautil.la \
+  $(top_builddir)/xayagame/libxayagame.la \
+  $(JSONCPP_LIBS) $(SQLITE_LIBS) $(GLOG_LIBS)
+libnonfungible_la_SOURCES = \
+  logic.cpp
+noinst_HEADERS = \
+  logic.hpp
+
+nonfungibled_CXXFLAGS = \
+  -I$(top_srcdir) \
+  $(JSONCPP_CFLAGS) $(JSONRPCCLIENT_CFLAGS) $(JSONRPCSERVER_CFLAGS) \
+  $(GLOG_CFLAGS) $(GFLAGS_CFLAGS)
+nonfungibled_LDADD = \
+  $(builddir)/libnonfungible.la \
+  $(top_builddir)/xayautil/libxayautil.la \
+  $(top_builddir)/xayagame/libxayagame.la \
+  $(GLOG_LIBS) $(GFLAGS_LIBS)
+nonfungibled_SOURCES = main.cpp

--- a/nonfungible/README.md
+++ b/nonfungible/README.md
@@ -1,0 +1,148 @@
+# Non-Fungible Assets
+
+While Xaya empowers game developers to build *fully decentralised
+and yet complex games*, there are also a lot of potential applications
+based on just generic fungible and non-fungible tokens.  The `nonfungible` GSP
+is an application built on Xaya that implements such tokens, which
+everyone can issue, transfer and collect, in a way similar to
+[ERC-1155](https://eips.ethereum.org/EIPS/eip-1155) on Ethereum.
+
+Besides being a potentially useful application, this is also a simple
+example for using libxayagame together with [SQLite](https://www.sqlite.org/),
+and is used as a demo and for testing the
+[Democrit framework](https://github.com/xaya/democrit) for atomic trading.
+
+This application is using `g/nf` as its game ID.
+
+## <a id="assets">Assets</a>
+
+On the non-fungible platform, any user (i.e. `p/` name) can mint
+*assets*.  Each asset is identified by two strings:  The minting user's name
+and another string, which specifies the asset itself.  (But two users can
+mint assets of the same name, and those two assets will be different.)
+In the game state (as returned by the RPC interface) as well as moves,
+an asset is identified by a JSON object of this form:
+
+    {"m": MINTER, "a": ASSET}
+
+Here, `MINTER` is the name of the minting user (without `p/` prefix) and
+`ASSET` is the asset's name within that user's namespace.  `ASSET` must not
+contain any unprintable characters (with code `<0x20`).
+
+Each minted asset has a fixed supply, which is an unsigned 64-bit integer.
+The supply is chosen by the minting user upon creation of the asset, and
+will from then on be fixed.  No more of an already existing asset can
+ever be created; only the existing pieces can be transferred or burned
+(and thus decrease the existing supply).
+If the supply is chosen as one token, this results in a true
+non-fungible token.  If the supply is larger, then as many tokens are
+minted that are between each other fungible (like a currency).
+
+Assets may have a total supply of zero, either because they are minted like
+that or because all issued tokens have been burned.  In that case, the asset
+still continues to exist, and no other asset with the same name can ever
+be minted by the same user again.
+
+When an asset is created, the minting user can specify a custom string
+that is associated to the asset.  This can for instance be a hash or
+[IPFS link](https://ipfs.io/) to some metadata.  After minting, this
+data is frozen and cannot ever be changed again.
+
+The minting user's role is only special when issuing a new asset;
+afterwards, they have no longer any more control over the token
+than any other user on the network.  This guarantees that assets
+issued through this application enjoy true ownership and trustlessness.
+
+## Game State
+
+The game state of this application has two main parts:  First, all assets
+created (identified by the minting user's name and the asset's name), and
+second the balances of each asset that each user holds.
+
+For the first part, the game state simply contains an append-only list
+of created assets and their associated custom string data.
+
+The balances are simply unsigned 64-bit integers keyed by (user, asset)
+holding the balance of a certain asset by some Xaya user (`p/` name).
+Note that all balances are integers; but of course those balances could
+be "interpreted" and shown by some front-end application as decimal numbers.
+
+## Moves
+
+Moves for `nonfungible` are in general represented either as a JSON object
+(for individual operations) or an array of such JSON objects (for batched
+operations in a single name-update transaction):
+
+    {"g": {"nf": MOVE}}
+    {"g": {"nf": [MOVE, MOVE, ...]}}
+
+If multiple moves are sent as a batch, then they are evaluated in order
+and independently.  In particular, later moves may depend on changes done
+by earlier ones, and if a move in the sequence is invalid, it will be ignored
+while other moves will still be executed (if valid).
+
+Each `MOVE` can be one of three operations:
+
+### Minting
+
+A user can *mint a new asset*.  For this, the move specifies the new asset's
+name, initial supply and custom data string:
+
+    {"m": {"a": ASSET, "n": SUPPLY}}
+    {"m": {"a": ASSET, "n": SUPPLY, "d": DATA}}
+
+Here, `ASSET` and `DATA` are JSON strings, and `SUPPLY` is an unsigned
+64-bit integer.  The `DATA` value is optional; if left out, then no
+custom data will be set for the asset.  The move is invalid if an asset of the
+given name exists already for the user doing the move.
+
+The maximum possible value for `SUPPLY` is 2^60.  This is an arbitrary
+choice; but it is large enough to be sufficient (a lot more than the
+number of satoshis in Bitcoin) and small enough to not cause any complications
+with implementations that perhaps do not support full unsigned 64-bit integers
+easily.
+
+Otherwise, a new asset with the given `DATA` string is added to the list
+of assets, and `SUPPLY` units of it are initially given to the minting user's
+balance (from where they can then be distributed as desired).
+
+### <a id="transfers">Transfers</a>
+
+Any user with a non-zero balance of some asset can transfer an arbitrary
+number of units (up to the balance) to any other user:
+
+    {"t": {"a": ASSET, "n": NUMBER, "r": RECIPIENT}}
+
+Here, `ASSET` is a JSON object specifying the [asset to transfer](#assets).
+`NUMBER` is an unsigned 64-bit integer, and `RECIPIENT` a JSON string
+identifying the receiving user's name (without `p/` prefix).
+
+If `NUMBER` is larger than zero and not larger than the user's current
+balance of `ASSET`, then the balance is decreased by `NUMBER` and the
+balance of `RECIPIENT` is increased accordingly.  Note that it is perfectly
+valid to send a token to any arbitrary `RECIPIENT`, even if the corresponding
+`p/` name has not even been registered on the Xaya blockchain yet, or would
+be invalid as name on Xaya.  (In which
+case anyone can register the name and thereby claim ownership of the token
+balance sent to it.)
+
+Note that if `NUMBER` is larger than the balance of the user, then
+*no tokens* will be sent (not even a sufficiently smaller amount).
+In other words, a transfer is executed as "all or nothing".
+
+### Burns
+
+Similarly, any user with a non-zero balance is free to burn one or more
+units of a token.  They will simply be removed from the total supply:
+
+    {"b": {"a": ASSET, "n": NUMBER}}
+
+`ASSET` is again a JSON object identifying the [asset to burn](#assets).
+`NUMBER` is a 64-bit integer and implies how many units will be burned.
+
+If `NUMBER` is larger than zero and not larger than the user's current
+balance of `ASSET`, then as many units will be removed from the user's
+balance and consequently also from the total existing supply of the token.
+
+As with [transfers](#transfers), no units are burned at all if `NUMBER`
+is larger than the user's current balance.

--- a/nonfungible/assets.cpp
+++ b/nonfungible/assets.cpp
@@ -1,0 +1,102 @@
+// Copyright (C) 2020 The Xaya developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "assets.hpp"
+
+#include "dbutils.hpp"
+
+namespace nf
+{
+
+Json::Value
+AmountToJson (const Amount n)
+{
+  return static_cast<Json::Int64> (n);
+}
+
+bool
+AmountFromJson (const Json::Value& val, Amount& n)
+{
+  if (!val.isInt64 ())
+    return false;
+
+  n = val.asInt64 ();
+  return n >= 0 && n <= MAX_AMOUNT;
+}
+
+void
+Asset::BindToParams (sqlite3_stmt* stmt,
+                     const int indMinter, const int indName) const
+{
+  BindParam (stmt, indMinter, minter);
+  BindParam (stmt, indName, name);
+}
+
+Json::Value
+Asset::ToJson () const
+{
+  Json::Value res(Json::objectValue);
+  res["m"] = minter;
+  res["a"] = name;
+  return res;
+}
+
+Asset
+Asset::FromColumns (sqlite3_stmt* stmt, const int indMinter, const int indName)
+{
+  return Asset (ColumnExtract<std::string> (stmt, indMinter),
+                ColumnExtract<std::string> (stmt, indName));
+}
+
+bool
+Asset::IsValidName (const std::string& nm)
+{
+  for (const unsigned char c : nm)
+    if (c < 0x20)
+      return false;
+
+  return true;
+}
+
+namespace
+{
+
+/**
+ * Returns true and extracts the result as string if the given JSON value
+ * is a string and does not contain any non-printable characters.
+ */
+bool
+GetPrintableString (const Json::Value& val, std::string& res)
+{
+  if (!val.isString ())
+    return false;
+
+  res = val.asString ();
+  return Asset::IsValidName (res);
+}
+
+} // anonymous namespace
+
+bool
+Asset::FromJson (const Json::Value& val)
+{
+  if (!val.isObject () || val.size () != 2)
+    return false;
+
+  if (!GetPrintableString (val["m"], minter))
+    return false;
+  if (!GetPrintableString (val["a"], name))
+    return false;
+
+  return true;
+}
+
+std::ostream&
+operator<< (std::ostream& out, const Asset& a)
+{
+  out << a.minter << "/" << a.name;
+  return out;
+}
+
+} // namespace nf

--- a/nonfungible/assets.cpp
+++ b/nonfungible/assets.cpp
@@ -6,6 +6,8 @@
 
 #include "dbutils.hpp"
 
+#include "xayautil/jsonutils.hpp"
+
 namespace nf
 {
 
@@ -18,7 +20,7 @@ AmountToJson (const Amount n)
 bool
 AmountFromJson (const Json::Value& val, Amount& n)
 {
-  if (!val.isInt64 ())
+  if (!xaya::IsIntegerValue (val) || !val.isInt64 ())
     return false;
 
   n = val.asInt64 ();

--- a/nonfungible/assets.hpp
+++ b/nonfungible/assets.hpp
@@ -1,0 +1,124 @@
+// Copyright (C) 2020 The Xaya developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef NONFUNGIBLE_ASSETS_HPP
+#define NONFUNGIBLE_ASSETS_HPP
+
+#include <sqlite3.h>
+
+#include <json/json.h>
+
+#include <cstdint>
+#include <ostream>
+#include <string>
+
+namespace nf
+{
+
+/** Type used for amounts.  */
+using Amount = int64_t;
+
+/** Maximum valid amount value (i.e. largest total supply of an asset).  */
+static constexpr Amount MAX_AMOUNT = (1ll << 60);
+
+/**
+ * Converts an amount to JSON.
+ */
+Json::Value AmountToJson (Amount n);
+
+/**
+ * Parses an amount from JSON and validates the range.  Returns true on success.
+ */
+bool AmountFromJson (const Json::Value& val, Amount& n);
+
+/**
+ * An asset (specified by minter and name).
+ */
+class Asset
+{
+
+private:
+
+  /** The minter's name (without p/ prefix).  */
+  std::string minter;
+
+  /** The asset's name.  */
+  std::string name;
+
+public:
+
+  Asset () = default;
+
+  explicit Asset (const std::string& m, const std::string& n)
+    : minter(m), name(n)
+  {}
+
+  Asset (const Asset&) = default;
+  Asset& operator= (const Asset&) = default;
+
+  const std::string&
+  GetMinter () const
+  {
+    return minter;
+  }
+
+  /**
+   * Binds an asset to two parameters in the SQLite statement.
+   */
+  void BindToParams (sqlite3_stmt* stmt, int indMinter, int indName) const;
+
+  /**
+   * Converts the asset to a JSON value.
+   */
+  Json::Value ToJson () const;
+
+  /**
+   * Extracts an Asset value from a database result.
+   */
+  static Asset FromColumns (sqlite3_stmt* stmt, int indMinter, int indName);
+
+  /**
+   * Checks if the given string as a valid asset name.
+   */
+  static bool IsValidName (const std::string& str);
+
+  /**
+   * Tries to parse an asset from JSON into this instance.
+   * Returns true if successful.
+   */
+  bool FromJson (const Json::Value& val);
+
+  friend bool
+  operator== (const Asset& a, const Asset& b)
+  {
+    return a.minter == b.minter && a.name == b.name;
+  }
+
+  friend bool
+  operator!= (const Asset& a, const Asset& b)
+  {
+    return !(a == b);
+  }
+
+  friend bool
+  operator< (const Asset& a, const Asset& b)
+  {
+    if (a.minter != b.minter)
+      return a.minter < b.minter;
+    return a.name < b.name;
+  }
+
+  /**
+   * Writes out the asset to a stream.  The format is readable and suited
+   * for normal debugging / logging, and not meant to be fully precise and
+   * unambiguous if the minter or asset name is weird in any case.  It is
+   * also not consensus-relevant in any way.
+   */
+  friend std::ostream& operator<< (std::ostream& out, const Asset& a);
+
+};
+
+} // namespace nf
+
+#endif // NONFUNGIBLE_ASSETS_HPP

--- a/nonfungible/assets_tests.cpp
+++ b/nonfungible/assets_tests.cpp
@@ -1,0 +1,131 @@
+// Copyright (C) 2020 The Xaya developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "assets.hpp"
+
+#include "testutils.hpp"
+
+#include <glog/logging.h>
+#include <gtest/gtest.h>
+
+namespace nf
+{
+namespace
+{
+
+using AssetsTests = DBTest;
+
+TEST_F (AssetsTests, AmountJsonRoundtrip)
+{
+  static constexpr Amount tests[] = {0, MAX_AMOUNT, 42, 5000};
+  for (const auto a : tests)
+    {
+      const Json::Value val = AmountToJson (a);
+      ASSERT_TRUE (val.isInt64 ());
+
+      Amount recovered;
+      ASSERT_TRUE (AmountFromJson (val, recovered));
+      ASSERT_EQ (recovered, a);
+    }
+}
+
+TEST_F (AssetsTests, InvalidAmountFromJson)
+{
+  Amount a;
+  ASSERT_FALSE (AmountFromJson (Json::Value (MAX_AMOUNT + 1), a));
+  for (const std::string str : {"-5", "42.5", "null", "false", "\"10\"",
+                                "[1]", "{\"foo\":\"bar\"}"})
+    ASSERT_FALSE (AmountFromJson (ParseJson (str), a)) << str;
+}
+
+TEST_F (AssetsTests, ValidAmountFromJson)
+{
+  Amount a;
+
+  ASSERT_TRUE (AmountFromJson (ParseJson ("42.0"), a));
+  EXPECT_EQ (a, 42);
+
+  ASSERT_TRUE (AmountFromJson (ParseJson ("1.5e1"), a));
+  EXPECT_EQ (a, 15);
+
+  ASSERT_TRUE (AmountFromJson (ParseJson ("-0"), a));
+  EXPECT_EQ (a, 0);
+}
+
+TEST_F (AssetsTests, DatabaseRoundtrip)
+{
+  /* This asset is not actually valid (when parsed from JSON).  But that doesn't
+     matter here, and makes sure that the DB logic can handle it.  */
+  const Asset a(std::string (u8"äöü\0foo", 10), std::string ("bar\0baz", 7));
+
+  auto* stmt = GetDb ().Prepare (R"(
+    INSERT INTO `assets`
+      (`minter`, `asset`)
+      VALUES (?1, ?2)
+  )");
+  a.BindToParams (stmt, 1, 2);
+  CHECK_EQ (sqlite3_step (stmt), SQLITE_DONE);
+
+  stmt = GetDb ().PrepareRo (R"(
+    SELECT `minter`, `asset` FROM `assets`
+  )");
+
+  CHECK_EQ (sqlite3_step (stmt), SQLITE_ROW);
+  const Asset recovered = Asset::FromColumns (stmt, 0, 1);
+  EXPECT_EQ (recovered, a);
+  CHECK_EQ (sqlite3_step (stmt), SQLITE_DONE);
+}
+
+TEST_F (AssetsTests, IsValidName)
+{
+  EXPECT_TRUE (Asset::IsValidName (""));
+  EXPECT_TRUE (Asset::IsValidName (" foo bar"));
+  EXPECT_TRUE (Asset::IsValidName (u8"äöü"));
+  EXPECT_FALSE (Asset::IsValidName ("foo\n"));
+  EXPECT_FALSE (Asset::IsValidName (std::string ("foo\0", 4)));
+}
+
+TEST_F (AssetsTests, JsonRoundtrip)
+{
+  const std::string tests[] =
+    {
+      R"({"m": "domob", "a": "foo bar"})",
+      u8R"({"m": "äöü", "a": "ß"})",
+      R"({"m": "", "a": ""})",
+    };
+
+  for (const auto& t : tests)
+    {
+      const auto val = ParseJson (t);
+
+      Asset a;
+      ASSERT_TRUE (a.FromJson (val)) << val;
+
+      EXPECT_EQ (a.ToJson (), val);
+    }
+}
+
+TEST_F (AssetsTests, InvalidJson)
+{
+  const std::string tests[] =
+    {
+      "null",
+      "{}",
+      "[]",
+      "\"foo\"",
+      R"({"m": "foo", "a": "bar", "x": 42})",
+      R"({"m": "foo"})",
+      R"({"m": "foo", "a": "bar\nbaz"})",
+      R"({"m": "foo", "a": "bar\u0000baz"})",
+    };
+
+  for (const auto& t : tests)
+    {
+      Asset a;
+      ASSERT_FALSE (a.FromJson (ParseJson (t)));
+    }
+}
+
+} // anonymous namespace
+} // namespace nf

--- a/nonfungible/assets_tests.cpp
+++ b/nonfungible/assets_tests.cpp
@@ -4,6 +4,7 @@
 
 #include "assets.hpp"
 
+#include "dbutils.hpp"
 #include "testutils.hpp"
 
 #include <glog/logging.h>
@@ -65,16 +66,16 @@ TEST_F (AssetsTests, DatabaseRoundtrip)
       VALUES (?1, ?2)
   )");
   a.BindToParams (stmt, 1, 2);
-  CHECK_EQ (sqlite3_step (stmt), SQLITE_DONE);
+  CHECK (!StepStatement (stmt));
 
   stmt = GetDb ().PrepareRo (R"(
     SELECT `minter`, `asset` FROM `assets`
   )");
 
-  CHECK_EQ (sqlite3_step (stmt), SQLITE_ROW);
+  CHECK (StepStatement (stmt));
   const Asset recovered = Asset::FromColumns (stmt, 0, 1);
   EXPECT_EQ (recovered, a);
-  CHECK_EQ (sqlite3_step (stmt), SQLITE_DONE);
+  CHECK (!StepStatement (stmt));
 }
 
 TEST_F (AssetsTests, IsValidName)

--- a/nonfungible/assets_tests.cpp
+++ b/nonfungible/assets_tests.cpp
@@ -34,7 +34,7 @@ TEST_F (AssetsTests, InvalidAmountFromJson)
 {
   Amount a;
   ASSERT_FALSE (AmountFromJson (Json::Value (MAX_AMOUNT + 1), a));
-  for (const std::string str : {"-5", "42.5", "null", "false", "\"10\"",
+  for (const std::string str : {"-5", "42.0", "1e5", "null", "false", "\"10\"",
                                 "[1]", "{\"foo\":\"bar\"}"})
     ASSERT_FALSE (AmountFromJson (ParseJson (str), a)) << str;
 }
@@ -43,11 +43,11 @@ TEST_F (AssetsTests, ValidAmountFromJson)
 {
   Amount a;
 
-  ASSERT_TRUE (AmountFromJson (ParseJson ("42.0"), a));
+  ASSERT_TRUE (AmountFromJson (ParseJson ("42"), a));
   EXPECT_EQ (a, 42);
 
-  ASSERT_TRUE (AmountFromJson (ParseJson ("1.5e1"), a));
-  EXPECT_EQ (a, 15);
+  ASSERT_TRUE (AmountFromJson (ParseJson ("1"), a));
+  EXPECT_EQ (a, 1);
 
   ASSERT_TRUE (AmountFromJson (ParseJson ("-0"), a));
   EXPECT_EQ (a, 0);

--- a/nonfungible/dbutils.cpp
+++ b/nonfungible/dbutils.cpp
@@ -55,4 +55,15 @@ ColumnIsNull (sqlite3_stmt* stmt, const int num)
   return sqlite3_column_type (stmt, num) == SQLITE_NULL;
 }
 
+bool
+StepStatement (sqlite3_stmt* stmt)
+{
+  const int rc = sqlite3_step (stmt);
+  if (rc == SQLITE_DONE)
+    return false;
+
+  CHECK_EQ (rc, SQLITE_ROW);
+  return true;
+}
+
 } // namespace nf

--- a/nonfungible/dbutils.cpp
+++ b/nonfungible/dbutils.cpp
@@ -1,0 +1,58 @@
+// Copyright (C) 2020 The Xaya developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "dbutils.hpp"
+
+#include <glog/logging.h>
+
+namespace nf
+{
+
+template <>
+  void
+  BindParam<std::string> (sqlite3_stmt* stmt, const int num,
+                          const std::string& val)
+{
+  CHECK_EQ (sqlite3_bind_text (stmt, num, &val[0], val.size (),
+                               SQLITE_TRANSIENT),
+            SQLITE_OK);
+}
+
+template <>
+  void
+  BindParam<int64_t> (sqlite3_stmt* stmt, const int num, const int64_t& val)
+{
+  CHECK_EQ (sqlite3_bind_int64 (stmt, num, val), SQLITE_OK);
+}
+
+void
+BindNullParam (sqlite3_stmt* stmt, const int num)
+{
+  CHECK_EQ (sqlite3_bind_null (stmt, num), SQLITE_OK);
+}
+
+template <>
+  std::string
+  ColumnExtract<std::string> (sqlite3_stmt* stmt, const int num)
+{
+  const int len = sqlite3_column_bytes (stmt, num);
+  const unsigned char* str = sqlite3_column_text (stmt, num);
+  CHECK (str != nullptr);
+  return std::string (reinterpret_cast<const char*> (str), len);
+}
+
+template <>
+  int64_t
+  ColumnExtract<int64_t> (sqlite3_stmt* stmt, const int num)
+{
+  return sqlite3_column_int64 (stmt, num);
+}
+
+bool
+ColumnIsNull (sqlite3_stmt* stmt, const int num)
+{
+  return sqlite3_column_type (stmt, num) == SQLITE_NULL;
+}
+
+} // namespace nf

--- a/nonfungible/dbutils.hpp
+++ b/nonfungible/dbutils.hpp
@@ -1,0 +1,40 @@
+// Copyright (C) 2020 The Xaya developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef NONFUNGIBLE_DBUTILS_HPP
+#define NONFUNGIBLE_DBUTILS_HPP
+
+#include <sqlite3.h>
+
+#include <cstdint>
+#include <string>
+
+namespace nf
+{
+
+/**
+ * Binds a value (of string or integer type) to an SQLite parameter.
+ */
+template <typename T>
+  void BindParam (sqlite3_stmt* stmt, int num, const T& val);
+
+/**
+ * Binds a null value to an SQLite parameter.
+ */
+void BindNullParam (sqlite3_stmt* stmt, int num);
+
+/**
+ * Extracts a string or integer value from a result column.
+ */
+template <typename T>
+  T ColumnExtract (sqlite3_stmt* stmt, int num);
+
+/**
+ * Checks if a result column is null.
+ */
+bool ColumnIsNull (sqlite3_stmt* stmt, int num);
+
+} // namespace nf
+
+#endif // NONFUNGIBLE_DBUTILS_HPP

--- a/nonfungible/dbutils.hpp
+++ b/nonfungible/dbutils.hpp
@@ -35,6 +35,12 @@ template <typename T>
  */
 bool ColumnIsNull (sqlite3_stmt* stmt, int num);
 
+/**
+ * Executes / advances the sqlite3_stmt, asserting that no error happened.
+ * Returns true if there are columns to extract, and false if not (SQLITE_DONE).
+ */
+bool StepStatement (sqlite3_stmt* stmt);
+
 } // namespace nf
 
 #endif // NONFUNGIBLE_DBUTILS_HPP

--- a/nonfungible/gametest/Makefile.am
+++ b/nonfungible/gametest/Makefile.am
@@ -1,0 +1,14 @@
+AM_TESTS_ENVIRONMENT = \
+  PYTHONPATH=$(top_srcdir)
+
+TEST_LIBRARY = \
+  nftest.py
+
+REGTESTS = \
+  burn.py \
+  minting.py \
+  reorg.py \
+  transfers.py
+
+EXTRA_DIST = $(REGTESTS) $(TEST_LIBRARY)
+TESTS = $(REGTESTS)

--- a/nonfungible/gametest/burn.py
+++ b/nonfungible/gametest/burn.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2020 The Xaya developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+"""
+Tests burning of coins.
+"""
+
+from nftest import NonFungibleTest
+
+
+class BurnTest (NonFungibleTest):
+
+  def run (self):
+    self.collectPremine ()
+
+    self.sendMove ("domob", [
+      {"m": {"a": "foo", "n": 10}},
+      {"b": {"a": {"m": "domob", "a": "foo"}, "n": 11}},
+      {"b": {"a": {"m": "domob", "a": "foo"}, "n": 9}},
+    ])
+    self.generate (1)
+    self.assertEqual (self.getRpc ("getassetdetails",
+                                   {"m": "domob", "a": "foo"}),
+                      {
+      "asset": {"m": "domob", "a": "foo"},
+      "supply": 1,
+      "data": None,
+      "balances": {"domob": 1},
+    })
+
+    self.sendMove ("domob", [
+      {"b": {"a": {"m": "domob", "a": "foo"}, "n": 1}},
+    ])
+    self.generate (1)
+    self.assertEqual (self.getRpc ("getuserbalances", "domob"), [])
+    self.assertEqual (self.getRpc ("getassetdetails",
+                                   {"m": "domob", "a": "foo"}),
+                      {
+      "asset": {"m": "domob", "a": "foo"},
+      "supply": 0,
+      "data": None,
+      "balances": {},
+    })
+
+
+if __name__ == "__main__":
+  BurnTest ().main ()

--- a/nonfungible/gametest/minting.py
+++ b/nonfungible/gametest/minting.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+# coding=utf8
+
+# Copyright (C) 2020 The Xaya developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+"""
+Tests minting of assets.
+"""
+
+from nftest import NonFungibleTest
+
+
+class MintingTest (NonFungibleTest):
+
+  def run (self):
+    self.collectPremine ()
+    self.assertEqual (self.getRpc ("listassets"), [])
+
+    self.sendMove ("domob", [
+      {"m": {"a": "foo", "n": 10}},
+      {"m": {"a": "invalid\nname", "n": 1}},
+      {"m": {"a": "bar", "n": 0, "d": "custom data"}},
+      {"m": {"a": "bar", "n": 100}},
+    ])
+    self.sendMove ("", {"m": {"a": "", "n": 0}})
+    self.sendMove (u"äöü", {"m": {"a": u"ß", "n": 42}})
+    self.generate (1)
+
+    self.assertEqual (self.getRpc ("listassets"), [
+      {"m": "", "a": ""},
+      {"m": "domob", "a": "bar"},
+      {"m": "domob", "a": "foo"},
+      {"m": u"äöü", "a": u"ß"},
+    ])
+
+    self.assertEqual (self.getRpc ("getbalance",
+                                   name=u"äöü", asset={"m": u"äöü", "a": u"ß"}),
+                      42)
+    self.assertEqual (self.getRpc ("getbalance",
+                                   name="invalid",
+                                   asset={"m": "foo", "a": "bar"}),
+                      0)
+
+    self.assertEqual (self.getRpc ("getassetdetails",
+                                   {"m": "domob", "a": "foo"}),
+                      {
+      "asset": {"m": "domob", "a": "foo"},
+      "supply": 10,
+      "data": None,
+      "balances": {"domob": 10},
+    })
+    self.assertEqual (self.getRpc ("getassetdetails",
+                                   {"m": "domob", "a": "bar"}),
+                      {
+      "asset": {"m": "domob", "a": "bar"},
+      "supply": 0,
+      "data": "custom data",
+      "balances": {},
+    })
+
+    self.assertEqual (self.getRpc ("getuserbalances", "domob"), [
+      {
+        "asset": {"m": "domob", "a": "foo"},
+        "balance": 10,
+      },
+    ])
+
+
+if __name__ == "__main__":
+  MintingTest ().main ()

--- a/nonfungible/gametest/nftest.py
+++ b/nonfungible/gametest/nftest.py
@@ -1,0 +1,28 @@
+# Copyright (C) 2020 The Xaya developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+from xayagametest.testcase import XayaGameTest
+
+import os
+import os.path
+
+
+class NonFungibleTest (XayaGameTest):
+  """
+  An integration test for the non-fungible GSP.
+  """
+
+  def __init__ (self):
+    top_builddir = os.getenv ("top_builddir")
+    if top_builddir is None:
+      top_builddir = "../.."
+    nfd = os.path.join (top_builddir, "nonfungible", "nonfungibled")
+    super ().__init__ ("nf", nfd)
+
+  def getRpc (self, method, *args, **kwargs):
+    """
+    Calls a custom-state RPC method and returns the data field.
+    """
+
+    return self.getCustomState ("data", method, *args, **kwargs)

--- a/nonfungible/gametest/reorg.py
+++ b/nonfungible/gametest/reorg.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2020 The Xaya developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+"""
+Tests behaviour of the GSP with a reorg.
+"""
+
+from nftest import NonFungibleTest
+
+
+class ReorgTest (NonFungibleTest):
+
+  def run (self):
+    self.collectPremine ()
+    sendTo = {}
+    for _ in range (10):
+      sendTo[self.rpc.xaya.getnewaddress ()] = 10
+    self.rpc.xaya.sendmany ("", sendTo)
+    self.generate (1)
+
+    self.sendMove ("domob", [
+      {"m": {"a": "foo", "n": 10}},
+    ])
+    self.generate (10)
+    reorgBlk = self.rpc.xaya.getbestblockhash ()
+
+    # First reality:  Transfer assets and do a new mint.
+    self.sendMove ("domob", [
+      {"t": {"a": {"m": "domob", "a": "foo"}, "n": 7, "r": "andy"}},
+      {"m": {"a": "bar", "n": 100, "d": "data 1"}},
+      {"t": {"a": {"m": "domob", "a": "bar"}, "n": 50, "r": "daniel"}},
+    ])
+    self.generate (50)
+    self.expectGameState ([
+      {
+        "asset": {"m": "domob", "a": "bar"},
+        "supply": 100,
+        "data": "data 1",
+        "balances": {"domob": 50, "daniel": 50},
+      },
+      {
+        "asset": {"m": "domob", "a": "foo"},
+        "supply": 10,
+        "data": None,
+        "balances": {"domob": 3, "andy": 7},
+      },
+    ])
+
+    # Build an alternate reality where we transfer differently (such that
+    # the original transfer is invalid) and also mint the same asset with
+    # lower supply.
+    oldState = self.getGameState ()
+    self.rpc.xaya.invalidateblock (reorgBlk)
+
+    self.sendMove ("domob", [
+      {"t": {"a": {"m": "domob", "a": "foo"}, "n": 6, "r": "daniel"}},
+      {"m": {"a": "bar", "n": 10, "d": "data 2"}},
+    ])
+    self.generate (1)
+    self.expectGameState ([
+      {
+        "asset": {"m": "domob", "a": "bar"},
+        "supply": 10,
+        "data": "data 2",
+        "balances": {"domob": 10},
+      },
+      {
+        "asset": {"m": "domob", "a": "foo"},
+        "supply": 10,
+        "data": None,
+        "balances": {"domob": 4, "daniel": 6},
+      },
+    ])
+
+    self.rpc.xaya.reconsiderblock (reorgBlk)
+    self.expectGameState (oldState)
+
+
+if __name__ == "__main__":
+  ReorgTest ().main ()

--- a/nonfungible/gametest/transfers.py
+++ b/nonfungible/gametest/transfers.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2020 The Xaya developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+"""
+Tests coin transfers.
+"""
+
+from nftest import NonFungibleTest
+
+
+class TransfersTest (NonFungibleTest):
+
+  def run (self):
+    self.collectPremine ()
+
+    self.sendMove ("domob", [
+      {"m": {"a": "foo", "n": 10}},
+      {"m": {"a": "bar", "n": 10}},
+      {"t": {"a": {"m": "domob", "a": "foo"}, "n": 5, "r": "andy"}},
+    ])
+    self.sendMove ("andy", [
+      {"t": {"a": {"m": "domob", "a": "foo"}, "n": 10, "r": "wrong"}},
+      {"t": {"a": {"m": "domob", "a": "foo"}, "n": 3, "r": "andy"}},
+      {"t": {"a": {"m": "domob", "a": "foo"}, "n": 3, "r": "daniel"}},
+    ])
+    self.generate (1)
+
+    self.assertEqual (self.getRpc ("getassetdetails",
+                                   {"m": "domob", "a": "foo"}),
+                      {
+      "asset": {"m": "domob", "a": "foo"},
+      "supply": 10,
+      "data": None,
+      "balances": {"domob": 5, "andy": 2, "daniel": 3},
+    })
+
+
+if __name__ == "__main__":
+  TransfersTest ().main ()

--- a/nonfungible/logic.cpp
+++ b/nonfungible/logic.cpp
@@ -4,6 +4,8 @@
 
 #include "logic.hpp"
 
+#include "schema.hpp"
+
 #include <glog/logging.h>
 
 namespace nf
@@ -12,7 +14,7 @@ namespace nf
 void
 NonFungibleLogic::SetupSchema (xaya::SQLiteDatabase& db)
 {
-  LOG (WARNING) << "No database schema";
+  SetupDatabaseSchema (*db);
 }
 
 void

--- a/nonfungible/logic.cpp
+++ b/nonfungible/logic.cpp
@@ -1,0 +1,69 @@
+// Copyright (C) 2020 The Xaya developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "logic.hpp"
+
+#include <glog/logging.h>
+
+namespace nf
+{
+
+void
+NonFungibleLogic::SetupSchema (xaya::SQLiteDatabase& db)
+{
+  LOG (WARNING) << "No database schema";
+}
+
+void
+NonFungibleLogic::GetInitialStateBlock (unsigned& height,
+                                        std::string& hashHex) const
+{
+  const xaya::Chain chain = GetChain ();
+  switch (chain)
+    {
+    case xaya::Chain::MAIN:
+      height = 2'199'000;
+      hashHex
+          = "321ee13b84b0e5b9f07d43bcd3924c2a03006b043f687044807c4d66b4ac217f";
+      break;
+
+    case xaya::Chain::TEST:
+      height = 112'300;
+      hashHex
+          = "700f14e07b5d2a8d6836195d8a5f7ecd0aa4bf99d88631e99d29fd8ebb01a63f";
+      break;
+
+    case xaya::Chain::REGTEST:
+      height = 0;
+      hashHex
+          = "6f750b36d22f1dc3d0a6e483af45301022646dfc3b3ba2187865f5a7d6d83ab1";
+      break;
+
+    default:
+      LOG (FATAL) << "Invalid chain value: " << static_cast<int> (chain);
+    }
+}
+
+void
+NonFungibleLogic::InitialiseState (xaya::SQLiteDatabase& db)
+{
+  /* The initial state is simply an empty database with no assets or
+     balances yet.  */
+}
+
+void
+NonFungibleLogic::UpdateState (xaya::SQLiteDatabase& db,
+                               const Json::Value& blockData)
+{
+  LOG (WARNING) << "Implement state update";
+}
+
+Json::Value
+NonFungibleLogic::GetStateAsJson (const xaya::SQLiteDatabase& db)
+{
+  LOG (WARNING) << "Implement state JSON";
+  return Json::Value ();
+}
+
+} // namespace nf

--- a/nonfungible/logic.cpp
+++ b/nonfungible/logic.cpp
@@ -6,6 +6,7 @@
 
 #include "moveprocessor.hpp"
 #include "schema.hpp"
+#include "statejson.hpp"
 
 #include <glog/logging.h>
 
@@ -66,8 +67,7 @@ NonFungibleLogic::UpdateState (xaya::SQLiteDatabase& db,
 Json::Value
 NonFungibleLogic::GetStateAsJson (const xaya::SQLiteDatabase& db)
 {
-  LOG (WARNING) << "Implement state JSON";
-  return Json::Value ();
+  return StateJsonExtractor (db).FullState ();
 }
 
 } // namespace nf

--- a/nonfungible/logic.cpp
+++ b/nonfungible/logic.cpp
@@ -4,6 +4,7 @@
 
 #include "logic.hpp"
 
+#include "moveprocessor.hpp"
 #include "schema.hpp"
 
 #include <glog/logging.h>
@@ -58,7 +59,8 @@ void
 NonFungibleLogic::UpdateState (xaya::SQLiteDatabase& db,
                                const Json::Value& blockData)
 {
-  LOG (WARNING) << "Implement state update";
+  MoveProcessor proc(db);
+  proc.ProcessAll (blockData["moves"]);
 }
 
 Json::Value

--- a/nonfungible/logic.cpp
+++ b/nonfungible/logic.cpp
@@ -6,7 +6,6 @@
 
 #include "moveprocessor.hpp"
 #include "schema.hpp"
-#include "statejson.hpp"
 
 #include <glog/logging.h>
 
@@ -68,6 +67,17 @@ Json::Value
 NonFungibleLogic::GetStateAsJson (const xaya::SQLiteDatabase& db)
 {
   return StateJsonExtractor (db).FullState ();
+}
+
+Json::Value
+NonFungibleLogic::GetCustomStateData (xaya::Game& game, const StateCallback& cb)
+{
+  return SQLiteGame::GetCustomStateData (game, "data",
+      [this, &cb] (const xaya::SQLiteDatabase& db)
+        {
+          const StateJsonExtractor ext(db);
+          return cb(ext);
+        });
 }
 
 } // namespace nf

--- a/nonfungible/logic.hpp
+++ b/nonfungible/logic.hpp
@@ -5,11 +5,14 @@
 #ifndef NONFUNGIBLE_LOGIC_HPP
 #define NONFUNGIBLE_LOGIC_HPP
 
+#include "statejson.hpp"
+
 #include <xayagame/sqlitegame.hpp>
 #include <xayagame/sqlitestorage.hpp>
 
 #include <json/json.h>
 
+#include <functional>
 #include <string>
 
 namespace nf
@@ -36,10 +39,24 @@ protected:
 
 public:
 
+  /**
+   * Type for a callback that extracts custom JSON from the game state
+   * (through a StateJsonExtractor instance).
+   */
+  using StateCallback
+      = std::function<Json::Value (const StateJsonExtractor& ext)>;
+
   NonFungibleLogic () = default;
 
   NonFungibleLogic (const NonFungibleLogic&) = delete;
   void operator= (const NonFungibleLogic&) = delete;
+
+  /**
+   * Extracts some custom JSON from the current game-state database, using
+   * the provided extractor callback, which can then operate through a
+   * StateJsonExtractor instance.
+   */
+  Json::Value GetCustomStateData (xaya::Game& game, const StateCallback& cb);
 
 };
 

--- a/nonfungible/logic.hpp
+++ b/nonfungible/logic.hpp
@@ -1,0 +1,48 @@
+// Copyright (C) 2020 The Xaya developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef NONFUNGIBLE_LOGIC_HPP
+#define NONFUNGIBLE_LOGIC_HPP
+
+#include <xayagame/sqlitegame.hpp>
+#include <xayagame/sqlitestorage.hpp>
+
+#include <json/json.h>
+
+#include <string>
+
+namespace nf
+{
+
+/**
+ * The game logic implementation for the non-fungible game-state processor.
+ */
+class NonFungibleLogic : public xaya::SQLiteGame
+{
+
+protected:
+
+  void SetupSchema (xaya::SQLiteDatabase& db) override;
+
+  void GetInitialStateBlock (unsigned& height,
+                             std::string& hashHex) const override;
+  void InitialiseState (xaya::SQLiteDatabase& db) override;
+
+  void UpdateState (xaya::SQLiteDatabase& db,
+                    const Json::Value& blockData) override;
+
+  Json::Value GetStateAsJson (const xaya::SQLiteDatabase& db) override;
+
+public:
+
+  NonFungibleLogic () = default;
+
+  NonFungibleLogic (const NonFungibleLogic&) = delete;
+  void operator= (const NonFungibleLogic&) = delete;
+
+};
+
+} // namespace nf
+
+#endif // NONFUNGIBLE_LOGIC_HPP

--- a/nonfungible/main.cpp
+++ b/nonfungible/main.cpp
@@ -1,0 +1,75 @@
+// Copyright (C) 2020 The Xaya developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "config.h"
+
+#include "logic.hpp"
+
+#include "xayagame/defaultmain.hpp"
+
+#include <gflags/gflags.h>
+#include <glog/logging.h>
+
+#include <cstdlib>
+#include <iostream>
+
+namespace
+{
+
+DEFINE_string (xaya_rpc_url, "",
+               "URL at which Xaya Core's JSON-RPC interface is available");
+DEFINE_bool (xaya_rpc_wait, false,
+             "whether to wait on startup for Xaya Core to be available");
+
+DEFINE_int32 (game_rpc_port, 0,
+              "the port at which the GSP JSON-RPC server will be started"
+              " (if non-zero)");
+DEFINE_bool (game_rpc_listen_locally, true,
+             "whether the GSP's JSON-RPC server should listen locally");
+
+DEFINE_int32 (enable_pruning, -1,
+              "if non-negative (including zero), old undo data will be pruned"
+              " and only as many blocks as specified will be kept");
+
+DEFINE_string (datadir, "",
+               "base data directory for state data"
+               " (will be extended by 'nf' and the chain)");
+
+} // anonymous namespace
+
+int
+main (int argc, char** argv)
+{
+  google::InitGoogleLogging (argv[0]);
+
+  gflags::SetUsageMessage ("Run nonfungible GSP");
+  gflags::SetVersionString (PACKAGE_VERSION);
+  gflags::ParseCommandLineFlags (&argc, &argv, true);
+
+  if (FLAGS_xaya_rpc_url.empty ())
+    {
+      std::cerr << "Error: --xaya_rpc_url must be set" << std::endl;
+      return EXIT_FAILURE;
+    }
+  if (FLAGS_datadir.empty ())
+    {
+      std::cerr << "Error: --datadir must be specified" << std::endl;
+      return EXIT_FAILURE;
+    }
+
+  xaya::GameDaemonConfiguration config;
+  config.XayaRpcUrl = FLAGS_xaya_rpc_url;
+  config.XayaRpcWait = FLAGS_xaya_rpc_wait;
+  if (FLAGS_game_rpc_port != 0)
+    {
+      config.GameRpcServer = xaya::RpcServerType::HTTP;
+      config.GameRpcPort = FLAGS_game_rpc_port;
+      config.GameRpcListenLocally = FLAGS_game_rpc_listen_locally;
+    }
+  config.EnablePruning = FLAGS_enable_pruning;
+  config.DataDirectory = FLAGS_datadir;
+
+  nf::NonFungibleLogic rules;
+  return xaya::SQLiteMain (config, "nf", rules);
+}

--- a/nonfungible/main.cpp
+++ b/nonfungible/main.cpp
@@ -5,6 +5,7 @@
 #include "config.h"
 
 #include "logic.hpp"
+#include "pending.hpp"
 
 #include "xayagame/defaultmain.hpp"
 
@@ -35,6 +36,9 @@ DEFINE_int32 (enable_pruning, -1,
 DEFINE_string (datadir, "",
                "base data directory for state data"
                " (will be extended by 'nf' and the chain)");
+
+DEFINE_bool (pending_moves, true,
+             "whether or not pending moves should be tracked");
 
 } // anonymous namespace
 
@@ -71,5 +75,9 @@ main (int argc, char** argv)
   config.DataDirectory = FLAGS_datadir;
 
   nf::NonFungibleLogic rules;
+  nf::PendingMoves pending(rules);
+  if (FLAGS_pending_moves)
+    config.PendingMoves = &pending;
+
   return xaya::SQLiteMain (config, "nf", rules);
 }

--- a/nonfungible/moveparser.cpp
+++ b/nonfungible/moveparser.cpp
@@ -6,8 +6,6 @@
 
 #include "dbutils.hpp"
 
-#include <sqlite3.h>
-
 #include <glog/logging.h>
 
 namespace nf
@@ -23,9 +21,9 @@ MoveParser::AssetExists (const Asset& a) const
   )");
   a.BindToParams (stmt, 1, 2);
 
-  CHECK_EQ (sqlite3_step (stmt), SQLITE_ROW);
+  CHECK (StepStatement (stmt));
   const auto count = ColumnExtract<int64_t> (stmt, 0);
-  CHECK_EQ (sqlite3_step (stmt), SQLITE_DONE);
+  CHECK (!StepStatement (stmt));
 
   CHECK_GE (count, 0);
   CHECK_LE (count, 1);
@@ -44,13 +42,11 @@ MoveParser::GetBalance (const Asset& a, const std::string& name) const
   BindParam (stmt, 1, name);
   a.BindToParams (stmt, 2, 3);
 
-  const int rc = sqlite3_step (stmt);
-  if (rc == SQLITE_DONE)
+  if (!StepStatement (stmt))
     return 0;
 
-  CHECK_EQ (rc, SQLITE_ROW);
   const Amount res = ColumnExtract<int64_t> (stmt, 0);
-  CHECK_EQ (sqlite3_step (stmt), SQLITE_DONE);
+  CHECK (!StepStatement (stmt));
 
   return res;
 }

--- a/nonfungible/moveparser.cpp
+++ b/nonfungible/moveparser.cpp
@@ -1,0 +1,240 @@
+// Copyright (C) 2020 The Xaya developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "moveparser.hpp"
+
+#include "dbutils.hpp"
+
+#include <sqlite3.h>
+
+#include <glog/logging.h>
+
+namespace nf
+{
+
+bool
+MoveParser::AssetExists (const Asset& a) const
+{
+  auto* stmt = db.PrepareRo (R"(
+    SELECT COUNT(*)
+      FROM `assets`
+      WHERE `minter` = ?1 AND `asset` = ?2
+  )");
+  a.BindToParams (stmt, 1, 2);
+
+  CHECK_EQ (sqlite3_step (stmt), SQLITE_ROW);
+  const auto count = ColumnExtract<int64_t> (stmt, 0);
+  CHECK_EQ (sqlite3_step (stmt), SQLITE_DONE);
+
+  CHECK_GE (count, 0);
+  CHECK_LE (count, 1);
+
+  return count > 0;
+}
+
+Amount
+MoveParser::GetBalance (const Asset& a, const std::string& name) const
+{
+  auto* stmt = db.PrepareRo (R"(
+    SELECT `balance`
+      FROM `balances`
+      WHERE `name` = ?1 AND `minter` = ?2 AND `asset` = ?3
+  )");
+  BindParam (stmt, 1, name);
+  a.BindToParams (stmt, 2, 3);
+
+  const int rc = sqlite3_step (stmt);
+  if (rc == SQLITE_DONE)
+    return 0;
+
+  CHECK_EQ (rc, SQLITE_ROW);
+  const Amount res = ColumnExtract<int64_t> (stmt, 0);
+  CHECK_EQ (sqlite3_step (stmt), SQLITE_DONE);
+
+  return res;
+}
+
+void
+MoveParser::HandleOperation (const std::string& name, const Json::Value& mv)
+{
+  CHECK (mv.isObject ());
+  if (mv.size () != 1)
+    {
+      LOG (WARNING) << "Invalid operation: " << mv;
+      return;
+    }
+
+  if (mv.isMember ("m"))
+    HandleMint (name, mv["m"]);
+  else if (mv.isMember ("t"))
+    HandleTransfer (name, mv["t"]);
+  else if (mv.isMember ("b"))
+    HandleBurn (name, mv["b"]);
+  else
+    LOG (WARNING) << "Invalid operation: " << mv;
+}
+
+void
+MoveParser::HandleMint (const std::string& name, const Json::Value& op)
+{
+  if (!op.isObject ())
+    {
+      LOG (WARNING) << "Invalid mint operation: " << op;
+      return;
+    }
+
+  const bool hasData = op.isMember ("d");
+  if ((hasData && op.size () != 3) || (!hasData && op.size () != 2))
+    {
+      LOG (WARNING) << "Invalid mint operation: " << op;
+      return;
+    }
+
+  const auto& assetNameVal = op["a"];
+  if (!assetNameVal.isString ())
+    {
+      LOG (WARNING) << "Invalid asset in mint: " << op;
+      return;
+    }
+  const std::string assetName = assetNameVal.asString ();
+  if (!Asset::IsValidName (assetName))
+    {
+      LOG (WARNING) << "Invalid asset in mint: " << op;
+      return;
+    }
+  const Asset a(name, assetName);
+
+  Amount supply;
+  if (!AmountFromJson (op["n"], supply))
+    {
+      LOG (WARNING) << "Invalid supply in mint: " << op;
+      return;
+    }
+
+  std::string data;
+  if (hasData)
+    {
+      const auto& dataVal = op["d"];
+      if (!dataVal.isString ())
+        {
+          LOG (WARNING) << "Invalid data in mint: " << op;
+          return;
+        }
+      data = dataVal.asString ();
+    }
+
+  if (AssetExists (a))
+    {
+      LOG (WARNING) << "Mint of already existing asset " << a << ": " << op;
+      return;
+    }
+
+  ProcessMint (a, supply, hasData ? &data : nullptr);
+}
+
+void
+MoveParser::HandleTransfer (const std::string& name, const Json::Value& op)
+{
+  if (!op.isObject () || op.size () != 3)
+    {
+      LOG (WARNING) << "Invalid transfer operation: " << op;
+      return;
+    }
+
+  Asset a;
+  if (!a.FromJson (op["a"]))
+    {
+      LOG (WARNING) << "Invalid asset in transfer: " << op;
+      return;
+    }
+
+  Amount n;
+  if (!AmountFromJson (op["n"], n) || n <= 0)
+    {
+      LOG (WARNING) << "Invalid amount in transfer: " << op;
+      return;
+    }
+
+  const auto& recvVal = op["r"];
+  if (!recvVal.isString ())
+    {
+      LOG (WARNING) << "Invalid recipient in transfer: " << op;
+      return;
+    }
+
+  const Amount balance = GetBalance (a, name);
+  if (n > balance)
+    {
+      LOG (WARNING)
+          << "User " << name << " only owns " << balance << " of " << a
+          << ", can't transfer " << n;
+      return;
+    }
+
+  ProcessTransfer (a, n, name, recvVal.asString ());
+}
+
+void
+MoveParser::HandleBurn (const std::string& name, const Json::Value& op)
+{
+  if (!op.isObject () || op.size () != 2)
+    {
+      LOG (WARNING) << "Invalid burn operation: " << op;
+      return;
+    }
+
+  Asset a;
+  if (!a.FromJson (op["a"]))
+    {
+      LOG (WARNING) << "Invalid asset in burn: " << op;
+      return;
+    }
+
+  Amount n;
+  if (!AmountFromJson (op["n"], n) || n <= 0)
+    {
+      LOG (WARNING) << "Invalid amount in burn: " << op;
+      return;
+    }
+
+  const Amount balance = GetBalance (a, name);
+  if (n > balance)
+    {
+      LOG (WARNING)
+          << "User " << name << " only owns " << balance << " of " << a
+          << ", can't burn " << n;
+      return;
+    }
+
+  ProcessBurn (a, n, name);
+}
+
+void
+MoveParser::ProcessOne (const Json::Value& obj)
+{
+  CHECK (obj.isObject ());
+
+  const auto& nameVal = obj["name"];
+  CHECK (nameVal.isString ());
+  const std::string name = nameVal.asString ();
+
+  const auto& mv = obj["move"];
+
+  if (mv.isObject ())
+    HandleOperation (name, mv);
+  else if (mv.isArray ())
+    {
+      for (const auto& op : mv)
+        {
+          if (op.isObject ())
+            HandleOperation (name, op);
+          else
+            LOG (WARNING) << "Invalid operation inside array move: " << op;
+        }
+    }
+  else
+    LOG (WARNING) << "Invalid move: " << mv;
+}
+
+} // namespace nf

--- a/nonfungible/moveparser.hpp
+++ b/nonfungible/moveparser.hpp
@@ -17,6 +17,13 @@ namespace nf
 {
 
 /**
+ * Extracts the balance of a given asset and user from the database.
+ * Returns 0 if there is no entry.
+ */
+Amount GetDbBalance (const xaya::SQLiteDatabase& db, const Asset& a,
+                     const std::string& name);
+
+/**
  * Core implementation of parsing and validating moves received either
  * in new blocks or as pending transactions.  The actual processing of them
  * (i.e. updating the game-state database or pending state) is done by

--- a/nonfungible/moveparser.hpp
+++ b/nonfungible/moveparser.hpp
@@ -1,0 +1,115 @@
+// Copyright (C) 2020 The Xaya developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef NONFUNGIBLE_MOVEPARSER_HPP
+#define NONFUNGIBLE_MOVEPARSER_HPP
+
+#include "assets.hpp"
+
+#include <xayagame/sqlitestorage.hpp>
+
+#include <json/json.h>
+
+#include <string>
+
+namespace nf
+{
+
+/**
+ * Core implementation of parsing and validating moves received either
+ * in new blocks or as pending transactions.  The actual processing of them
+ * (i.e. updating the game-state database or pending state) is done by
+ * subclasses.
+ */
+class MoveParser
+{
+
+private:
+
+  /**
+   * Handles an individual operation (i.e. a move that is a JSON object,
+   * or an element of an array move).
+   */
+  void HandleOperation (const std::string& name, const Json::Value& mv);
+
+  /**
+   * Handles a mint operation, i.e. a move's "m" part if any.
+   */
+  void HandleMint (const std::string& name, const Json::Value& op);
+
+  /**
+   * Handles a transfer operation, i.e. a move's "t" part if any.
+   */
+  void HandleTransfer (const std::string& name, const Json::Value& op);
+
+  /**
+   * Handles a burn operation, i.e. a move's "b" part if any.
+   */
+  void HandleBurn (const std::string& name, const Json::Value& op);
+
+protected:
+
+  /**
+   * The database we use.  It is used for reading the current state
+   * when validating moves.
+   */
+  const xaya::SQLiteDatabase& db;
+
+  /**
+   * Called when a valid move to mint an asset has been found.  If there
+   * is custom data specified with it, the data pointer will be non-null.
+   */
+  virtual void ProcessMint (const Asset& a, Amount supply,
+                            const std::string* data) = 0;
+
+  /**
+   * Called when a valid transfer move has been found.
+   */
+  virtual void ProcessTransfer (const Asset& a, Amount num,
+                                const std::string& sender,
+                                const std::string& recipient) = 0;
+
+  /**
+   * Called when a valid burn move has been found.
+   */
+  virtual void ProcessBurn (const Asset& a, Amount num,
+                            const std::string& sender) = 0;
+
+  /**
+   * Determine if an asset of this type exists already.  By default, it
+   * looks up in the database.  Subclasses may extend this function (e.g. to
+   * take pending state into account).
+   */
+  virtual bool AssetExists (const Asset& a) const;
+
+  /**
+   * Get the current balance of some name and asset.  By default, this
+   * checks in the database.  Subclasses may extend this, e.g. to look at
+   * the pending state in addition.
+   */
+  virtual Amount GetBalance (const Asset& a, const std::string& name) const;
+
+public:
+
+  explicit MoveParser (const xaya::SQLiteDatabase& d)
+    : db(d)
+  {}
+
+  virtual ~MoveParser () = default;
+
+  MoveParser () = delete;
+  MoveParser (const MoveParser&) = delete;
+  void operator= (const MoveParser&) = delete;
+
+  /**
+   * Processes a single move given as JSON object as per the ZMQ
+   * interface (i.e. containing both the name and actual move).
+   */
+  void ProcessOne (const Json::Value& obj);
+
+};
+
+} // namespace nf
+
+#endif // NONFUNGIBLE_MOVEPARSER_HPP

--- a/nonfungible/moveprocessor.cpp
+++ b/nonfungible/moveprocessor.cpp
@@ -1,0 +1,108 @@
+// Copyright (C) 2020 The Xaya developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "moveprocessor.hpp"
+
+#include "dbutils.hpp"
+
+#include <glog/logging.h>
+
+namespace nf
+{
+
+xaya::SQLiteDatabase&
+MoveProcessor::MutableDb ()
+{
+  /* The constructor of MoveProcessor expects a mutable database, which is
+     then just stored in a const& in MoveParser.  Thus it is fine to
+     const-cast it back to be mutable here.  */
+  return const_cast<xaya::SQLiteDatabase&> (db);
+}
+
+void
+MoveProcessor::UpdateBalance (const Asset& a, const std::string& name,
+                              const Amount num)
+{
+  const Amount oldBalance = GetBalance (a, name);
+  const Amount newBalance = oldBalance + num;
+  CHECK_GE (newBalance, 0);
+  CHECK_LE (newBalance, MAX_AMOUNT);
+
+  if (newBalance == 0)
+    {
+      auto* stmt = MutableDb ().Prepare (R"(
+        DELETE FROM `balances`
+          WHERE `name` = ?1 AND `minter` = ?2 AND `asset` = ?3
+      )");
+      BindParam (stmt, 1, name);
+      a.BindToParams (stmt, 2, 3);
+      CHECK_EQ (sqlite3_step (stmt), SQLITE_DONE);
+    }
+  else
+    {
+      auto* stmt = MutableDb ().Prepare (R"(
+        INSERT OR REPLACE INTO `balances`
+            (`name`, `minter`, `asset`, `balance`)
+            VALUES (?1, ?2, ?3, ?4)
+      )");
+      BindParam (stmt, 1, name);
+      a.BindToParams (stmt, 2, 3);
+      BindParam (stmt, 4, newBalance);
+      CHECK_EQ (sqlite3_step (stmt), SQLITE_DONE);
+    }
+}
+
+void
+MoveProcessor::ProcessMint (const Asset& a, const Amount supply,
+                            const std::string* data)
+{
+  auto* stmt = MutableDb ().Prepare (R"(
+    INSERT INTO `assets`
+      (`minter`, `asset`, `data`)
+      VALUES (?1, ?2, ?3)
+  )");
+  a.BindToParams (stmt, 1, 2);
+  if (data != nullptr)
+    BindParam (stmt, 3, *data);
+  else
+    BindNullParam (stmt, 3);
+  CHECK_EQ (sqlite3_step (stmt), SQLITE_DONE);
+
+  if (supply > 0)
+    UpdateBalance (a, a.GetMinter (), supply);
+
+  LOG (INFO) << "Minted " << supply << " of new asset " << a;
+}
+
+void
+MoveProcessor::ProcessTransfer (const Asset& a, const Amount num,
+                                const std::string& sender,
+                                const std::string& recipient)
+{
+  UpdateBalance (a, sender, -num);
+  UpdateBalance (a, recipient, num);
+  LOG (INFO)
+      << "Sent " << num << " of " << a
+      << " from " << sender << " to " << recipient;
+}
+
+void
+MoveProcessor::ProcessBurn (const Asset& a, const Amount num,
+                            const std::string& sender)
+{
+  UpdateBalance (a, sender, -num);
+  LOG (INFO) << sender << " burnt " << num << " of " << a;
+}
+
+void
+MoveProcessor::ProcessAll (const Json::Value& moves)
+{
+  CHECK (moves.isArray ());
+  LOG_IF (INFO, !moves.empty ())
+      << "Processing " << moves.size () << " moves...";
+  for (const auto& mv : moves)
+    ProcessOne (mv);
+}
+
+} // namespace nf

--- a/nonfungible/moveprocessor.cpp
+++ b/nonfungible/moveprocessor.cpp
@@ -37,7 +37,7 @@ MoveProcessor::UpdateBalance (const Asset& a, const std::string& name,
       )");
       BindParam (stmt, 1, name);
       a.BindToParams (stmt, 2, 3);
-      CHECK_EQ (sqlite3_step (stmt), SQLITE_DONE);
+      CHECK (!StepStatement (stmt));
     }
   else
     {
@@ -49,7 +49,7 @@ MoveProcessor::UpdateBalance (const Asset& a, const std::string& name,
       BindParam (stmt, 1, name);
       a.BindToParams (stmt, 2, 3);
       BindParam (stmt, 4, newBalance);
-      CHECK_EQ (sqlite3_step (stmt), SQLITE_DONE);
+      CHECK (!StepStatement (stmt));
     }
 }
 
@@ -67,7 +67,7 @@ MoveProcessor::ProcessMint (const Asset& a, const Amount supply,
     BindParam (stmt, 3, *data);
   else
     BindNullParam (stmt, 3);
-  CHECK_EQ (sqlite3_step (stmt), SQLITE_DONE);
+  CHECK (!StepStatement (stmt));
 
   if (supply > 0)
     UpdateBalance (a, a.GetMinter (), supply);

--- a/nonfungible/moveprocessor.hpp
+++ b/nonfungible/moveprocessor.hpp
@@ -1,0 +1,71 @@
+// Copyright (C) 2020 The Xaya developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef NONFUNGIBLE_MOVEPROCESSOR_HPP
+#define NONFUNGIBLE_MOVEPROCESSOR_HPP
+
+#include "assets.hpp"
+#include "moveparser.hpp"
+
+#include <xayagame/sqlitestorage.hpp>
+
+#include <json/json.h>
+
+#include <string>
+
+namespace nf
+{
+
+/**
+ * Processor for moves in confirmed blocks, i.e. which will be reflected
+ * in an update to the game-state database.
+ */
+class MoveProcessor : private MoveParser
+{
+
+private:
+
+  /**
+   * Updates the balance of the given user with the given delta.
+   */
+  void UpdateBalance (const Asset& a, const std::string& name, Amount num);
+
+protected:
+
+  /**
+   * Returns the underlying database instance as mutable.
+   */
+  xaya::SQLiteDatabase& MutableDb ();
+
+  void ProcessMint (const Asset& a, Amount supply,
+                    const std::string* data) override;
+
+  void ProcessTransfer (const Asset& a, Amount num,
+                        const std::string& sender,
+                        const std::string& recipient) override;
+
+  void ProcessBurn (const Asset& a, Amount num,
+                    const std::string& sender) override;
+
+public:
+
+  explicit MoveProcessor (xaya::SQLiteDatabase& d)
+    : MoveParser(d)
+  {}
+
+  MoveProcessor () = delete;
+  MoveProcessor (const MoveProcessor&) = delete;
+  void operator= (const MoveProcessor&) = delete;
+
+  /**
+   * Processes all moves from a given block (given as the block's
+   * "moves" JSON array).
+   */
+  void ProcessAll (const Json::Value& moves);
+
+};
+
+} // namespace nf
+
+#endif // NONFUNGIBLE_MOVEPROCESSOR_HPP

--- a/nonfungible/moveprocessor_tests.cpp
+++ b/nonfungible/moveprocessor_tests.cpp
@@ -1,0 +1,392 @@
+// Copyright (C) 2020 The Xaya developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "moveprocessor.hpp"
+
+#include "dbutils.hpp"
+#include "testutils.hpp"
+
+#include <glog/logging.h>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <map>
+
+namespace nf
+{
+namespace
+{
+
+/* ************************************************************************** */
+
+/**
+ * Type for a list of expected assets in the database.  The values are
+ * the custom data strings.  The magic value "null" means that they
+ * are null.
+ */
+using AllAssets = std::map<Asset, std::string>;
+
+/**
+ * Expects that the set of assets in the database matches exactly
+ * the given expected set.
+ */
+void
+ExpectAssets (const xaya::SQLiteDatabase& db, const AllAssets& expected)
+{
+  auto* stmt = db.PrepareRo (R"(
+    SELECT `minter`, `asset`, `data`
+      FROM `assets`
+  )");
+
+  AllAssets actual;
+  while (true)
+    {
+      const int rc = sqlite3_step (stmt);
+      if (rc == SQLITE_DONE)
+        break;
+      CHECK_EQ (rc, SQLITE_ROW);
+
+      const auto a = Asset::FromColumns (stmt, 0, 1);
+      std::string data;
+      if (ColumnIsNull (stmt, 2))
+        data = "null";
+      else
+        data = ColumnExtract<std::string> (stmt, 2);
+
+      const auto ins = actual.emplace (a, data);
+      CHECK (ins.second) << "Already had entry for " << a;
+    }
+
+  ASSERT_EQ (actual, expected);
+}
+
+/**
+ * Type for a list of expected balances in the database.  The first map
+ * is keyed by account names, the second by assets.
+ */
+using AllBalances = std::map<std::string, std::map<Asset, Amount>>;
+
+/**
+ * Expects that the set of balances in the database matches exactly
+ * the given expected set.
+ */
+void
+ExpectBalances (const xaya::SQLiteDatabase& db, const AllBalances& expected)
+{
+  auto* stmt = db.PrepareRo (R"(
+    SELECT `name`, `minter`, `asset`, `balance`
+      FROM `balances`
+  )");
+
+  AllBalances actual;
+  while (true)
+    {
+      const int rc = sqlite3_step (stmt);
+      if (rc == SQLITE_DONE)
+        break;
+      CHECK_EQ (rc, SQLITE_ROW);
+
+      const auto name = ColumnExtract<std::string> (stmt, 0);
+      const auto a = Asset::FromColumns (stmt, 1, 2);
+      const auto num = ColumnExtract<int64_t> (stmt, 3);
+
+      auto& nameEntry = actual[name];
+      const auto ins = nameEntry.emplace (a, num);
+      CHECK (ins.second) << "Already had entry for " << name << " and " << a;
+    }
+
+  ASSERT_EQ (actual, expected);
+}
+
+class MoveProcessorTests : public DBTest
+{
+
+protected:
+
+  /**
+   * Processes a move given as JSON string for the given name.
+   */
+  void
+  Process (const std::string& name, const std::string& str)
+  {
+    Json::Value mv(Json::objectValue);
+    mv["name"] = name;
+    mv["move"] = ParseJson (str);
+
+    Json::Value moves(Json::arrayValue);
+    moves.append (mv);
+
+    MoveProcessor proc(GetDb ());
+    proc.ProcessAll (moves);
+  }
+
+};
+
+/* ************************************************************************** */
+
+TEST_F (MoveProcessorTests, ValidMint)
+{
+  Process ("domob", R"([
+    {"m": {"a": "foo", "n": 20}},
+    {"m": {"a": "äöü", "n": 1, "d": ""}}
+  ])");
+  Process ("andy", R"(
+    {"m": {"a": "foo", "n": 0, "d": "custom\u0000data"}}
+  )");
+  Process ("", R"(
+    {"m": {"a": "", "n": 10}}
+  )");
+
+  ExpectAssets (GetDb (), {
+    {Asset ("domob", "foo"), "null"},
+    {Asset ("domob", u8"äöü"), ""},
+    {Asset ("andy", "foo"), std::string ("custom\0data", 11)},
+    {Asset ("", ""), "null"},
+  });
+  ExpectBalances (GetDb (), {
+    {"domob", {{Asset ("domob", "foo"), 20}, {Asset ("domob", u8"äöü"), 1}}},
+    {"", {{Asset ("", ""), 10}}},
+  });
+}
+
+TEST_F (MoveProcessorTests, InvalidMintFormat)
+{
+  Process ("domob", R"([
+    {"m": "foo"},
+    {"m": {"n": 20}},
+    {"m": {"n": 20, "x": 10}},
+    {"m": {"a": 42, "n": 20}},
+    {"m": {"a": "foo"}},
+    {"m": {"a": "foo", "x": 10}},
+    {"m": {"a": "foo\nbar", "n": 20}},
+    {"m": {"a": "foo\nbar", "n": "20"}},
+    {"m": {"a": "foo", "n": "20"}},
+    {"m": {"a": "foo", "n": -20}},
+    {"m": {"a": "foo", "n": 20, "x": 10}},
+    {"m": {"a": "foo", "n": 20, "d": "data", "x": 10}},
+    {"m": {"a": "foo", "n": 20, "d": ["foo"]}}
+  ])");
+
+  ExpectAssets (GetDb (), {});
+  ExpectBalances (GetDb (), {});
+}
+
+TEST_F (MoveProcessorTests, InvalidMintExistingAsset)
+{
+  InsertAsset (Asset ("domob", "foo"), "null");
+  Process ("domob", R"(
+    {"m": {"a": "foo", "n": 20}}
+  )");
+
+  ExpectAssets (GetDb (), {
+    {{Asset ("domob", "foo"), "null"}},
+  });
+  ExpectBalances (GetDb (), {});
+}
+
+TEST_F (MoveProcessorTests, MintSupply)
+{
+  Process ("domob", R"([
+    {"m": {"a": "zero", "n": 0}},
+    {"m": {"a": "max",        "n": 1152921504606846976}},
+    {"m": {"a": "toomuch",    "n": 1152921504606846977}},
+    {"m": {"a": "superlarge", "n": 9999999999999999999999999999999999}}
+  ])");
+
+  ExpectAssets (GetDb (), {
+    {Asset ("domob", "zero"), "null"},
+    {Asset ("domob", "max"), "null"},
+  });
+  ExpectBalances (GetDb (), {
+    {"domob", {{Asset ("domob", "max"), MAX_AMOUNT}}},
+  });
+}
+
+/* ************************************************************************** */
+
+TEST_F (MoveProcessorTests, ValidTransfer)
+{
+  InsertAsset (Asset ("domob", "foo"), "null");
+  InsertAsset (Asset ("domob", "bar"), "null");
+  InsertBalance (Asset ("domob", "foo"), "domob", 10);
+  InsertBalance (Asset ("domob", "foo"), "andy", 10);
+  InsertBalance (Asset ("domob", "bar"), "domob", 20);
+
+  Process ("domob", R"([
+    {"t": {"a": {"m": "domob", "a": "foo"}, "n": 5, "r": "andy"}},
+    {"t": {"a": {"m": "domob", "a": "foo"}, "n": 5, "r": "domob"}},
+    {"t": {"a": {"m": "domob", "a": "bar"}, "n": 10, "r": ""}},
+    {"t": {"a": {"m": "domob", "a": "bar"}, "n": 10, "r": "invalid\nxaya"}}
+  ])");
+
+  ExpectBalances (GetDb (), {
+    {"domob", {{Asset ("domob", "foo"), 5}}},
+    {"andy", {{Asset ("domob", "foo"), 15}}},
+    {"", {{Asset ("domob", "bar"), 10}}},
+    {"invalid\nxaya", {{Asset ("domob", "bar"), 10}}},
+  });
+}
+
+TEST_F (MoveProcessorTests, InvalidTransferFormat)
+{
+  InsertAsset (Asset ("domob", "foo"), "null");
+  InsertBalance (Asset ("domob", "foo"), "domob", 10);
+
+  Process ("domob", R"([
+    {"t": "foo"},
+    {"t": {"n": 1, "r": "andy"}},
+    {"t": {"a": {"m": "domob", "a": "foo"}, "r": "andy"}},
+    {"t": {"a": {"m": "domob", "a": "foo"}, "n": 1}},
+    {"t": {"a": {"m": "domob", "a": "foo"}, "n": 1, "r": "andy", "x": null}},
+    {"t": {"a": {"m": "domob", "a": "bar"}, "n": 1, "r": "andy"}},
+    {"t": {"a": {"m": "domob"}, "n": 1, "r": "andy"}},
+    {"t": {"a": {"m": "domob", "a": "foo"}, "n": "1", "r": "andy"}},
+    {"t": {"a": {"m": "domob", "a": "foo"}, "n": -1, "r": "andy"}},
+    {"t": {"a": {"m": "domob", "a": "foo"}, "n": 0, "r": "andy"}},
+    {"t": {"a": {"m": "domob", "a": "foo"}, "n": 1, "r": 50}}
+  ])");
+
+  ExpectBalances (GetDb (), {
+    {"domob", {{Asset ("domob", "foo"), 10}}},
+  });
+}
+
+TEST_F (MoveProcessorTests, InvalidTransferTooMuch)
+{
+  InsertAsset (Asset ("domob", "foo"), "null");
+  InsertBalance (Asset ("domob", "foo"), "domob", 10);
+
+  Process ("domob", R"([
+    {"t": {"a": {"m": "domob", "a": "foo"}, "n": 5, "r": "andy"}},
+    {"t": {"a": {"m": "domob", "a": "foo"}, "n": 6, "r": "daniel"}}
+  ])");
+
+  ExpectBalances (GetDb (), {
+    {"domob", {{Asset ("domob", "foo"), 5}}},
+    {"andy", {{Asset ("domob", "foo"), 5}}},
+  });
+}
+
+/* ************************************************************************** */
+
+TEST_F (MoveProcessorTests, ValidBurn)
+{
+  InsertAsset (Asset ("domob", "foo"), "null");
+  InsertBalance (Asset ("domob", "foo"), "domob", 10);
+  InsertBalance (Asset ("domob", "foo"), "andy", 10);
+
+  Process ("domob", R"([
+    {"b": {"a": {"m": "domob", "a": "foo"}, "n": 6}},
+    {"b": {"a": {"m": "domob", "a": "foo"}, "n": 2}}
+  ])");
+  Process ("andy", R"([
+    {"b": {"a": {"m": "domob", "a": "foo"}, "n": 10}}
+  ])");
+
+  ExpectBalances (GetDb (), {
+    {"domob", {{Asset ("domob", "foo"), 2}}},
+  });
+}
+
+TEST_F (MoveProcessorTests, InvalidBurnFormat)
+{
+  InsertAsset (Asset ("domob", "foo"), "null");
+  InsertBalance (Asset ("domob", "foo"), "domob", 10);
+
+  Process ("domob", R"([
+    {"b": "foo"},
+    {"b": {"n": 1}},
+    {"b": {"a": {"m": "domob", "a": "foo"}}},
+    {"b": {"a": "foo", "n": 1}},
+    {"b": {"a": {"m": "domob", "a": "foo"}, "n": 1, "x": "foo"}},
+    {"b": {"a": {"m": "domob", "a": "foo"}, "n": -1}},
+    {"b": {"a": {"m": "domob", "a": "foo"}, "n": "1"}},
+    {"b": {"a": {"m": "domob", "a": "foo"}, "n": 0}}
+  ])");
+
+  ExpectBalances (GetDb (), {
+    {"domob", {{Asset ("domob", "foo"), 10}}},
+  });
+}
+
+TEST_F (MoveProcessorTests, InvalidBurnTooMuch)
+{
+  InsertAsset (Asset ("domob", "foo"), "null");
+  InsertBalance (Asset ("domob", "foo"), "domob", 10);
+
+  Process ("domob", R"([
+    {"b": {"a": {"m": "domob", "a": "foo"}, "n": 5}},
+    {"b": {"a": {"m": "domob", "a": "foo"}, "n": 6}}
+  ])");
+
+  ExpectBalances (GetDb (), {
+    {"domob", {{Asset ("domob", "foo"), 5}}},
+  });
+}
+
+/* ************************************************************************** */
+
+TEST_F (MoveProcessorTests, MoveJsonTypes)
+{
+  InsertAsset (Asset ("domob", "foo"), "null");
+  InsertBalance (Asset ("domob", "foo"), "domob", 10);
+
+  Process ("domob", R"([
+    {"t": {"a": {"m": "domob", "a": "foo"}, "n": 1, "r": "andy"}},
+    {"t": {"a": {"m": "domob", "a": "foo"}, "n": 1, "r": "andy"}}
+  ])");
+  Process ("domob", R"(
+    {"t": {"a": {"m": "domob", "a": "foo"}, "n": 1, "r": "andy"}}
+  )");
+  Process ("domob", "[]");
+  Process ("domob", "null");
+  Process ("domob", "false");
+  Process ("domob", "42");
+  Process ("domob", "\"foo\"");
+
+  ExpectBalances (GetDb (), {
+    {"domob", {{Asset ("domob", "foo"), 7}}},
+    {"andy", {{Asset ("domob", "foo"), 3}}},
+  });
+}
+
+TEST_F (MoveProcessorTests, ProcessedInOrder)
+{
+  Process ("domob", R"([
+    {"m": {"a": "foo", "n": 20}},
+    {"t": {"a": {"m": "domob", "a": "foo"}, "n": 10, "r": "andy"}},
+    {"b": {"a": {"m": "domob", "a": "foo"}, "n": 10}},
+    {"t": {"a": {"m": "domob", "a": "foo"}, "n": 1, "r": "andy"}}
+  ])");
+
+  ExpectAssets (GetDb (), {
+    {Asset ("domob", "foo"), "null"},
+  });
+  ExpectBalances (GetDb (), {
+    {"andy", {{Asset ("domob", "foo"), 10}}},
+  });
+}
+
+TEST_F (MoveProcessorTests, InvalidArrayElementsIgnored)
+{
+  InsertAsset (Asset ("domob", "foo"), "null");
+  InsertBalance (Asset ("domob", "foo"), "domob", 10);
+
+  Process ("domob", R"([
+    {"t": {"a": {"m": "domob", "a": "foo"}, "n": 5, "r": "andy"}},
+    "foo",
+    {"b": {"a": {"m": "domob", "a": "foo"}, "n": 6}},
+    {"t": {"a": {"m": "domob", "a": "foo"}, "n": 1, "r": "andy"}}
+  ])");
+
+  ExpectBalances (GetDb (), {
+    {"domob", {{Asset ("domob", "foo"), 4}}},
+    {"andy", {{Asset ("domob", "foo"), 6}}},
+  });
+}
+
+/* ************************************************************************** */
+
+} // anonymous namespace
+} // namespace nf

--- a/nonfungible/moveprocessor_tests.cpp
+++ b/nonfungible/moveprocessor_tests.cpp
@@ -40,13 +40,8 @@ ExpectAssets (const xaya::SQLiteDatabase& db, const AllAssets& expected)
   )");
 
   AllAssets actual;
-  while (true)
+  while (StepStatement (stmt))
     {
-      const int rc = sqlite3_step (stmt);
-      if (rc == SQLITE_DONE)
-        break;
-      CHECK_EQ (rc, SQLITE_ROW);
-
       const auto a = Asset::FromColumns (stmt, 0, 1);
       std::string data;
       if (ColumnIsNull (stmt, 2))
@@ -80,13 +75,8 @@ ExpectBalances (const xaya::SQLiteDatabase& db, const AllBalances& expected)
   )");
 
   AllBalances actual;
-  while (true)
+  while (StepStatement (stmt))
     {
-      const int rc = sqlite3_step (stmt);
-      if (rc == SQLITE_DONE)
-        break;
-      CHECK_EQ (rc, SQLITE_ROW);
-
       const auto name = ColumnExtract<std::string> (stmt, 0);
       const auto a = Asset::FromColumns (stmt, 1, 2);
       const auto num = ColumnExtract<int64_t> (stmt, 3);

--- a/nonfungible/pending.cpp
+++ b/nonfungible/pending.cpp
@@ -1,0 +1,168 @@
+// Copyright (C) 2020 The Xaya developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "pending.hpp"
+
+#include "logic.hpp"
+
+#include <glog/logging.h>
+
+namespace nf
+{
+
+/* ************************************************************************** */
+
+bool
+PendingState::IsNewAsset (const Asset& a) const
+{
+  return assets.count (a) > 0;
+}
+
+void
+PendingState::AddAsset (const Asset& a, const std::string* data)
+{
+  std::unique_ptr<std::string> dataCopy;
+  if (data != nullptr)
+    dataCopy = std::make_unique<std::string> (*data);
+
+  const auto ins = assets.emplace (a, std::move (dataCopy));
+  CHECK (ins.second) << "Asset was already in the pending map: " << a;
+}
+
+bool
+PendingState::GetBalance (const Asset& a, const std::string& name,
+                          Amount& balance) const
+{
+  const auto mit = balances.find ({name, a});
+  if (mit == balances.end ())
+    return false;
+
+  balance = mit->second;
+  return true;
+}
+
+void
+PendingState::SetBalance (const Asset& a, const std::string& name,
+                          const Amount balance)
+{
+  balances[{name, a}] = balance;
+}
+
+Json::Value
+PendingState::ToJson () const
+{
+  Json::Value assetsJson(Json::arrayValue);
+  for (const auto& entry : assets)
+    {
+      Json::Value cur(Json::objectValue);
+      cur["asset"] = entry.first.ToJson ();
+      if (entry.second == nullptr)
+        cur["data"] = Json::Value ();
+      else
+        cur["data"] = *entry.second;
+      assetsJson.append (cur);
+    }
+
+  Json::Value balancesJson(Json::objectValue);
+  for (const auto& entry : balances)
+    {
+      Json::Value cur(Json::objectValue);
+      cur["asset"] = entry.first.second.ToJson ();
+      cur["balance"] = AmountToJson (entry.second);
+
+      if (!balancesJson.isMember (entry.first.first))
+        balancesJson[entry.first.first] = Json::Value (Json::arrayValue);
+      balancesJson[entry.first.first].append (cur);
+    }
+
+  Json::Value res(Json::objectValue);
+  res["assets"] = assetsJson;
+  res["balances"] = balancesJson;
+
+  return res;
+}
+
+/* ************************************************************************** */
+
+void
+PendingStateUpdater::UpdateBalance (const Asset& a, const std::string& name,
+                                    const Amount num)
+{
+  state.SetBalance (a, name, GetBalance (a, name) + num);
+}
+
+void
+PendingStateUpdater::ProcessMint (const Asset& a, const Amount supply,
+                                  const std::string* data)
+{
+  state.AddAsset (a, data);
+  if (supply > 0)
+    UpdateBalance (a, a.GetMinter (), supply);
+}
+
+void
+PendingStateUpdater::ProcessTransfer (const Asset& a, const Amount num,
+                                      const std::string& sender,
+                                      const std::string& recipient)
+{
+  UpdateBalance (a, sender, -num);
+  UpdateBalance (a, recipient, num);
+}
+
+void
+PendingStateUpdater::ProcessBurn (const Asset& a, const Amount num,
+                                  const std::string& sender)
+{
+  UpdateBalance (a, sender, -num);
+}
+
+bool
+PendingStateUpdater::AssetExists (const Asset& a) const
+{
+  if (state.IsNewAsset (a))
+    return true;
+
+  return MoveParser::AssetExists (a);
+}
+
+Amount
+PendingStateUpdater::GetBalance (const Asset& a, const std::string& name) const
+{
+  Amount res;
+  if (state.GetBalance (a, name, res))
+    return res;
+
+  return MoveParser::GetBalance (a, name);
+}
+
+/* ************************************************************************** */
+
+PendingMoves::PendingMoves (NonFungibleLogic& rules)
+  : xaya::SQLiteGame::PendingMoves(rules)
+{}
+
+void
+PendingMoves::Clear ()
+{
+  state = PendingState ();
+}
+
+void
+PendingMoves::AddPendingMove (const Json::Value& mv)
+{
+  const auto& db = AccessConfirmedState ();
+
+  PendingStateUpdater updater(db, state);
+  updater.ProcessOne (mv);
+}
+
+Json::Value
+PendingMoves::ToJson () const
+{
+  return state.ToJson ();
+}
+
+/* ************************************************************************** */
+
+} // namespace nf

--- a/nonfungible/pending.hpp
+++ b/nonfungible/pending.hpp
@@ -1,0 +1,145 @@
+// Copyright (C) 2020 The Xaya developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef NONFUNGIBLE_PENDING_HPP
+#define NONFUNGIBLE_PENDING_HPP
+
+#include "assets.hpp"
+#include "moveparser.hpp"
+
+#include <xayagame/sqlitegame.hpp>
+#include <xayagame/sqlitestorage.hpp>
+
+#include <json/json.h>
+
+#include <map>
+#include <memory>
+#include <string>
+#include <utility>
+
+namespace nf
+{
+
+class NonFungibleLogic;
+
+/**
+ * A currently pending state.
+ */
+class PendingState
+{
+
+private:
+
+  /**
+   * All newly minted assets (that are pending).  The values are the associated
+   * data strings or null if there is no data.
+   */
+  std::map<Asset, std::unique_ptr<std::string>> assets;
+
+  /** Changes to any balances compared to the database.  */
+  std::map<std::pair<std::string, Asset>, Amount> balances;
+
+public:
+
+  PendingState () = default;
+  PendingState (PendingState&&) = default;
+  PendingState& operator= (PendingState&&) = default;
+
+  PendingState (const PendingState&) = delete;
+  void operator= (const PendingState&) = delete;
+
+  /**
+   * Returns true if the given asset is in the list of newly minted ones.
+   */
+  bool IsNewAsset (const Asset& a) const;
+
+  /**
+   * Adds a new asset to the list of ones being minted.
+   */
+  void AddAsset (const Asset& a, const std::string* data);
+
+  /**
+   * Tries to look up a pending balance.  Returns true and sets the
+   * output value if we have an entry, and returns false otherwise.
+   */
+  bool GetBalance (const Asset& a, const std::string& name,
+                   Amount& balance) const;
+
+  /**
+   * Inserts or updates the pending balance.
+   */
+  void SetBalance (const Asset& a, const std::string& name, Amount balance);
+
+  /**
+   * Returns a JSON representation of the state.
+   */
+  Json::Value ToJson () const;
+
+};
+
+/**
+ * MoveParser subclass that updates to a pending state (and takes it into
+ * account for validation).
+ */
+class PendingStateUpdater : public MoveParser
+{
+
+private:
+
+  /** The state being updated.  */
+  PendingState& state;
+
+  /**
+   * Updates the balance of someone by a given amount.
+   */
+  void UpdateBalance (const Asset& a, const std::string& name, Amount num);
+
+protected:
+
+  void ProcessMint (const Asset& a, Amount supply,
+                    const std::string* data) override;
+  void ProcessTransfer (const Asset& a, Amount num,
+                        const std::string& sender,
+                        const std::string& recipient) override;
+  void ProcessBurn (const Asset& a, Amount num,
+                    const std::string& sender) override;
+
+  bool AssetExists (const Asset& a) const override;
+  Amount GetBalance (const Asset& a, const std::string& name) const override;
+
+public:
+
+  explicit PendingStateUpdater (const xaya::SQLiteDatabase& d, PendingState& s)
+    : MoveParser(d), state(s)
+  {}
+
+};
+
+/**
+ * The tracker for pending moves, using the libxayagame framework.
+ */
+class PendingMoves : public xaya::SQLiteGame::PendingMoves
+{
+
+private:
+
+  /** The current state of pending moves.  */
+  PendingState state;
+
+protected:
+
+  void Clear () override;
+  void AddPendingMove (const Json::Value& mv) override;
+
+public:
+
+  explicit PendingMoves (NonFungibleLogic& rules);
+
+  Json::Value ToJson () const override;
+
+};
+
+} // namespace nf
+
+#endif // NONFUNGIBLE_PENDING_HPP

--- a/nonfungible/pending_tests.cpp
+++ b/nonfungible/pending_tests.cpp
@@ -1,0 +1,244 @@
+// Copyright (C) 2020 The Xaya developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "pending.hpp"
+
+#include "testutils.hpp"
+
+#include <glog/logging.h>
+#include <gtest/gtest.h>
+
+namespace nf
+{
+namespace
+{
+
+/* ************************************************************************** */
+
+class PendingStateTests : public testing::Test
+{
+
+protected:
+
+  PendingState state;
+
+  /** Utility variable to use as output for GetBalance.  */
+  Amount balance;
+
+  /**
+   * Expects that the JSON of the current pending state matches a value
+   * parsed from string.
+   */
+  void
+  ExpectStateJson (const std::string& expectedStr) const
+  {
+    ASSERT_EQ (state.ToJson (), ParseJson (expectedStr));
+  }
+
+};
+
+TEST_F (PendingStateTests, Empty)
+{
+  EXPECT_FALSE (state.IsNewAsset (Asset ("domob", "foo")));
+  EXPECT_FALSE (state.GetBalance (Asset ("domob", "foo"), "domob", balance));
+
+  ExpectStateJson (R"({
+    "assets": [],
+    "balances": {}
+  })");
+}
+
+TEST_F (PendingStateTests, Assets)
+{
+  static const std::string data = "data";
+  state.AddAsset (Asset ("domob", "foo"), nullptr);
+  state.AddAsset (Asset ("domob", "bar"), &data);
+
+  EXPECT_TRUE (state.IsNewAsset (Asset ("domob", "foo")));
+  EXPECT_TRUE (state.IsNewAsset (Asset ("domob", "bar")));
+  EXPECT_FALSE (state.IsNewAsset (Asset ("domob", "baz")));
+  EXPECT_FALSE (state.IsNewAsset (Asset ("andy", "foo")));
+
+  ExpectStateJson (R"({
+    "balances": {},
+    "assets":
+      [
+        {"asset": {"m": "domob", "a": "bar"}, "data": "data"},
+        {"asset": {"m": "domob", "a": "foo"}, "data": null}
+      ]
+  })");
+}
+
+TEST_F (PendingStateTests, Balances)
+{
+  state.SetBalance (Asset ("domob", "foo"), "andy", 10);
+  state.SetBalance (Asset ("domob", "bar"), "andy", 10);
+  state.SetBalance (Asset ("domob", "foo"), "domob", 20);
+  state.SetBalance (Asset ("domob", "bar"), "andy", 30);
+
+  ASSERT_TRUE (state.GetBalance (Asset ("domob", "foo"), "domob", balance));
+  EXPECT_EQ (balance, 20);
+
+  ASSERT_TRUE (state.GetBalance (Asset ("domob", "foo"), "andy", balance));
+  EXPECT_EQ (balance, 10);
+
+  ASSERT_TRUE (state.GetBalance (Asset ("domob", "bar"), "andy", balance));
+  EXPECT_EQ (balance, 30);
+
+  ExpectStateJson (R"({
+    "assets": [],
+    "balances":
+      {
+        "andy":
+          [
+            {"asset": {"m": "domob", "a": "bar"}, "balance": 30},
+            {"asset": {"m": "domob", "a": "foo"}, "balance": 10}
+          ],
+        "domob":
+          [
+            {"asset": {"m": "domob", "a": "foo"}, "balance": 20}
+          ]
+      }
+  })");
+}
+
+/* ************************************************************************** */
+
+class PendingStateUpdaterTests : public DBTest
+{
+
+private:
+
+  PendingState state;
+
+protected:
+
+  /**
+   * Processes the given move on top of our state.
+   */
+  void
+  Process (const std::string& name, const std::string& str)
+  {
+    Json::Value mv(Json::objectValue);
+    mv["name"] = name;
+    mv["move"] = ParseJson (str);
+
+    PendingStateUpdater proc(GetDb (), state);
+    proc.ProcessOne (mv);
+  }
+
+  /**
+   * Expects that the JSON of the current pending state matches a value
+   * parsed from string.
+   */
+  void
+  ExpectStateJson (const std::string& expectedStr) const
+  {
+    ASSERT_EQ (state.ToJson (), ParseJson (expectedStr));
+  }
+
+};
+
+TEST_F (PendingStateUpdaterTests, Minting)
+{
+  InsertAsset (Asset ("domob", "foo"), "null");
+  InsertAsset (Asset ("andy", "bar"), "null");
+
+  Process ("domob", R"([
+    {"m": {"a": "foo", "n": 10}},
+    {"m": {"a": "bar", "n": 10}},
+    {"m": {"a": "bar", "n": 20, "d": "invalid"}},
+    {"m": {"a": "baz", "n": 30, "d": "valid"}},
+    {"m": {"a": "zero", "n": 0}}
+  ])");
+
+  ExpectStateJson (R"({
+    "assets":
+      [
+        {"asset": {"m": "domob", "a": "bar"}, "data": null},
+        {"asset": {"m": "domob", "a": "baz"}, "data": "valid"},
+        {"asset": {"m": "domob", "a": "zero"}, "data": null}
+      ],
+    "balances":
+      {
+        "domob":
+          [
+            {"asset": {"m": "domob", "a": "bar"}, "balance": 10},
+            {"asset": {"m": "domob", "a": "baz"}, "balance": 30}
+          ]
+      }
+  })");
+}
+
+TEST_F (PendingStateUpdaterTests, Transfer)
+{
+  InsertAsset (Asset ("domob", "foo"), "null");
+  InsertBalance (Asset ("domob", "foo"), "andy", 20);
+
+  /* These are not touched and should not show up in the pending state.  */
+  InsertAsset (Asset ("domob", "bar"), "null");
+  InsertBalance (Asset ("domob", "bar"), "andy", 42);
+
+  Process ("andy", R"([
+    {"t": {"a": {"m": "domob", "a": "foo"}, "n": 10, "r": "domob"}},
+    {"t": {"a": {"m": "andy", "a": "mine"}, "n": 1, "r": "wrong"}},
+    {"m": {"a": "mine", "n": 10}},
+    {"t": {"a": {"m": "andy", "a": "mine"}, "n": 1, "r": "domob"}},
+    {"t": {"a": {"m": "andy", "a": "mine"}, "n": 10, "r": "wrong"}}
+  ])");
+
+  ExpectStateJson (R"({
+    "assets":
+      [
+        {"asset": {"m": "andy", "a": "mine"}, "data": null}
+      ],
+    "balances":
+      {
+        "andy":
+          [
+            {"asset": {"m": "andy", "a": "mine"}, "balance": 9},
+            {"asset": {"m": "domob", "a": "foo"}, "balance": 10}
+          ],
+        "domob":
+          [
+            {"asset": {"m": "andy", "a": "mine"}, "balance": 1},
+            {"asset": {"m": "domob", "a": "foo"}, "balance": 10}
+          ]
+      }
+  })");
+}
+
+TEST_F (PendingStateUpdaterTests, Burn)
+{
+  InsertAsset (Asset ("domob", "foo"), "null");
+  InsertBalance (Asset ("domob", "foo"), "domob", 20);
+
+  Process ("domob", R"([
+    {"b": {"a": {"m": "domob", "a": "foo"}, "n": 2}},
+    {"b": {"a": {"m": "domob", "a": "bar"}, "n": 10}},
+    {"m": {"a": "bar", "n": 10}},
+    {"b": {"a": {"m": "domob", "a": "bar"}, "n": 6}},
+    {"b": {"a": {"m": "domob", "a": "bar"}, "n": 6}}
+  ])");
+
+  ExpectStateJson (R"({
+    "assets":
+      [
+        {"asset": {"m": "domob", "a": "bar"}, "data": null}
+      ],
+    "balances":
+      {
+        "domob":
+          [
+            {"asset": {"m": "domob", "a": "bar"}, "balance": 4},
+            {"asset": {"m": "domob", "a": "foo"}, "balance": 18}
+          ]
+      }
+  })");
+}
+
+/* ************************************************************************** */
+
+} // anonymous namespace
+} // namespace nf

--- a/nonfungible/rpc-stubs/nf.json
+++ b/nonfungible/rpc-stubs/nf.json
@@ -1,0 +1,56 @@
+[
+  {
+    "name": "stop",
+    "params": {}
+  },
+  {
+    "name": "getcurrentstate",
+    "params": {},
+    "returns": {}
+  },
+  {
+    "name": "getnullstate",
+    "params": {},
+    "returns": {}
+  },
+  {
+    "name": "getpendingstate",
+    "params": {},
+    "returns": {}
+  },
+  {
+    "name": "waitforchange",
+    "params": ["known block"],
+    "returns": ""
+  },
+  {
+    "name": "waitforpendingchange",
+    "params": [42],
+    "returns": {}
+  },
+
+  {
+    "name": "listassets",
+    "params": [],
+    "returns": {}
+  },
+  {
+    "name": "getassetdetails",
+    "params": [{"m": "domob", "a": "foo"}],
+    "returns": {}
+  },
+  {
+    "name": "getbalance",
+    "params":
+      {
+        "asset": {},
+        "name": "daniel"
+      },
+    "returns": {}
+  },
+  {
+    "name": "getuserbalances",
+    "params": ["daniel"],
+    "returns": {}
+  }
+]

--- a/nonfungible/rpcserver.cpp
+++ b/nonfungible/rpcserver.cpp
@@ -1,0 +1,131 @@
+// Copyright (C) 2020 The Xaya developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "rpcserver.hpp"
+
+#include "statejson.hpp"
+
+#include "xayagame/gamerpcserver.hpp"
+
+#include <jsonrpccpp/common/errors.h>
+#include <jsonrpccpp/common/exception.h>
+
+#include <glog/logging.h>
+
+namespace nf
+{
+
+namespace
+{
+
+/**
+ * Tries to parse a JSON value as Asset, and throws a JSON-RPC exception
+ * if it doesn't work.
+ */
+Asset
+GetAsset (const Json::Value& val)
+{
+  Asset res;
+  if (!res.FromJson (val))
+    {
+      std::ostringstream out;
+      out << "invalid asset spec: " << val;
+      throw jsonrpc::JsonRpcException (
+          jsonrpc::Errors::ERROR_RPC_INVALID_PARAMS, out.str ());
+    }
+
+  return res;
+}
+
+} // anonymous namespace
+
+void
+RpcServer::stop ()
+{
+  LOG (INFO) << "RPC method called: stop";
+  game.RequestStop ();
+}
+
+Json::Value
+RpcServer::getcurrentstate ()
+{
+  LOG (INFO) << "RPC method called: getcurrentstate";
+  return game.GetCurrentJsonState ();
+}
+
+Json::Value
+RpcServer::getnullstate ()
+{
+  LOG (INFO) << "RPC method called: getnullstate";
+  return game.GetNullJsonState ();
+}
+
+Json::Value
+RpcServer::getpendingstate ()
+{
+  LOG (INFO) << "RPC method called: getpendingstate";
+  return game.GetPendingJsonState ();
+}
+
+std::string
+RpcServer::waitforchange (const std::string& knownBlock)
+{
+  LOG (INFO) << "RPC method called: waitforchange " << knownBlock;
+  return xaya::GameRpcServer::DefaultWaitForChange (game, knownBlock);
+}
+
+Json::Value
+RpcServer::waitforpendingchange (const int knownVersion)
+{
+  LOG (INFO) << "RPC method called: waitforpendingchange " << knownVersion;
+  return game.WaitForPendingChange (knownVersion);
+}
+
+Json::Value
+RpcServer::listassets ()
+{
+  LOG (INFO) << "RPC method called: listassets";
+  return logic.GetCustomStateData (game,
+      [] (const StateJsonExtractor& ext)
+        {
+          return ext.ListAssets ();
+        });
+}
+
+Json::Value
+RpcServer::getassetdetails (const Json::Value& assetVal)
+{
+  const auto asset = GetAsset (assetVal);
+  LOG (INFO) << "RPC method called: getassetdetails " << asset;
+  return logic.GetCustomStateData (game,
+      [&asset] (const StateJsonExtractor& ext)
+        {
+          return ext.GetAssetDetails (asset);
+        });
+}
+
+Json::Value
+RpcServer::getbalance (const Json::Value& assetVal, const std::string& name)
+{
+  const auto asset = GetAsset (assetVal);
+  LOG (INFO) << "RPC method called: getbalance " << asset << " " << name;
+  return logic.GetCustomStateData (game,
+      [&asset, &name] (const StateJsonExtractor& ext)
+        {
+          return ext.GetBalance (asset, name);
+        });
+}
+
+Json::Value
+RpcServer::getuserbalances (const std::string& name)
+{
+  LOG (INFO) << "RPC method called: getuserbalances " << name;
+  return logic.GetCustomStateData (game,
+      [&name] (const StateJsonExtractor& ext)
+        {
+          return ext.GetUserBalances (name);
+        });
+}
+
+} // namespace nf

--- a/nonfungible/rpcserver.hpp
+++ b/nonfungible/rpcserver.hpp
@@ -1,0 +1,60 @@
+// Copyright (C) 2020 The Xaya developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef NONFUNGIBLE_RPCSERVER_HPP
+#define NONFUNGIBLE_RPCSERVER_HPP
+
+#include "logic.hpp"
+#include "rpc-stubs/nfrpcserverstub.h"
+
+#include "xayagame/game.hpp"
+
+#include <json/json.h>
+#include <jsonrpccpp/server.h>
+
+#include <string>
+
+namespace nf
+{
+
+/**
+ * RPC interface for nonfungibled.
+ */
+class RpcServer : public NFRpcServerStub
+{
+
+private:
+
+  /** The underlying Game instance that manages everything.  */
+  xaya::Game& game;
+
+  /** The NF logic instance for the SQLite database.  */
+  NonFungibleLogic& logic;
+
+public:
+
+  explicit RpcServer (xaya::Game& g, NonFungibleLogic& l,
+                      jsonrpc::AbstractServerConnector& conn)
+    : NFRpcServerStub(conn), game(g), logic(l)
+  {}
+
+  void stop () override;
+
+  Json::Value getcurrentstate () override;
+  Json::Value getnullstate () override;
+  Json::Value getpendingstate () override;
+  std::string waitforchange (const std::string& knownBlock) override;
+  Json::Value waitforpendingchange (int knownVersion) override;
+
+  Json::Value listassets () override;
+  Json::Value getassetdetails (const Json::Value& asset) override;
+  Json::Value getbalance (const Json::Value& asset,
+                          const std::string& name) override;
+  Json::Value getuserbalances (const std::string& name) override;
+
+};
+
+} // namespace nf
+
+#endif // NONFUNGIBLE_RPCSERVER_HPP

--- a/nonfungible/schema.hpp
+++ b/nonfungible/schema.hpp
@@ -1,0 +1,21 @@
+// Copyright (C) 2020 The Xaya developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef NONFUNGIBLE_SCHEMA_HPP
+#define NONFUNGIBLE_SCHEMA_HPP
+
+#include <sqlite3.h>
+
+namespace nf
+{
+
+/**
+ * Sets up the database schema (if it is not already present) on the given
+ * SQLite connection.
+ */
+void SetupDatabaseSchema (sqlite3* db);
+
+} // namespace xid
+
+#endif // NONFUNGIBLE_SCHEMA_HPP

--- a/nonfungible/schema.sql
+++ b/nonfungible/schema.sql
@@ -1,0 +1,44 @@
+-- Copyright (C) 2020 The Xaya developers
+-- Distributed under the MIT software license, see the accompanying
+-- file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+-- All the assets that have been created yet.  This table is append only:
+-- New assets can be created (if the user/asset combination does not yet
+-- exist), but once created, the data is immutable.
+CREATE TABLE IF NOT EXISTS `assets` (
+
+  -- The minting user's name.
+  `minter` TEXT NOT NULL,
+
+  -- The asset's name (within all assets of the user).
+  `asset` TEXT NOT NULL,
+
+  -- The associated data string (which can e.g. be a hash or IPFS link
+  -- to some metadata about this asset).
+  `data` TEXT NULL,
+
+  PRIMARY KEY (`minter`, `asset`)
+
+);
+
+-- All non-zero balances of assets that users have.
+CREATE TABLE IF NOT EXISTS `balances` (
+
+  -- The user's name who owns the balance.
+  `name` TEXT NOT NULL,
+
+  -- The asset this is about.
+  `minter` TEXT NOT NULL,
+  `asset` TEXT NOT NULL,
+
+  -- The balance.  It is always larger than zero; if it reaches
+  -- zero, then the entry is removed.
+  `balance` INTEGER NOT NULL,
+
+  PRIMARY KEY (`name`, `minter`, `asset`)
+
+);
+
+-- Allow efficient retrieval of all balances of a given asset.
+CREATE INDEX IF NOT EXISTS `balances_by_asset`
+    ON `balances` (`minter`, `asset`);

--- a/nonfungible/schema_head.cpp
+++ b/nonfungible/schema_head.cpp
@@ -1,0 +1,14 @@
+// Copyright (C) 2020 The Xaya developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "schema.hpp"
+
+#include <glog/logging.h>
+
+namespace nf
+{
+namespace
+{
+
+constexpr const char SCHEMA_SQL[] = R"(

--- a/nonfungible/schema_tail.cpp
+++ b/nonfungible/schema_tail.cpp
@@ -1,0 +1,21 @@
+)";
+
+/**
+ * Callback for sqlite3_exec that expects not to be called.
+ */
+int
+ExpectNoResult (void* data, int columns, char** strs, char** names)
+{
+  LOG (FATAL) << "Expected no result from DB query";
+}
+
+} // anonymous namespace
+
+void
+SetupDatabaseSchema (sqlite3* db)
+{
+  CHECK_EQ (sqlite3_exec (db, SCHEMA_SQL, &ExpectNoResult, nullptr, nullptr),
+            SQLITE_OK);
+}
+
+} // namespace nf

--- a/nonfungible/schema_tests.cpp
+++ b/nonfungible/schema_tests.cpp
@@ -1,0 +1,30 @@
+// Copyright (C) 2020 The Xaya developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "schema.hpp"
+
+#include "testutils.hpp"
+
+#include <gtest/gtest.h>
+
+namespace nf
+{
+namespace
+{
+
+using SchemaTests = DBTest;
+
+TEST_F (SchemaTests, Valid)
+{
+  /* DBTest itself already sets up the schema.  */
+}
+
+TEST_F (SchemaTests, MultipleTimesIsOk)
+{
+  SetupDatabaseSchema (GetHandle ());
+  SetupDatabaseSchema (GetHandle ());
+}
+
+} // anonymous namespace
+} // namespace nf

--- a/nonfungible/statejson.cpp
+++ b/nonfungible/statejson.cpp
@@ -1,0 +1,133 @@
+// Copyright (C) 2020 The Xaya developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "statejson.hpp"
+
+#include "dbutils.hpp"
+#include "moveparser.hpp"
+
+#include <glog/logging.h>
+
+namespace nf
+{
+
+Json::Value
+StateJsonExtractor::ListAssets () const
+{
+  auto* stmt = db.PrepareRo (R"(
+    SELECT `minter`, `asset`
+      FROM `assets`
+      ORDER BY `minter`, `asset`
+  )");
+
+  Json::Value res(Json::arrayValue);
+  while (StepStatement (stmt))
+    res.append (Asset::FromColumns (stmt, 0, 1).ToJson ());
+
+  return res;
+}
+
+Json::Value
+StateJsonExtractor::GetAssetDetails (const Asset& a) const
+{
+  auto* stmt = db.PrepareRo (R"(
+    SELECT `data`
+      FROM `assets`
+      WHERE `minter` = ?1 AND `asset` = ?2
+  )");
+  a.BindToParams (stmt, 1, 2);
+
+  if (!StepStatement (stmt))
+    return Json::Value ();
+
+  Json::Value data;
+  if (!ColumnIsNull (stmt, 0))
+    data = ColumnExtract<std::string> (stmt, 0);
+
+  CHECK (!StepStatement (stmt));
+
+  stmt = db.PrepareRo (R"(
+    SELECT `name`, `balance`
+      FROM `balances`
+      WHERE `minter` = ?1 AND `asset` = ?2
+      ORDER BY `name`
+  )");
+  a.BindToParams (stmt, 1, 2);
+
+  Json::Value balances(Json::objectValue);
+  Amount total = 0;
+  while (StepStatement (stmt))
+    {
+      const auto name = ColumnExtract<std::string> (stmt, 0);
+      const Amount val = ColumnExtract<int64_t> (stmt, 1);
+
+      CHECK_GT (val, 0);
+      CHECK (!balances.isMember (name)) << "Duplicate user: " << name;
+
+      total += val;
+      balances[name] = val;
+    }
+
+  Json::Value res(Json::objectValue);
+  res["asset"] = a.ToJson ();
+  res["data"] = data;
+  res["supply"] = AmountToJson (total);
+  res["balances"] = balances;
+
+  return res;
+}
+
+Json::Value
+StateJsonExtractor::GetBalance (const Asset& a, const std::string& name) const
+{
+  return AmountToJson (GetDbBalance (db, a, name));
+}
+
+Json::Value
+StateJsonExtractor::GetUserBalances (const std::string& name) const
+{
+  auto* stmt = db.PrepareRo (R"(
+    SELECT `minter`, `asset`, `balance`
+      FROM `balances`
+      WHERE `name` = ?1
+      ORDER BY `minter`, `asset`
+  )");
+  BindParam (stmt, 1, name);
+
+  Json::Value res(Json::arrayValue);
+  while (StepStatement (stmt))
+    {
+      const auto asset = Asset::FromColumns (stmt, 0, 1);
+      const Amount balance = ColumnExtract<int64_t> (stmt, 2);
+
+      Json::Value cur(Json::objectValue);
+      cur["asset"] = asset.ToJson ();
+      cur["balance"] = AmountToJson (balance);
+
+      res.append (cur);
+    }
+
+  return res;
+}
+
+Json::Value
+StateJsonExtractor::FullState () const
+{
+  auto* stmt = db.PrepareRo (R"(
+    SELECT `minter`, `asset`
+      FROM `assets`
+      ORDER BY `minter`, `asset`
+  )");
+
+  Json::Value res(Json::arrayValue);
+  while (StepStatement (stmt))
+    {
+      const auto asset = Asset::FromColumns (stmt, 0, 1);
+      res.append (GetAssetDetails (asset));
+    }
+
+  return res;
+}
+
+} // namespace nf

--- a/nonfungible/statejson.hpp
+++ b/nonfungible/statejson.hpp
@@ -1,0 +1,75 @@
+// Copyright (C) 2020 The Xaya developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef NONFUNGIBLE_STATEJSON_HPP
+#define NONFUNGIBLE_STATEJSON_HPP
+
+#include "assets.hpp"
+
+#include <xayagame/sqlitestorage.hpp>
+
+#include <json/json.h>
+
+#include <string>
+
+namespace nf
+{
+
+/**
+ * Wrapper around a (read-only) database, which is able to extract bits
+ * of the game state as JSON.  This is basically the internal implementation
+ * of the RPC interface, but without the actual RPC server around and in
+ * an easily-testable form.
+ */
+class StateJsonExtractor
+{
+
+private:
+
+  /** The underlying database.  */
+  const xaya::SQLiteDatabase& db;
+
+public:
+
+  explicit StateJsonExtractor (const xaya::SQLiteDatabase& d)
+    : db(d)
+  {}
+
+  StateJsonExtractor () = delete;
+  StateJsonExtractor (const StateJsonExtractor&) = delete;
+  void operator= (const StateJsonExtractor&) = delete;
+
+  /**
+   * Retrieves an "overview list" of all assets in the system.
+   */
+  Json::Value ListAssets () const;
+
+  /**
+   * Retrieves detailed data about the given asset.  This includes the
+   * custom string and also a list of all holders / balances.
+   */
+  Json::Value GetAssetDetails (const Asset& a) const;
+
+  /**
+   * Retrieves a single balance of a (user, asset) combination.
+   */
+  Json::Value GetBalance (const Asset& a, const std::string& name) const;
+
+  /**
+   * Returns all assets and balances owned by the given user.
+   */
+  Json::Value GetUserBalances (const std::string& name) const;
+
+  /**
+   * Returns the entire game state as JSON.  This method is not very efficient
+   * and might produce a huge result, and should thus be avoided in practice.
+   * It is mainly meant for testing, e.g. on regtest.
+   */
+  Json::Value FullState () const;
+
+};
+
+} // namespace nf
+
+#endif // NONFUNGIBLE_STATEJSON_HPP

--- a/nonfungible/statejson_tests.cpp
+++ b/nonfungible/statejson_tests.cpp
@@ -1,0 +1,126 @@
+// Copyright (C) 2020 The Xaya developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "statejson.hpp"
+
+#include "testutils.hpp"
+
+#include <gtest/gtest.h>
+
+namespace nf
+{
+namespace
+{
+
+class StateJsonTests : public DBTest
+{
+
+protected:
+
+  const StateJsonExtractor ext;
+
+  StateJsonTests ()
+    : ext(GetDb ())
+  {}
+
+};
+
+TEST_F (StateJsonTests, ListAssets)
+{
+  InsertAsset (Asset ("domob", "foo"), "null");
+  InsertAsset (Asset ("domob", "bar"), "null");
+  InsertAsset (Asset ("andy", "xyz"), "null");
+  InsertBalance (Asset ("domob", "foo"), "daniel", 50);
+
+  EXPECT_EQ (ext.ListAssets (), ParseJson (R"([
+    {"m": "andy", "a": "xyz"},
+    {"m": "domob", "a": "bar"},
+    {"m": "domob", "a": "foo"}
+  ])"));
+}
+
+TEST_F (StateJsonTests, GetAssetDetails)
+{
+  InsertAsset (Asset ("domob", "foo"), "data");
+  InsertAsset (Asset ("domob", "bar"), "null");
+  InsertBalance (Asset ("domob", "foo"), "domob", 2);
+  InsertBalance (Asset ("domob", "foo"), "andy", 5);
+
+  EXPECT_EQ (ext.GetAssetDetails (Asset ("domob", "foo")), ParseJson (R"({
+    "asset": {"m": "domob", "a": "foo"},
+    "data": "data",
+    "supply": 7,
+    "balances": {"andy": 5, "domob": 2}
+  })"));
+
+  EXPECT_EQ (ext.GetAssetDetails (Asset ("domob", "bar")), ParseJson (R"({
+    "asset": {"m": "domob", "a": "bar"},
+    "data": null,
+    "supply": 0,
+    "balances": {}
+  })"));
+}
+
+TEST_F (StateJsonTests, GetBalance)
+{
+  InsertAsset (Asset ("domob", "foo"), "null");
+  InsertBalance (Asset ("domob", "foo"), "domob", 2);
+  InsertBalance (Asset ("domob", "foo"), "andy", 5);
+
+  EXPECT_EQ (ext.GetBalance (Asset ("domob", "foo"), "domob"),
+             AmountToJson (2));
+  EXPECT_EQ (ext.GetBalance (Asset ("domob", "foo"), "andy"),
+             AmountToJson (5));
+  EXPECT_EQ (ext.GetBalance (Asset ("domob", "foo"), "other"),
+             AmountToJson (0));
+  EXPECT_EQ (ext.GetBalance (Asset ("domob", "bar"), "domob"),
+             AmountToJson (0));
+}
+
+TEST_F (StateJsonTests, GetUserBalances)
+{
+  InsertAsset (Asset ("domob", "foo"), "null");
+  InsertAsset (Asset ("domob", "bar"), "null");
+  InsertAsset (Asset ("andy", "xyz"), "null");
+  InsertBalance (Asset ("domob", "foo"), "domob", 2);
+  InsertBalance (Asset ("andy", "xyz"), "domob", 1);
+  InsertBalance (Asset ("domob", "foo"), "andy", 5);
+
+  EXPECT_EQ (ext.GetUserBalances ("domob"), ParseJson (R"([
+    {"asset": {"m": "andy", "a": "xyz"}, "balance": 1},
+    {"asset": {"m": "domob", "a": "foo"}, "balance": 2}
+  ])"));
+
+  EXPECT_EQ (ext.GetUserBalances ("andy"), ParseJson (R"([
+    {"asset": {"m": "domob", "a": "foo"}, "balance": 5}
+  ])"));
+
+  EXPECT_EQ (ext.GetUserBalances ("other"), ParseJson ("[]"));
+}
+
+TEST_F (StateJsonTests, FullState)
+{
+  InsertAsset (Asset ("domob", "foo"), "data");
+  InsertAsset (Asset ("domob", "bar"), "null");
+  InsertBalance (Asset ("domob", "foo"), "domob", 2);
+  InsertBalance (Asset ("domob", "foo"), "andy", 5);
+
+  EXPECT_EQ (ext.FullState (), ParseJson (R"([
+    {
+      "asset": {"m": "domob", "a": "bar"},
+      "data": null,
+      "supply": 0,
+      "balances": {}
+    },
+    {
+      "asset": {"m": "domob", "a": "foo"},
+      "data": "data",
+      "supply": 7,
+      "balances": {"andy": 5, "domob": 2}
+    }
+  ])"));
+}
+
+} // anonymous namespace
+} // namespace nf

--- a/nonfungible/testutils.cpp
+++ b/nonfungible/testutils.cpp
@@ -1,0 +1,20 @@
+// Copyright (C) 2020 The Xaya developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "testutils.hpp"
+
+#include "schema.hpp"
+
+#include <glog/logging.h>
+
+namespace nf
+{
+
+DBTest::DBTest ()
+  : db("test", SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_MEMORY)
+{
+  SetupDatabaseSchema (GetHandle ());
+}
+
+} // namespace nf

--- a/nonfungible/testutils.cpp
+++ b/nonfungible/testutils.cpp
@@ -37,12 +37,14 @@ DBTest::InsertAsset (const Asset& a, const std::string& data)
       (`minter`, `asset`, `data`)
       VALUES (?1, ?2, ?3)
   )");
+
   a.BindToParams (stmt, 1, 2);
   if (data == "null")
     BindNullParam (stmt, 3);
   else
     BindParam (stmt, 3, data);
-  CHECK_EQ (sqlite3_step (stmt), SQLITE_DONE);
+
+  CHECK (!StepStatement (stmt));
 }
 
 void
@@ -54,10 +56,12 @@ DBTest::InsertBalance (const Asset& a, const std::string& name,
       (`name`, `minter`, `asset`, `balance`)
       VALUES (?1, ?2, ?3, ?4)
   )");
+
   BindParam (stmt, 1, name);
   a.BindToParams (stmt, 2, 3);
   BindParam (stmt, 4, num);
-  CHECK_EQ (sqlite3_step (stmt), SQLITE_DONE);
+
+  CHECK (!StepStatement (stmt));
 }
 
 } // namespace nf

--- a/nonfungible/testutils.cpp
+++ b/nonfungible/testutils.cpp
@@ -4,12 +4,24 @@
 
 #include "testutils.hpp"
 
+#include "dbutils.hpp"
 #include "schema.hpp"
 
 #include <glog/logging.h>
 
+#include <sstream>
+
 namespace nf
 {
+
+Json::Value
+ParseJson (const std::string& val)
+{
+  std::istringstream in(val);
+  Json::Value res;
+  in >> res;
+  return res;
+}
 
 DBTest::DBTest ()
   : db("test", SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_MEMORY)

--- a/nonfungible/testutils.cpp
+++ b/nonfungible/testutils.cpp
@@ -29,4 +29,35 @@ DBTest::DBTest ()
   SetupDatabaseSchema (GetHandle ());
 }
 
+void
+DBTest::InsertAsset (const Asset& a, const std::string& data)
+{
+  auto* stmt = db.Prepare (R"(
+    INSERT INTO `assets`
+      (`minter`, `asset`, `data`)
+      VALUES (?1, ?2, ?3)
+  )");
+  a.BindToParams (stmt, 1, 2);
+  if (data == "null")
+    BindNullParam (stmt, 3);
+  else
+    BindParam (stmt, 3, data);
+  CHECK_EQ (sqlite3_step (stmt), SQLITE_DONE);
+}
+
+void
+DBTest::InsertBalance (const Asset& a, const std::string& name,
+                       const Amount num)
+{
+  auto* stmt = db.Prepare (R"(
+    INSERT INTO `balances`
+      (`name`, `minter`, `asset`, `balance`)
+      VALUES (?1, ?2, ?3, ?4)
+  )");
+  BindParam (stmt, 1, name);
+  a.BindToParams (stmt, 2, 3);
+  BindParam (stmt, 4, num);
+  CHECK_EQ (sqlite3_step (stmt), SQLITE_DONE);
+}
+
 } // namespace nf

--- a/nonfungible/testutils.hpp
+++ b/nonfungible/testutils.hpp
@@ -11,8 +11,15 @@
 
 #include <sqlite3.h>
 
+#include <json/json.h>
+
 namespace nf
 {
+
+/**
+ * Parses JSON from a string.
+ */
+Json::Value ParseJson (const std::string& val);
 
 /**
  * Test fixture with a temporary, in-memory SQLite database and our

--- a/nonfungible/testutils.hpp
+++ b/nonfungible/testutils.hpp
@@ -1,0 +1,54 @@
+// Copyright (C) 2020 The Xaya developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef NONFUNGIBLE_TESTUTILS_HPP
+#define NONFUNGIBLE_TESTUTILS_HPP
+
+#include "xayagame/sqlitestorage.hpp"
+
+#include <gtest/gtest.h>
+
+#include <sqlite3.h>
+
+namespace nf
+{
+
+/**
+ * Test fixture with a temporary, in-memory SQLite database and our
+ * database schema applied.
+ */
+class DBTest : public testing::Test
+{
+
+private:
+
+  xaya::SQLiteDatabase db;
+
+protected:
+
+  DBTest ();
+
+  /**
+   * Returns the underlying database handle for SQLite.
+   */
+  sqlite3*
+  GetHandle ()
+  {
+    return *db;
+  }
+
+  /**
+   * Returns a Database instance for the test.
+   */
+  xaya::SQLiteDatabase&
+  GetDb ()
+  {
+    return db;
+  }
+
+};
+
+} // namespace nf
+
+#endif // NONFUNGIBLE_TESTUTILS_HPP

--- a/nonfungible/testutils.hpp
+++ b/nonfungible/testutils.hpp
@@ -5,6 +5,8 @@
 #ifndef NONFUNGIBLE_TESTUTILS_HPP
 #define NONFUNGIBLE_TESTUTILS_HPP
 
+#include "assets.hpp"
+
 #include "xayagame/sqlitestorage.hpp"
 
 #include <gtest/gtest.h>
@@ -12,6 +14,8 @@
 #include <sqlite3.h>
 
 #include <json/json.h>
+
+#include <string>
 
 namespace nf
 {
@@ -53,6 +57,18 @@ protected:
   {
     return db;
   }
+
+  /**
+   * Inserts an asset into the database for testing purposes.  If data is
+   * "null" (as literal string), then no data will be placed, otherwise the
+   * given string.
+   */
+  void InsertAsset (const Asset& a, const std::string& data);
+
+  /**
+   * Inserts a balance entry into the database for testing purposes.
+   */
+  void InsertBalance (const Asset& a, const std::string& name, Amount num);
 
 };
 

--- a/xayautil/Makefile.am
+++ b/xayautil/Makefile.am
@@ -12,6 +12,7 @@ libxayautil_la_SOURCES = \
   compression.cpp \
   cryptorand.cpp \
   hash.cpp \
+  jsonutils.cpp \
   random.cpp \
   uint256.cpp
 xayautil_HEADERS = \
@@ -19,6 +20,7 @@ xayautil_HEADERS = \
   compression.hpp \
   cryptorand.hpp \
   hash.hpp \
+  jsonutils.hpp \
   random.hpp random.tpp \
   uint256.hpp
 noinst_HEADERS = \
@@ -35,5 +37,6 @@ tests_SOURCES = \
   compression_tests.cpp \
   cryptorand_tests.cpp \
   hash_tests.cpp \
+  jsonutils_tests.cpp \
   random_tests.cpp \
   uint256_tests.cpp

--- a/xayautil/jsonutils.cpp
+++ b/xayautil/jsonutils.cpp
@@ -1,0 +1,24 @@
+// Copyright (C) 2020 The Xaya developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "jsonutils.hpp"
+
+namespace xaya
+{
+
+bool
+IsIntegerValue (const Json::Value& val)
+{
+  switch (val.type ())
+    {
+    case Json::intValue:
+    case Json::uintValue:
+      return true;
+
+    default:
+      return false;
+    }
+}
+
+} // namespace xaya

--- a/xayautil/jsonutils.hpp
+++ b/xayautil/jsonutils.hpp
@@ -1,0 +1,26 @@
+// Copyright (C) 2020 The Xaya developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef XAYAUTIL_JSONUTILS_HPP
+#define XAYAUTIL_JSONUTILS_HPP
+
+#include <json/json.h>
+
+namespace xaya
+{
+
+/**
+ * Returns true if the given JSON value is a true integer, i.e. really
+ * was parsed from an integer literal.  This is in contrast to a value that
+ * has isInt() return true, but was actually parsed from a floating-point
+ * literal and just happens to be integral.
+ *
+ * This function can be used in conjunction with isInt / isUInt on JSON values
+ * if we want to enforce that they are passed as integer literals.
+ */
+bool IsIntegerValue (const Json::Value& val);
+
+} // namespace xaya
+
+#endif // XAYAUTIL_JSONUTILS_HPP

--- a/xayautil/jsonutils_tests.cpp
+++ b/xayautil/jsonutils_tests.cpp
@@ -1,0 +1,43 @@
+// Copyright (C) 2020 The Xaya developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "jsonutils.hpp"
+
+#include <gtest/gtest.h>
+
+#include <sstream>
+
+namespace xaya
+{
+namespace
+{
+
+/**
+ * Parses a string using the JSON parser and returns the value.
+ */
+Json::Value
+ParseJson (const std::string& val)
+{
+  std::istringstream in(val);
+  Json::Value res;
+  in >> res;
+  return res;
+}
+
+TEST (JsonUtilsTests, IsIntegerValue)
+{
+  EXPECT_TRUE (IsIntegerValue (ParseJson ("0")));
+  EXPECT_TRUE (IsIntegerValue (ParseJson ("-5")));
+  EXPECT_TRUE (IsIntegerValue (ParseJson ("42")));
+  EXPECT_TRUE (IsIntegerValue (ParseJson ("18446744073709551615")));
+  EXPECT_TRUE (IsIntegerValue (ParseJson ("-9223372036854775808")));
+
+  EXPECT_FALSE (IsIntegerValue (ParseJson ("1e5")));
+  EXPECT_FALSE (IsIntegerValue (ParseJson ("1.0")));
+  EXPECT_FALSE (IsIntegerValue (ParseJson ("18446744073709551616")));
+  EXPECT_FALSE (IsIntegerValue (ParseJson ("-9223372036854775809")));
+}
+
+} // anonymous namespace
+} // namespace xaya


### PR DESCRIPTION
This adds a new GSP for `g/nf`.  It is a simple but complete implementation of non-fungible assets similar to ERC-1155, which everyone on Xaya can mint, own, transfer, burn and trade.  It is by itself a potentially useful application on top of Xaya, but it also serves as a simple real-world example of using `SQLiteGame` with all features like pending moves, custom RPC server and so on.  And it will be used as example and for integration testing [Democrit](https://github.com/xaya/democrit).