### PR TITLE
Some cleanups in the Python test framework

### DIFF
--- a/gamechannel/channeltest.py
+++ b/gamechannel/channeltest.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2019-2020 The Xaya developers
+# Copyright (C) 2019-2021 The Xaya developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -160,10 +160,7 @@ class TestCase (XayaGameTest):
   def setup (self):
     super (TestCase, self).setup ()
 
-    bcPort = random.randint (1024, 3000)
-    self.nextChannelPort = bcPort + 1
-    self.log.info ("Using ports starting from %d for channel daemons" % bcPort)
-
+    bcPort = next (self.ports)
     self.broadcast = rpcbroadcast.Server ("localhost", bcPort)
     self.bcurl = "http://localhost:%d" % bcPort
     def serveBroadcast ():
@@ -183,9 +180,7 @@ class TestCase (XayaGameTest):
     underlying Daemon instance when entered.
     """
 
-    port = self.nextChannelPort
-    self.nextChannelPort += 1
-    daemon = Daemon (channelId, playerName, self.basedir, port,
+    daemon = Daemon (channelId, playerName, self.basedir, next (self.ports),
                      self.args.channel_daemon)
 
     return DaemonContext (daemon, self.xayanode.rpcurl, self.gamenode.rpcurl,

--- a/mover/gametest/stopped_xayad.py
+++ b/mover/gametest/stopped_xayad.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (C) 2018-2020 The Xaya developers
+# Copyright (C) 2018-2021 The Xaya developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -29,8 +29,9 @@ class StoppedXayadTest (MoverTest):
     # message while xayad is down.  The ZMQ subscription should be back up
     # again automatically.
     self.log.info ("Restarting Xaya daemon")
-    self.stopXayaDaemon ()
-    self.startXayaDaemon ()
+    self.xayanode.stop ()
+    self.xayanode.start ()
+    self.rpc.xaya = self.xayanode.rpc
 
     # Track the game again and sleep a short time, which ensures that the
     # ZMQ subscription has indeed had time to catch up again.

--- a/mover/gametest/xayarpcwait.py
+++ b/mover/gametest/xayarpcwait.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (C) 2018-2020 The Xaya developers
+# Copyright (C) 2018-2021 The Xaya developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -22,11 +22,12 @@ class XayaRpcWaitTest (MoverTest):
     self.generate (1)
 
     self.mainLogger.info ("Stopping Xaya Core and starting the GSP...")
-    self.stopXayaDaemon ()
+    self.xayanode.stop ()
     self.startGameDaemon (extraArgs=["--xaya_rpc_wait"], wait=False)
 
     self.mainLogger.info ("Starting Xaya Core as well to sync up...")
-    self.startXayaDaemon ()
+    self.xayanode.start ()
+    self.rpc.xaya = self.xayanode.rpc
     time.sleep (1)
     self.expectGameState ({"players": {
       "a": {"x": 0, "y": 1, "dir": "up", "steps": 1},

--- a/xayagametest/testcase.py
+++ b/xayagametest/testcase.py
@@ -152,10 +152,10 @@ class XayaGameTest (object):
       game = None
     self.rpc = RpcHandles ()
 
-    self.startXayaDaemon ()
     cleanup = False
     success = False
-    try:
+    with self.xayanode.run ():
+      self.rpc.xaya = self.xayanode.rpc
       self.startGameDaemon ()
       try:
         self.setup ()
@@ -172,12 +172,12 @@ class XayaGameTest (object):
       finally:
         self.shutdown ()
         self.stopGameDaemon ()
-    finally:
-      self.stopXayaDaemon ()
-      if cleanup:
-        self.log.info ("Cleaning up base directory in %s" % self.basedir)
-        shutil.rmtree (self.basedir, ignore_errors=True)
-      logging.shutdown ()
+
+    if cleanup:
+      self.log.info ("Cleaning up base directory in %s" % self.basedir)
+      shutil.rmtree (self.basedir, ignore_errors=True)
+
+    logging.shutdown ()
 
     if not success:
       sys.exit ("Test failed")
@@ -204,21 +204,6 @@ class XayaGameTest (object):
   def run (self):
     self.mainLogger.warning (
         "Test 'run' method not overridden, this tests nothing")
-
-  def startXayaDaemon (self):
-    """
-    Starts the Xaya Core daemon.
-    """
-
-    self.xayanode.start ()
-    self.rpc.xaya = self.xayanode.rpc
-
-  def stopXayaDaemon (self):
-    """
-    Stops the Xaya Core daemon.
-    """
-
-    self.xayanode.stop ()
 
   def startGameDaemon (self, extraArgs=[], wait=True):
     """

--- a/xayagametest/testcase.py
+++ b/xayagametest/testcase.py
@@ -129,17 +129,17 @@ class XayaGameTest (object):
     self.ports = portGenerator (startPort)
 
     zmqPorts = {
-      "blocks": next (self.ports),
+      "gameblocks": next (self.ports),
     }
     if self.zmqPending == "none":
       self.log.info ("Disabling ZMQ for pending moves in Xaya Core")
     elif self.zmqPending == "one socket":
       self.log.info ("Pending moves are sent on the same socket as blocks")
-      zmqPorts["pending"] = zmqPorts["blocks"]
+      zmqPorts["gamepending"] = zmqPorts["gameblocks"]
     elif self.zmqPending == "two sockets":
       self.log.info ("Pending moves are sent on a different socket as blocks")
-      zmqPorts["pending"] = next (self.ports)
-      assert zmqPorts["pending"] != zmqPorts["blocks"]
+      zmqPorts["gamepending"] = next (self.ports)
+      assert zmqPorts["gamepending"] != zmqPorts["gameblocks"]
     else:
       raise AssertionError ("Invalid zmqPending: %s" % self.zmqPending)
 

--- a/xayagametest/xaya.py
+++ b/xayagametest/xaya.py
@@ -75,7 +75,7 @@ class Node ():
         self.log.info ("Daemon %s is up" % data["subversion"])
         break
       except:
-        time.sleep (1)
+        time.sleep (0.1)
 
     # Make sure we have a default wallet.
     wallets = rpc.listwallets ()
@@ -101,6 +101,13 @@ class Node ():
     self.proc.wait ()
     self.proc = None
 
+  def run (self):
+    """
+    Runs the Xaya node with a context manager.
+    """
+
+    return NodeContext (self)
+
   def getWalletRpc (self, wallet):
     """
     Returns the RPC URL to use for a particular wallet as well as
@@ -109,3 +116,19 @@ class Node ():
 
     url = "%s/wallet/%s" % (self.baseRpcUrl, wallet)
     return url, jsonrpclib.ServerProxy (url)
+
+
+class NodeContext ():
+  """
+  A context manager that starts and stops a Xaya node.
+  """
+
+  def __init__ (self, node):
+    self.node = node
+
+  def __enter__ (self):
+    self.node.start ()
+    return self.node
+
+  def __exit__ (self, excType, excValue, traceback):
+    self.node.stop ()

--- a/xayagametest/xaya.py
+++ b/xayagametest/xaya.py
@@ -32,11 +32,9 @@ class Node ():
       "rpcpassword": "xayagametest",
       "rpcport": rpcPort,
       "fallbackfee": 0.001,
-      "zmqpubgameblocks": "tcp://127.0.0.1:%d" % zmqPorts["blocks"],
     }
-    if "pending" in zmqPorts:
-      zmqPending = "tcp://127.0.0.1:%d" % zmqPorts["pending"]
-      self.config["zmqpubgamepending"] = zmqPending
+    for name, port in zmqPorts.items ():
+      self.config["zmqpub%s" % name] = "tcp://127.0.0.1:%d" % port
     self.baseRpcUrl = ("http://%s:%s@localhost:%d"
         % (self.config["rpcuser"], self.config["rpcpassword"],
            self.config["rpcport"]))


### PR DESCRIPTION
This is a collection of commits cleaning up / simplifying various things in the Python test framework:
- New ports are generated as needed with a generator, rather than a base number and hardcoded offsets
- We use a context manager for the `xaya.Node`
- The Xaya node code is generalised to support all ZMQ notifications desired, not just the Xaya-specific ones