### PR TITLE
Follow-up tweaks for Xayaships loss declarations

### DIFF
--- a/gamechannel/Makefile.am
+++ b/gamechannel/Makefile.am
@@ -63,7 +63,7 @@ gamechannel_HEADERS = \
   boardrules.hpp \
   broadcast.hpp \
   channelgame.hpp \
-  channelmanager.hpp \
+  channelmanager.hpp channelmanager.tpp \
   chaintochannel.hpp \
   daemon.hpp \
   database.hpp \

--- a/gamechannel/channelmanager.cpp
+++ b/gamechannel/channelmanager.cpp
@@ -7,8 +7,6 @@
 #include "gamestatejson.hpp"
 #include "stateproof.hpp"
 
-#include <glog/logging.h>
-
 #include <chrono>
 
 namespace xaya

--- a/gamechannel/channelmanager.cpp
+++ b/gamechannel/channelmanager.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 The Xaya developers
+// Copyright (C) 2019-2021 The Xaya developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -38,6 +38,7 @@ ChannelManager::ChannelManager (const BoardRules& r, OpenChannel& oc,
     boardStates(rules, rpc, channelId)
 {
   blockHash.SetNull ();
+  pendingPutStateOnChain.SetNull ();
   pendingDispute.SetNull ();
 }
 
@@ -269,6 +270,7 @@ ChannelManager::ProcessOnChain (const uint256& blk, const unsigned h,
   blockHash = blk;
   onChainHeight = h;
 
+  ResetMinedTxid (onChainSender, pendingPutStateOnChain);
   ResetMinedTxid (onChainSender, pendingDispute);
   exists = true;
   boardStates.UpdateOnChain (meta, reinitState, proof);
@@ -378,6 +380,43 @@ ChannelManager::TriggerAutoMoves ()
 }
 
 uint256
+ChannelManager::PutStateOnChain ()
+{
+  LOG (INFO)
+      << "Trying to put the latest state on chain for " << channelId.ToHex ();
+  std::lock_guard<std::mutex> lock(mut);
+
+  uint256 txidNull;
+  txidNull.SetNull ();
+
+  if (!exists)
+    {
+      LOG (WARNING) << "The channel does not exist on chain";
+      return txidNull;
+    }
+
+  const unsigned latestCnt = boardStates.GetLatestState ().TurnCount ();
+  const unsigned onChainCnt = boardStates.GetOnChainTurnCount ();
+  if (latestCnt <= boardStates.GetOnChainTurnCount ())
+    {
+      /* We always update the latest state based on what we get on chain,
+         so it should not happen that the on-chain count is actually
+         better than the latest state.  */
+      CHECK_EQ (latestCnt, onChainCnt);
+      LOG (WARNING)
+          << "Latest state on chain matches the best known state already"
+          << " at turn count " << onChainCnt
+          << ", not sending the state on chain";
+      return txidNull;
+    }
+
+  CHECK (onChainSender != nullptr);
+  pendingPutStateOnChain
+      = onChainSender->SendResolution (boardStates.GetStateProof ());
+  return pendingPutStateOnChain;
+}
+
+uint256
 ChannelManager::FileDispute ()
 {
   LOG (INFO) << "Trying to file a dispute for channel " << channelId.ToHex ();
@@ -454,6 +493,8 @@ ChannelManager::UnlockedToJson () const
     }
 
   Json::Value pending(Json::objectValue);
+  if (!pendingPutStateOnChain.IsNull ())
+    pending["putstateonchain"] = pendingPutStateOnChain.ToHex ();
   if (!pendingDispute.IsNull ())
     pending["dispute"] = pendingDispute.ToHex ();
   if (dispute != nullptr && !dispute->pendingResolution.IsNull ())

--- a/gamechannel/channelmanager.hpp
+++ b/gamechannel/channelmanager.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 The Xaya developers
+// Copyright (C) 2019-2021 The Xaya developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -158,6 +158,13 @@ private:
   std::unique_ptr<DisputeData> dispute;
 
   /**
+   * The txid of a pending move putting the current state on chain.  Set to
+   * null if there is none.  If multiple put-on-chain requests are sent,
+   * this corresponds to the latest.
+   */
+  uint256 pendingPutStateOnChain;
+
+  /**
    * The transaction ID of a dispute move we sent (if any).  Set to null
    * if there is none.
    */
@@ -273,6 +280,15 @@ public:
    * but affects the automoves logic).
    */
   void TriggerAutoMoves ();
+
+  /**
+   * Requests to send a resolution move with the current state, and returns
+   * the txid if successful.  Resolutions for active disputes will be
+   * sent automatically as needed, but this function can be used to
+   * explicitly trigger one in situations where putting the current state
+   * on-chain is useful for a different purpose.
+   */
+  uint256 PutStateOnChain ();
 
   /**
    * Requests to file a dispute with the current state.  Returns the txid

--- a/gamechannel/channelmanager.hpp
+++ b/gamechannel/channelmanager.hpp
@@ -315,6 +315,23 @@ public:
   Json::Value ToJson () const;
 
   /**
+   * Gives access to the currently latest channel state to a caller,
+   * for custom logic they may need with it.  The callback is invoked
+   * with the latest parsed state cast to the given type (which must be
+   * the actual type of board states used by the game in question).  While
+   * the callback is active, the state is locked and the callback is free
+   * to examine it as needed.
+   *
+   * The callback may be invoked with a null pointer in case there is no
+   * latest state, e.g. because the channel does not yet exist on chain.
+   *
+   * If the callback returns a value, that value will be returned from
+   * this function.
+   */
+  template <typename State, typename Fcn>
+    auto ReadLatestState (const Fcn& cb) const;
+
+  /**
    * Blocks the calling thread until the state of the channel has (probably)
    * been changed.  This can be used by frontends to implement long-polling
    * RPC methods like waitforchange.  Note that the function may return
@@ -337,5 +354,7 @@ public:
 };
 
 } // namespace xaya
+
+#include "channelmanager.tpp"
 
 #endif // GAMECHANNEL_CHANNELMANAGER_HPP

--- a/gamechannel/channelmanager.tpp
+++ b/gamechannel/channelmanager.tpp
@@ -1,0 +1,27 @@
+// Copyright (C) 2019-2021 The Xaya developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+/* Template implementation code for channelmanager.hpp.  */
+
+#include <glog/logging.h>
+
+namespace xaya
+{
+
+template <typename State, typename Fcn>
+  auto
+  ChannelManager::ReadLatestState (const Fcn& cb) const
+{
+  std::lock_guard<std::mutex> lock(mut);
+
+  if (!exists)
+    return cb (nullptr);
+
+  const auto& state = boardStates.GetLatestState ();
+  const auto* typedState = dynamic_cast<const State*> (&state);
+  CHECK (typedState != nullptr);
+  return cb (typedState);
+}
+
+} // namespace xaya

--- a/gamechannel/rollingstate.hpp
+++ b/gamechannel/rollingstate.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 The Xaya developers
+// Copyright (C) 2019-2021 The Xaya developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -54,6 +54,9 @@ private:
     /** The initial state for that reinitialisation.  */
     BoardState reinitState;
 
+    /** The turn count for the latest state known on chain.  */
+    unsigned onChainTurn;
+
     /** The state proof for the latest state.  */
     proto::StateProof proof;
 
@@ -108,6 +111,11 @@ public:
    * Returns a proof for the current latest state.
    */
   const proto::StateProof& GetStateProof () const;
+
+  /**
+   * Returns the turn count of the best state known on chain.
+   */
+  unsigned GetOnChainTurnCount () const;
 
   /**
    * Returns the reinitialisation ID of the channel for which the current

--- a/gamechannel/rollingstate_tests.cpp
+++ b/gamechannel/rollingstate_tests.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 The Xaya developers
+// Copyright (C) 2019-2021 The Xaya developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -82,6 +82,7 @@ TEST_F (RollingStateTests, OnChainUpdate)
     initial_state: { data: "13 5" }
   )")));
   ExpectState ("13 5", "reinit 1");
+  EXPECT_EQ (state.GetOnChainTurnCount (), 5);
 
   EXPECT_TRUE (state.UpdateOnChain (meta2, "25 4", ParseStateProof (R"(
     initial_state: { data: "25 4" }
@@ -96,6 +97,7 @@ TEST_F (RollingStateTests, OnChainUpdate)
       }
   )")));
   ExpectState ("65 5", "reinit 2");
+  EXPECT_EQ (state.GetOnChainTurnCount (), 5);
 
   EXPECT_TRUE (state.UpdateOnChain (meta1, "13 5", ParseStateProof (R"(
     initial_state: { data: "13 5" }
@@ -110,6 +112,7 @@ TEST_F (RollingStateTests, OnChainUpdate)
       }
   )")));
   ExpectState ("63 6", "reinit 1");
+  EXPECT_EQ (state.GetOnChainTurnCount (), 6);
 
   /* This provides a state proof that is older than the best known state,
      but it does change the current reinit ID.  */
@@ -122,6 +125,7 @@ TEST_F (RollingStateTests, OnChainUpdate)
       }
   )")));
   ExpectState ("65 5", "reinit 2");
+  EXPECT_EQ (state.GetOnChainTurnCount (), 5);
 
   /* This is an older state and does not change the reinit ID.  */
   EXPECT_FALSE (state.UpdateOnChain (meta2, "25 4", ParseStateProof (R"(
@@ -133,6 +137,7 @@ TEST_F (RollingStateTests, OnChainUpdate)
       }
   )")));
   ExpectState ("65 5", "reinit 2");
+  EXPECT_EQ (state.GetOnChainTurnCount (), 5);
 }
 
 TEST_F (RollingStateTests, UpdateWithMoveUnknownReinit)
@@ -217,6 +222,7 @@ TEST_F (RollingStateTests, UpdateWithMoveNotFresher)
   )")));
 
   ExpectState ("63 6", "reinit 1");
+  EXPECT_EQ (state.GetOnChainTurnCount (), 6);
 }
 
 TEST_F (RollingStateTests, UpdateWithMoveSuccessful)
@@ -253,6 +259,7 @@ TEST_F (RollingStateTests, UpdateWithMoveSuccessful)
       }
   )")));
   ExpectState ("25 4", "reinit 2");
+  EXPECT_EQ (state.GetOnChainTurnCount (), 4);
 
   /* This on-chain update switches to "reinit 1" but is not fresher in turn
      count than the off-chain update from before.  */
@@ -269,6 +276,7 @@ TEST_F (RollingStateTests, UpdateWithMoveSuccessful)
       }
   )")));
   ExpectState ("60 7", "reinit 1");
+  EXPECT_EQ (state.GetOnChainTurnCount (), 6);
 }
 
 } // anonymous namespace

--- a/ships/README.md
+++ b/ships/README.md
@@ -196,9 +196,14 @@ the game state), without any changes to game stats of the player.
 Either participant of an open channel can declare themselves the loser
 any time:
 
-    {"l": {"id": CHANNEL-ID}}
+    {"l": {"id": CHANNEL-ID, "r": REINIT}}
 
-As before, `CHANNEL-ID` is the channel's ID as hex string.
+As before, `CHANNEL-ID` is the channel's ID as hex string, and `REINIT`
+is the reinitialisation ID (raw data base64-encoded) for whose game state
+the user lost.
+(The latter prevents a loss declaration made on a channel from being
+replayed in case there is a reorg that changes who joins the channel as
+second player, and thus might in reality have a different outcome.)
 
 Such a move is valid as long as the channel is currently open and has two
 participants, of which the sending user is one.  There are no other checks

--- a/ships/channel.cpp
+++ b/ships/channel.cpp
@@ -7,6 +7,7 @@
 #include <gamechannel/proto/signatures.pb.h>
 #include <gamechannel/protoutils.hpp>
 #include <gamechannel/signatures.hpp>
+#include <xayautil/base64.hpp>
 #include <xayautil/hash.hpp>
 
 namespace ships
@@ -292,6 +293,7 @@ ShipsChannel::MaybeOnChainMove (const xaya::ParsedBoardState& state,
 
   Json::Value data(Json::objectValue);
   data["id"] = id.ToHex ();
+  data["r"] = xaya::EncodeBase64 (meta.reinit ());
 
   Json::Value mv(Json::objectValue);
   mv["l"] = data;

--- a/ships/channeltest/Makefile.am
+++ b/ships/channeltest/Makefile.am
@@ -3,6 +3,7 @@ AM_TESTS_ENVIRONMENT = \
 
 REGTESTS = \
   disputes.py \
+  force_close.py \
   full_game.py \
   pending.py \
   reorg.py \

--- a/ships/channeltest/force_close.py
+++ b/ships/channeltest/force_close.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+# Copyright (C) 2021 The Xaya developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+"""
+Tests the situation of force-closing a channel with the filedispute RPC
+in case the loser does not do so automatically.
+"""
+
+from shipstest import ShipsTest
+
+
+class ForceCloseTest (ShipsTest):
+
+  def run (self):
+    myAddr = self.rpc.xaya.getnewaddress ()
+    self.rpc.xaya.generatetoaddress (10, myAddr)
+    self.generate (150)
+
+    self.mainLogger.info ("Creating test channel...")
+    channelId = self.openChannel (["foo", "bar"])
+
+    self.mainLogger.info ("Starting channel daemons...")
+    with self.runChannelDaemon (channelId, "foo") as foo, \
+         self.runChannelDaemon (channelId, "bar") as bar:
+
+      daemons = [foo, bar]
+
+      self.mainLogger.info ("Running initialisation sequence...")
+      foo.rpc._notify.setposition ("""
+        xxxx..xx
+        ........
+        xxx.xxx.
+        ........
+        xx.xx.xx
+        ........
+        ........
+        ........
+      """)
+      bar.rpc._notify.setposition ("""
+        ........
+        ........
+        ........
+        xxxx..xx
+        ........
+        xxx.xxx.
+        ........
+        xx.xx.xx
+      """)
+      _, state = self.waitForPhase (daemons, ["shoot"])
+
+      # Make sure it is foo's turn.  If not, miss a shot with bar.
+      if state["current"]["state"]["whoseturn"] == 1:
+        bar.rpc._notify.shoot (row=7, column=0)
+        _, state = self.waitForPhase (daemons, ["shoot"])
+      self.assertEqual (state["current"]["state"]["whoseturn"], 0)
+
+      # Let foo lose the game, but the loser declaration will not be sent
+      # because the wallet is locked.
+      self.mainLogger.info ("Game is lost without loser declaration...")
+      self.lockFunds ()
+      foo.rpc._notify.revealposition ()
+      self.waitForPhase (daemons, ["finished"])
+
+      # Now unlock the wallet and "force close" the channel by requesting
+      # a dispute (which will actually send a resolution move in this case).
+      # and we should get the move in.
+      self.mainLogger.info ("Force closing the channel...")
+      self.unlockFunds ()
+      txid = bar.rpc.filedispute ()
+      self.lockFunds ()
+      self.expectPendingMoves ("foo", [])
+      pendingTxids = self.expectPendingMoves ("bar", ["r"])
+      self.assertEqual (pendingTxids, [txid])
+      self.generate (1)
+      state = bar.getCurrentState ()
+      self.assertEqual (state["existsonchain"], False)
+      self.expectGameState ({
+        "channels": {},
+        "gamestats": {
+          "foo": {"won": 0, "lost": 1},
+          "bar": {"won": 1, "lost": 0},
+        },
+      })
+
+  def generate (self, n):
+    """
+    Mines n blocks, but to an address not owned by the test wallet.
+    This ensures that we keep control over locked/unlocked outputs as
+    needed in this test, and not new outputs get added when mining blocks.
+    """
+
+    notMine = "cdpSgeapVR8ZgRkqA8zF3fDJ2NgaUqm2pu"
+    self.rpc.xaya.generatetoaddress (n, notMine)
+
+
+if __name__ == "__main__":
+  ForceCloseTest ().main ()

--- a/ships/gametest/channel_management.py
+++ b/ships/gametest/channel_management.py
@@ -82,7 +82,7 @@ class ChannelManagementTest (ShipsTest):
 
     # Declare loss in the channel.
     self.mainLogger.info ("Declaring loss in a game to close the channel...")
-    self.sendMove ("foo", {"l": {"id": id1}})
+    self.sendMove ("foo", {"l": {"id": id1, "r": ch1["meta"]["reinit"]}})
     self.generate (1)
 
     state = self.getGameState ()

--- a/ships/gametest/reorg.py
+++ b/ships/gametest/reorg.py
@@ -49,7 +49,8 @@ class ReorgTest (ShipsTest):
     self.mainLogger.info ("Reorg and create alternate reality...")
     self.rpc.xaya.invalidateblock (reorgBlock)
     self.expectChannelState (cid, "first commitment", disputeHeight)
-    self.sendMove ("bar", {"l": {"id": cid}})
+    ch = self.getGameState ()["channels"][cid]
+    self.sendMove ("bar", {"l": {"id": cid, "r": ch["meta"]["reinit"]}})
     self.generate (10)
     self.expectGameState ({
       "gamestats":

--- a/ships/gametest/shipstest.py
+++ b/ships/gametest/shipstest.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2019-2020 The Xaya developers
+# Copyright (C) 2019-2021 The Xaya developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -132,3 +132,20 @@ class ShipsTest (channeltest.TestCase):
 
       self.log.warning ("Phase is %s, waiting to catch up..." % phase)
       time.sleep (0.01)
+
+  def lockFunds (self):
+    """
+    Locks all UTXO's in the wallet, so that no name_update transactions
+    can be made temporarily.  This does not affect signing messages.
+    """
+
+    outputs = self.rpc.xaya.listunspent ()
+    self.rpc.xaya.lockunspent (False, outputs)
+
+  def unlockFunds (self):
+    """
+    Unlocks all outputs in the wallet, so that name_update's can be done
+    again successfully.
+    """
+
+    self.rpc.xaya.lockunspent (True)


### PR DESCRIPTION
This does some necessarily follow-up changes for the update to Xayaships that replaced winner statements with loss declarations (#103, #104):

- The `filedispute` RPC method on the Xayaships channel daemon can now be used to also put the ending state on chain (and thus force-close the channel) if the loser does not declare their loss.
- The loss-declaration move contains now the reinit string, to make sure it can't be replayed in case of a reorg with different channel participants (and perhaps a different flow of the game / different result).