### PR TITLE
Time out ships channels

### DIFF
--- a/ships/README.md
+++ b/ships/README.md
@@ -27,7 +27,8 @@ currently open game channels as needed to process disputes.
 Channels can be opened at any time by sending a move requesting to
 open a channel, and anyone can send a move to join an existing channel
 waiting for a second player.  Channels can be closed anytime by the
-player in it as long as no other has joined.  If there are already
+player in it as long as no other has joined, and they are auto-closed
+if noone joined after some time.  If there are already
 two players in a channel, then any participant can close the channel
 by declaring themselves loser.
 

--- a/ships/logic.cpp
+++ b/ships/logic.cpp
@@ -39,9 +39,9 @@ ShipsLogic::GetInitialStateBlock (unsigned& height, std::string& hashHex) const
   switch (chain)
     {
     case xaya::Chain::MAIN:
-      height = 2'650'000;
+      height = 2'960'000;
       hashHex
-          = "ff155d68419cf3543942ba140c88e5cfeacc74496d87dcffc127974b6c1397a1";
+          = "81c60638621eec528667941d954e044577f0125465ca2ba26347385d5e3aecdd";
       break;
 
     case xaya::Chain::TEST:

--- a/ships/logic.cpp
+++ b/ships/logic.cpp
@@ -100,9 +100,8 @@ ParseCreateChannelMove (const Json::Value& obj, std::string& addr)
  */
 void
 HandleCreateChannel (xaya::SQLiteDatabase& db,
-                     const Json::Value& obj,
-                     const std::string& name,
-                     const xaya::uint256& txid)
+                     const Json::Value& obj, const unsigned height,
+                     const std::string& name, const xaya::uint256& txid)
 {
   std::string addr;
   if (!ParseCreateChannelMove (obj, addr))
@@ -125,6 +124,15 @@ HandleCreateChannel (xaya::SQLiteDatabase& db,
   p->set_name (name);
   p->set_address (addr);
   h->Reinitialise (meta, "");
+
+  auto stmt = db.Prepare (R"(
+    INSERT INTO `channel_extradata`
+      (`id`, `createdheight`, `participants`)
+      VALUES (?1, ?2, 1)
+  )");
+  stmt.Bind (1, h->GetId ());
+  stmt.Bind (2, height);
+  stmt.Execute ();
 }
 
 /**
@@ -233,6 +241,15 @@ HandleJoinChannel (xaya::SQLiteDatabase& db,
   xaya::BoardState state;
   CHECK (InitialBoardState ().SerializeToString (&state));
   h->Reinitialise (newMeta, state);
+
+  auto stmt = db.Prepare (R"(
+    UPDATE `channel_extradata`
+      SET `participants` = ?2
+      WHERE `id` = ?1
+  )");
+  stmt.Bind (1, h->GetId ());
+  stmt.Bind (2, newMeta.participants_size ());
+  stmt.Execute ();
 }
 
 /**
@@ -278,6 +295,24 @@ ParseAbortChannelMove (const Json::Value& obj, const std::string& name,
 }
 
 /**
+ * Deletes a channel from the database by ID.  This deletes it from the
+ * game-channel library managed table, as well as from our extra-data one.
+ */
+void
+DeleteChannelById (xaya::SQLiteDatabase& db, xaya::ChannelsTable& tbl,
+                   const xaya::uint256& id)
+{
+  tbl.DeleteById (id);
+
+  auto stmt = db.Prepare (R"(
+    DELETE FROM `channel_extradata`
+      WHERE `id` = ?1
+  )");
+  stmt.Bind (1, id);
+  stmt.Execute ();
+}
+
+/**
  * Tries to process an "abort channel" move.
  */
 void
@@ -291,7 +326,7 @@ HandleAbortChannel (xaya::SQLiteDatabase& db,
     return;
 
   LOG (INFO) << "Aborting channel " << id.ToHex ();
-  tbl.DeleteById (id);
+  DeleteChannelById (db, tbl, id);
 }
 
 /**
@@ -388,7 +423,7 @@ ShipsLogic::HandleDeclareLoss (xaya::SQLiteDatabase& db,
 
   UpdateStats (db, meta, winner);
   h.reset ();
-  tbl.DeleteById (id);
+  DeleteChannelById (db, tbl, id);
 }
 
 namespace
@@ -485,7 +520,7 @@ ShipsLogic::HandleDisputeResolution (xaya::SQLiteDatabase& db,
 
       UpdateStats (db, meta, pb.winner ());
       h.reset ();
-      tbl.DeleteById (id);
+      DeleteChannelById (db, tbl, id);
     }
 }
 
@@ -526,7 +561,7 @@ ShipsLogic::ProcessExpiredDisputes (xaya::SQLiteDatabase& db,
 
       UpdateStats (db, meta, winner);
       h.reset ();
-      tbl.DeleteById (id);
+      DeleteChannelById (db, tbl, id);
     }
 }
 
@@ -567,6 +602,45 @@ ShipsLogic::UpdateStats (xaya::SQLiteDatabase& db,
   stmt.Bind (2, loserName);
   stmt.Execute ();
 }
+
+namespace
+{
+
+/**
+ * Auto-closes all channels that have just one participant and been open
+ * for a timeout number of blocks.
+ */
+void
+TimeOutChannels (xaya::SQLiteDatabase& db, const unsigned height)
+{
+  /* Make sure we don't underflow for the first couple of blocks, particularly
+     on regtest.  */
+  if (height < CHANNEL_TIMEOUT_BLOCKS)
+    return;
+
+  auto stmt = db.PrepareRo (R"(
+    SELECT `id`, `createdheight`, `participants`
+      FROM `channel_extradata`
+      WHERE `participants` < 2 AND `createdheight` <= ?1
+  )");
+  stmt.Bind (1, height - CHANNEL_TIMEOUT_BLOCKS);
+
+  unsigned num = 0;
+  xaya::ChannelsTable tbl(db);
+  while (stmt.Step ())
+    {
+      const auto id = stmt.Get<xaya::uint256> (0);
+      CHECK_EQ (stmt.Get<int> (1), height - CHANNEL_TIMEOUT_BLOCKS);
+      CHECK_EQ (stmt.Get<int> (2), 1);
+      DeleteChannelById (db, tbl, id);
+      ++num;
+    }
+
+  LOG_IF (INFO, num > 0)
+      << "Timed out " << num << " channels at height " << height;
+}
+
+} // anonymous namespace
 
 void
 ShipsLogic::UpdateState (xaya::SQLiteDatabase& db, const Json::Value& blockData)
@@ -612,7 +686,7 @@ ShipsLogic::UpdateState (xaya::SQLiteDatabase& db, const Json::Value& blockData)
           continue;
         }
 
-      HandleCreateChannel (db, data["c"], name, txid);
+      HandleCreateChannel (db, data["c"], height, name, txid);
       HandleJoinChannel (db, data["j"], name, txid);
       HandleAbortChannel (db, data["a"], name);
       HandleDeclareLoss (db, data["l"], name);
@@ -621,6 +695,7 @@ ShipsLogic::UpdateState (xaya::SQLiteDatabase& db, const Json::Value& blockData)
     }
 
   ProcessExpiredDisputes (db, height);
+  TimeOutChannels (db, height);
 }
 
 Json::Value

--- a/ships/logic.hpp
+++ b/ships/logic.hpp
@@ -26,6 +26,12 @@ namespace ships
 constexpr unsigned DISPUTE_BLOCKS = 10;
 
 /**
+ * The number of blocks until a channel that has not been joined by a second
+ * participant is auto-closed again.
+ */
+constexpr unsigned CHANNEL_TIMEOUT_BLOCKS = 12;
+
+/**
  * The main game logic for the on-chain part of Xayaships.  This takes care of
  * the public game state (win/loss statistics for names), management of open
  * channels and dispute processing.

--- a/ships/schema.sql
+++ b/ships/schema.sql
@@ -1,4 +1,4 @@
--- Copyright (C) 2019 The Xaya developers
+-- Copyright (C) 2019-2021 The Xaya developers
 -- Distributed under the MIT software license, see the accompanying
 -- file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -15,3 +15,23 @@ CREATE TABLE IF NOT EXISTS `game_stats` (
   `lost` INTEGER NOT NULL
 
 );
+
+-- Extra data about open channels, in addition to what the core game-channel
+-- library holds and uses.
+CREATE TABLE IF NOT EXISTS `channel_extradata` (
+
+  -- The channel ID this entry is for.
+  `id` BLOB PRIMARY KEY,
+
+  -- The height when the channel was created.
+  `createdheight` INTEGER NOT NULL,
+
+  -- Number of participants in the channel.
+  `participants` INTEGER NOT NULL
+
+);
+
+-- Allows to query for channels that were created some time ago and
+-- have not yet gotten a second participant.
+CREATE INDEX IF NOT EXISTS `channel_extradata_by_height_and_participants`
+  ON `channel_extradata` (`createdheight`, `participants`);


### PR DESCRIPTION
This modifies the Xayaships channel management, so that channels without a second participant are automatically closed after 12 blocks.  Since this is a hardfork of the game state (and we are not going to keep the old state), it also bumps up the mainnet start height to a recent block.