### PR TITLE
Allow changing the JSON-RPC version used to connect to Xaya Core

### DIFF
--- a/mover/main.cpp
+++ b/mover/main.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2020 The Xaya developers
+// Copyright (C) 2018-2021 The Xaya developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -22,6 +22,8 @@ namespace
 
 DEFINE_string (xaya_rpc_url, "",
                "URL at which Xaya Core's JSON-RPC interface is available");
+DEFINE_int32 (xaya_rpc_protocol, 1,
+              "JSON-RPC version for connecting to Xaya Core");
 DEFINE_bool (xaya_rpc_wait, false,
              "whether to wait on startup for Xaya Core to be available");
 
@@ -72,6 +74,7 @@ main (int argc, char** argv)
 
   xaya::GameDaemonConfiguration config;
   config.XayaRpcUrl = FLAGS_xaya_rpc_url;
+  config.XayaJsonRpcProtocol = FLAGS_xaya_rpc_protocol;
   config.XayaRpcWait = FLAGS_xaya_rpc_wait;
   if (FLAGS_game_rpc_port != 0)
     {

--- a/nonfungible/main.cpp
+++ b/nonfungible/main.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 The Xaya developers
+// Copyright (C) 2020-2021 The Xaya developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -21,6 +21,8 @@ namespace
 
 DEFINE_string (xaya_rpc_url, "",
                "URL at which Xaya Core's JSON-RPC interface is available");
+DEFINE_int32 (xaya_rpc_protocol, 1,
+              "JSON-RPC version for connecting to Xaya Core");
 DEFINE_bool (xaya_rpc_wait, false,
              "whether to wait on startup for Xaya Core to be available");
 
@@ -93,6 +95,7 @@ main (int argc, char** argv)
 
   xaya::GameDaemonConfiguration config;
   config.XayaRpcUrl = FLAGS_xaya_rpc_url;
+  config.XayaJsonRpcProtocol = FLAGS_xaya_rpc_protocol;
   config.XayaRpcWait = FLAGS_xaya_rpc_wait;
   if (FLAGS_game_rpc_port != 0)
     {

--- a/ships/main-gsp.cpp
+++ b/ships/main-gsp.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2020 The Xaya developers
+// Copyright (C) 2019-2021 The Xaya developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -22,6 +22,8 @@ namespace
 
 DEFINE_string (xaya_rpc_url, "",
                "URL at which Xaya Core's JSON-RPC interface is available");
+DEFINE_int32 (xaya_rpc_protocol, 1,
+              "JSON-RPC version for connecting to Xaya Core");
 DEFINE_bool (xaya_rpc_wait, false,
              "whether to wait on startup for Xaya Core to be available");
 
@@ -67,6 +69,7 @@ main (int argc, char** argv)
 
   xaya::GameDaemonConfiguration config;
   config.XayaRpcUrl = FLAGS_xaya_rpc_url;
+  config.XayaJsonRpcProtocol = FLAGS_xaya_rpc_protocol;
   config.XayaRpcWait = FLAGS_xaya_rpc_wait;
   if (FLAGS_game_rpc_port != 0)
     {

--- a/xayagame/defaultmain.hpp
+++ b/xayagame/defaultmain.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2020 The Xaya developers
+// Copyright (C) 2018-2021 The Xaya developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -164,6 +164,13 @@ struct GameDaemonConfiguration
    *  http://user:password@localhost:port
    */
   std::string XayaRpcUrl;
+
+  /**
+   * The JSON-RPC protocol version that should be used when talking to Xaya.
+   * For a real Xaya Core, this should be 1.  In other situations (e.g.
+   * when using Xaya X), it could be set to 2.
+   */
+  int XayaJsonRpcProtocol = 1;
 
   /**
    * The minimum required Xaya Core version.  By default, this is

--- a/xayagame/game.cpp
+++ b/xayagame/game.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2020 The Xaya developers
+// Copyright (C) 2018-2021 The Xaya developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -42,8 +42,6 @@ Game::Game (const std::string& id)
   genesisHash.SetNull ();
   zmq.AddListener (gameId, this);
 }
-
-jsonrpc::clientVersion_t Game::rpcClientVersion = jsonrpc::JSONRPC_CLIENT_V1;
 
 std::string
 Game::StateToString (const State s)
@@ -395,13 +393,14 @@ Game::PendingMove (const std::string& id, const Json::Value& data)
 }
 
 void
-Game::ConnectRpcClient (jsonrpc::IClientConnector& conn)
+Game::ConnectRpcClient (jsonrpc::IClientConnector& conn,
+                        const jsonrpc::clientVersion_t version)
 {
   std::lock_guard<std::mutex> lock(mut);
   CHECK (rpcClient == nullptr) << "RPC client is already connected";
   CHECK (chain == Chain::UNKNOWN);
 
-  rpcClient = std::make_unique<XayaRpcClient> (conn, rpcClientVersion);
+  rpcClient = std::make_unique<XayaRpcClient> (conn, version);
 
   const Json::Value info = rpcClient->getblockchaininfo ();
   const std::string chainStr = info["chain"].asString ();

--- a/xayagame/game.hpp
+++ b/xayagame/game.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2020 The Xaya developers
+// Copyright (C) 2018-2021 The Xaya developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -174,13 +174,6 @@ private:
   /** The pruning queue if we are pruning.  */
   std::unique_ptr<internal::PruningQueue> pruningQueue;
 
-  /**
-   * The JSON-RPC version to use for talking to Xaya Core.  The actual daemon
-   * needs V1, but for the unit test (where the server is mocked and set up
-   * based on jsonrpccpp), we want V2.
-   */
-  static jsonrpc::clientVersion_t rpcClientVersion;
-
   void BlockAttach (const std::string& id, const Json::Value& data,
                     bool seqMismatch) override;
   void BlockDetach (const std::string& id, const Json::Value& data,
@@ -308,9 +301,13 @@ public:
 
   /**
    * Sets up the RPC client based on the given connector.  This must only
-   * be called once.
+   * be called once.  The JSON-RPC protocol version to use can be specified.
+   * V1 is what needs to be used with a real Xaya Core instance, while
+   * unit tests and other situations (e.g. Xaya X) need V2.
    */
-  void ConnectRpcClient (jsonrpc::IClientConnector& conn);
+  void ConnectRpcClient (
+      jsonrpc::IClientConnector& conn,
+      jsonrpc::clientVersion_t version = jsonrpc::JSONRPC_CLIENT_V1);
 
   /**
    * Returns the version of the connected Xaya Core daemon in the form

--- a/xayagame/game_tests.cpp
+++ b/xayagame/game_tests.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2020 The Xaya developers
+// Copyright (C) 2018-2021 The Xaya developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -372,6 +372,16 @@ protected:
                                       "", seqMismatch);
   }
 
+  /**
+   * Connects the given Game instance to our mock server.
+   */
+  void
+  ConnectToMockRpc (Game& g)
+  {
+    g.ConnectRpcClient (mockXayaServer.GetClientConnector (),
+                        jsonrpc::JSONRPC_CLIENT_V2);
+  }
+
 };
 
 /* ************************************************************************** */
@@ -386,7 +396,7 @@ TEST_F (XayaVersionTests, Works)
       .WillOnce (Return (networkInfo));
 
   Game g(GAME_ID);
-  g.ConnectRpcClient (mockXayaServer.GetClientConnector ());
+  ConnectToMockRpc (g);
   EXPECT_EQ (g.GetXayaVersion (), 1020300);
 }
 
@@ -398,7 +408,7 @@ TEST_F (ChainDetectionTests, ChainDetected)
 {
   Game g(GAME_ID);
   mockXayaServer->SetBestBlock (0, BlockHash (0));
-  g.ConnectRpcClient (mockXayaServer.GetClientConnector ());
+  ConnectToMockRpc (g);
   EXPECT_TRUE (g.GetChain () == Chain::MAIN);
 }
 
@@ -415,8 +425,8 @@ TEST_F (ChainDetectionTests, Reconnection)
     {
       mockXayaServer->StartListening ();
       mockXayaServer->SetBestBlock (0, BlockHash (0));
-      g.ConnectRpcClient (mockXayaServer.GetClientConnector ());
-      g.ConnectRpcClient (mockXayaServer.GetClientConnector ());
+      ConnectToMockRpc (g);
+      ConnectToMockRpc (g);
     },
     "RPC client is already connected");
 }
@@ -440,7 +450,7 @@ TEST_F (DetectZmqEndpointTests, BlocksWithoutPending)
 
   Game g(GAME_ID);
   mockXayaServer->SetBestBlock (0, BlockHash (0));
-  g.ConnectRpcClient (mockXayaServer.GetClientConnector ());
+  ConnectToMockRpc (g);
   ASSERT_TRUE (g.DetectZmqEndpoint ());
   EXPECT_EQ (GetZmqEndpoint (g), "address");
   EXPECT_EQ (GetZmqEndpointPending (g), "");
@@ -460,7 +470,7 @@ TEST_F (DetectZmqEndpointTests, BlocksAndPending)
 
   Game g(GAME_ID);
   mockXayaServer->SetBestBlock (0, BlockHash (0));
-  g.ConnectRpcClient (mockXayaServer.GetClientConnector ());
+  ConnectToMockRpc (g);
   ASSERT_TRUE (g.DetectZmqEndpoint ());
   EXPECT_EQ (GetZmqEndpoint (g), "address blocks");
   EXPECT_EQ (GetZmqEndpointPending (g), "address pending");
@@ -480,7 +490,7 @@ TEST_F (DetectZmqEndpointTests, NotSet)
 
   Game g(GAME_ID);
   mockXayaServer->SetBestBlock (0, BlockHash (0));
-  g.ConnectRpcClient (mockXayaServer.GetClientConnector ());
+  ConnectToMockRpc (g);
   ASSERT_FALSE (g.DetectZmqEndpoint ());
   EXPECT_EQ (GetZmqEndpoint (g), "");
 }
@@ -507,7 +517,7 @@ TEST_F (TrackGameTests, CallsMade)
 
   Game g(GAME_ID);
   mockXayaServer->SetBestBlock (0, BlockHash (0));
-  g.ConnectRpcClient (mockXayaServer.GetClientConnector ());
+  ConnectToMockRpc (g);
   TrackGame (g);
   UntrackGame (g);
 }
@@ -539,7 +549,7 @@ protected:
         .WillRepeatedly (Return (GAME_GENESIS_HASH));
 
     mockXayaServer->SetBestBlock (0, BlockHash (0));
-    g.ConnectRpcClient (mockXayaServer.GetClientConnector ());
+    ConnectToMockRpc (g);
 
     g.SetStorage (storage);
     g.SetGameLogic (rules);
@@ -717,7 +727,7 @@ TEST_F (GetCurrentJsonStateTests, HeightResolvedViaRpc)
      state).  */
   Game freshGame(GAME_ID);
   TestGame freshRules;
-  freshGame.ConnectRpcClient (mockXayaServer.GetClientConnector ());
+  ConnectToMockRpc (freshGame);
   freshGame.SetStorage (storage);
   freshGame.SetGameLogic (freshRules);
   ReinitialiseState (freshGame);

--- a/xayagame/testutils.hpp
+++ b/xayagame/testutils.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2019 The Xaya developers
+// Copyright (C) 2018-2021 The Xaya developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -264,14 +264,6 @@ protected:
   explicit GameTestFixture (const std::string& id)
     : gameId(id)
   {}
-
-  static void
-  SetUpTestCase ()
-  {
-    /* Use JSON-RPC V2 by the RPC client in Game.  It seems that V1 to V1
-       does not work with jsonrpccpp for some reason.  */
-    Game::rpcClientVersion = jsonrpc::JSONRPC_CLIENT_V2;
-  }
 
   static std::string
   GetZmqEndpoint (const Game& g)


### PR DESCRIPTION
This introduces a flag with `DefaultMain` and associated command-line parameters for the GSP binaries (`--xaya_rpc_protocol`), which can be used to choose the JSON-RPC version used to connect to Xaya Core.  For a real Xaya Core, it should be 1 (the default), but it may be useful to use 2 for other servers in the future, e.g. [Xaya X](https://github.com/xaya/xayax).