### PR TITLE
Track pending moves for Xayaships

### DIFF
--- a/ships/logic.hpp
+++ b/ships/logic.hpp
@@ -90,13 +90,29 @@ public:
 };
 
 /**
- * PendingMoveProcessor for Xayaships.  This just passes StateProofs recovered
- * from pending disputes and resolutions to ChannelGame::PendingMoves.
+ * PendingMoveProcessor for Xayaships.  This passes StateProofs recovered
+ * from pending disputes and resolutions to ChannelGame::PendingMoves, and
+ * keeps track of basic things like created/joined/aborted channels.
  */
 class ShipsPending : public xaya::ChannelGame::PendingMoves
 {
 
 private:
+
+  /** Pending "create channel" moves, already formatted as JSON.  */
+  Json::Value create;
+
+  /**
+   * Clears the internal state for ships (not including the Clear
+   * method for PendingMoves).
+   */
+  void ClearShips ();
+
+  /**
+   * Tries to process a pending "create channel" move.
+   */
+  void HandleCreateChannel (const Json::Value& obj, const std::string& name,
+                            const xaya::uint256& txid);
 
   /**
    * Tries to process a pending dispute or resolution move.
@@ -116,13 +132,18 @@ private:
 
 protected:
 
+  void Clear () override;
   void AddPendingMove (const Json::Value& mv) override;
 
 public:
 
   ShipsPending (ShipsLogic& g)
     : PendingMoves(g)
-  {}
+  {
+    ClearShips ();
+  }
+
+  Json::Value ToJson () const override;
 
 };
 

--- a/ships/logic.hpp
+++ b/ships/logic.hpp
@@ -103,6 +103,14 @@ private:
   Json::Value create;
 
   /**
+   * Pending "join channel" moves, already formatted as JSON.  If there
+   * are multiple joins for the same channel, we simply return all of them
+   * in a JSON array, as the order in which they would be processed in a
+   * block is not known beforehand.
+   */
+  Json::Value join;
+
+  /**
    * Clears the internal state for ships (not including the Clear
    * method for PendingMoves).
    */
@@ -113,6 +121,12 @@ private:
    */
   void HandleCreateChannel (const Json::Value& obj, const std::string& name,
                             const xaya::uint256& txid);
+
+  /**
+   * Tries to process a pending "join channel" move.
+   */
+  void HandleJoinChannel (xaya::SQLiteDatabase& db, const Json::Value& obj,
+                          const std::string& name);
 
   /**
    * Tries to process a pending dispute or resolution move.

--- a/ships/logic.hpp
+++ b/ships/logic.hpp
@@ -110,6 +110,9 @@ private:
    */
   Json::Value join;
 
+  /** Channels being aborted with pending moves.  */
+  std::set<xaya::uint256> abort;
+
   /**
    * Clears the internal state for ships (not including the Clear
    * method for PendingMoves).
@@ -127,6 +130,12 @@ private:
    */
   void HandleJoinChannel (xaya::SQLiteDatabase& db, const Json::Value& obj,
                           const std::string& name);
+
+  /**
+   * Tries to process a pending "abort channel" move.
+   */
+  void HandleAbortChannel (xaya::SQLiteDatabase& db, const Json::Value& obj,
+                           const std::string& name);
 
   /**
    * Tries to process a pending dispute or resolution move.


### PR DESCRIPTION
This extends the pending tracker for Xayaships:  Previously, we were only tracking state-proofs sent for existing channels (e.g. so that the channel daemon can take advantage of them already before they get confirmed).  With this, we add tracking of create, join and abort channel moves, which will be used by the frontend.