### PR TITLE
Abstract "base-chain environment" for integration tests

### DIFF
--- a/mover/gametest/Makefile.am
+++ b/mover/gametest/Makefile.am
@@ -1,5 +1,5 @@
 AM_TESTS_ENVIRONMENT = \
-  PYTHONPATH=$(top_srcdir)
+  PYTHONPATH=$(top_srcdir):$(PYTHONPATH)
 
 TEST_LIBRARY = \
   mover.py \

--- a/nonfungible/gametest/Makefile.am
+++ b/nonfungible/gametest/Makefile.am
@@ -1,5 +1,5 @@
 AM_TESTS_ENVIRONMENT = \
-  PYTHONPATH=$(top_srcdir)
+  PYTHONPATH=$(top_srcdir):$(PYTHONPATH)
 
 TEST_LIBRARY = \
   nftest.py

--- a/ships/gametest/Makefile.am
+++ b/ships/gametest/Makefile.am
@@ -1,5 +1,5 @@
 AM_TESTS_ENVIRONMENT = \
-  PYTHONPATH=$(top_srcdir):$(top_srcdir)/ships
+  PYTHONPATH=$(top_srcdir):$(top_srcdir)/ships:$(PYTHONPATH)
 
 TEST_LIBRARY = shipstest.py
 

--- a/xayagametest/testcase.py
+++ b/xayagametest/testcase.py
@@ -11,6 +11,7 @@ from . import premine
 from . import xaya
 
 import argparse
+from contextlib import contextmanager
 import copy
 import json
 import logging
@@ -128,34 +129,17 @@ class XayaGameTest (object):
         % (startPort))
     self.ports = portGenerator (startPort)
 
-    zmqPorts = {
-      "gameblocks": next (self.ports),
-    }
-    if self.zmqPending == "none":
-      self.log.info ("Disabling ZMQ for pending moves in Xaya Core")
-    elif self.zmqPending == "one socket":
-      self.log.info ("Pending moves are sent on the same socket as blocks")
-      zmqPorts["gamepending"] = zmqPorts["gameblocks"]
-    elif self.zmqPending == "two sockets":
-      self.log.info ("Pending moves are sent on a different socket as blocks")
-      zmqPorts["gamepending"] = next (self.ports)
-      assert zmqPorts["gamepending"] != zmqPorts["gameblocks"]
-    else:
-      raise AssertionError ("Invalid zmqPending: %s" % self.zmqPending)
-
-    self.xayanode = xaya.Node (self.basedir, next (self.ports), zmqPorts,
-                               self.args.xayad_binary)
-    self.gamenode = self.createGameNode ()
-
     class RpcHandles:
-      xaya = None
       game = None
+      # Other fields may be set based on the base-chain environment
+      # (see baseChainEnvironment).
     self.rpc = RpcHandles ()
 
     cleanup = False
     success = False
-    with self.xayanode.run ():
-      self.rpc.xaya = self.xayanode.rpc
+    with self.runBaseChainEnvironment () as env:
+      self.env = env
+      self.gamenode = self.createGameNode ()
       self.startGameDaemon ()
       try:
         self.setup ()
@@ -201,6 +185,39 @@ class XayaGameTest (object):
 
     pass
 
+  @contextmanager
+  def runBaseChainEnvironment (self):
+    """
+    Constructs a context manager that runs the environment instance
+    that should be used for the base chain that the GSP is then linked to.
+
+    By default, this is just a xaya.Environment instance, but tests
+    can override this method to e.g. link to a custom chain using Xaya X.
+    """
+
+    zmqPorts = {
+      "gameblocks": next (self.ports),
+    }
+    if self.zmqPending == "none":
+      self.log.info ("Disabling ZMQ for pending moves in Xaya Core")
+    elif self.zmqPending == "one socket":
+      self.log.info ("Pending moves are sent on the same socket as blocks")
+      zmqPorts["gamepending"] = zmqPorts["gameblocks"]
+    elif self.zmqPending == "two sockets":
+      self.log.info ("Pending moves are sent on a different socket as blocks")
+      zmqPorts["gamepending"] = next (self.ports)
+      assert zmqPorts["gamepending"] != zmqPorts["gameblocks"]
+    else:
+      raise AssertionError ("Invalid zmqPending: %s" % self.zmqPending)
+
+    env = xaya.Environment (self.basedir, next (self.ports), zmqPorts,
+                            self.args.xayad_binary)
+    with env.run ():
+      self.xayanode = env.node
+      self.rpc.xaya = env.node.rpc
+      yield env
+
+
   def run (self):
     self.mainLogger.warning (
         "Test 'run' method not overridden, this tests nothing")
@@ -211,7 +228,10 @@ class XayaGameTest (object):
     the game daemon is restarted and needs to catch up.
     """
 
-    self.gamenode.start (self.xayanode.rpcurl, extraArgs, wait=wait)
+    rpcurl, args = self.env.getGspArguments ()
+    extraArgs.extend (args)
+
+    self.gamenode.start (rpcurl, extraArgs, wait=wait)
     self.rpc.game = self.gamenode.rpc
 
   def stopGameDaemon (self):
@@ -262,20 +282,27 @@ class XayaGameTest (object):
     """
 
     for nm in names:
-      self.rpc.xaya.name_register ("p/" + nm, "{}")
+      self.env.register ("p", nm)
 
-  def registerOrUpdateName (self, name, value, options={}):
+  def registerOrUpdateName (self, name, value, *args, **kwargs):
     """
     Tries to update or register the name with the given value, depending
     on whether or not it already exists.
+
+    Extra arguments are forwarded directly to the environment's
+    move function.
     """
 
-    try:
-      return self.rpc.xaya.name_update (name, value, options)
-    except Exception as exc:
-      self.log.exception (exc)
-      self.log.info ("name_update for %s failed, trying name_register" % name)
-      return self.rpc.xaya.name_register (name, value, options)
+    pos = name.find ("/")
+    assert pos > -1, "'%s' contains no namespace" % name
+
+    ns = name[:pos]
+    base = name[pos + 1:]
+
+    if not self.env.nameExists (ns, base):
+      self.env.register (ns, base)
+
+    return self.env.move (ns, base, value, *args, **kwargs)
 
   def sendMove (self, name, move, options={}, burn=0):
     """
@@ -315,8 +342,7 @@ class XayaGameTest (object):
 
     fcn = getattr (self.rpc.game, method)
 
-    bestblk = self.rpc.xaya.getbestblockhash ()
-    bestheight = self.rpc.xaya.getblockcount ()
+    bestblk, bestheight = self.env.getChainTip ()
 
     while True:
       state = fcn (*args, **kwargs)
@@ -383,8 +409,7 @@ class XayaGameTest (object):
     Generates n new blocks on the Xaya network.
     """
 
-    addr = self.rpc.xaya.getnewaddress ()
-    return self.rpc.xaya.generatetoaddress (n, addr)
+    return self.env.generate (n)
 
   def expectError (self, code, msgRegExp, method, *args, **kwargs):
     """

--- a/xayagametest/xaya.py
+++ b/xayagametest/xaya.py
@@ -6,6 +6,7 @@
 Code for running the Xaya Core daemon as component in an integration test.
 """
 
+from contextlib import contextmanager
 import jsonrpclib
 import logging
 import os
@@ -15,7 +16,7 @@ import subprocess
 import time
 
 
-class Node ():
+class Node:
   """
   An instance of the Xaya Core daemon that is running in regtest mode and
   used as component in an integration test of a Xaya game.
@@ -104,12 +105,17 @@ class Node ():
     self.proc.wait ()
     self.proc = None
 
+  @contextmanager
   def run (self):
     """
     Runs the Xaya node with a context manager.
     """
 
-    return NodeContext (self)
+    self.start ()
+    try:
+      yield self
+    finally:
+      self.stop ()
 
   def getWalletRpc (self, wallet):
     """
@@ -127,17 +133,86 @@ class Node ():
     return url, rpc
 
 
-class NodeContext ():
+class Environment:
   """
-  A context manager that starts and stops a Xaya node.
+  A "base-chain environment" that consists just of a Xaya Core instance.
+
+  This is an abstraction that can be used for testing in situations where
+  a GSP is run not connected directly to Xaya Core, but for instance
+  to a Xaya X instance and some other base chain.  In the present case, however,
+  it is just a simple wrapper around a normal Xaya Core node.
   """
 
-  def __init__ (self, node):
-    self.node = node
+  def __init__ (self, *args, **kwargs):
+    self.node = Node (*args, **kwargs)
 
-  def __enter__ (self):
-    self.node.start ()
-    return self.node
+  @contextmanager
+  def run (self):
+    """
+    Runs the environment in a context.
+    """
 
-  def __exit__ (self, excType, excValue, traceback):
-    self.node.stop ()
+    with self.node.run ():
+      yield self
+
+  def generate (self, num):
+    """
+    Generates num new blocks on the active chain, and returns their hashes
+    in an array.
+    """
+
+    addr = self.node.rpc.getnewaddress ()
+    return self.node.rpc.generatetoaddress (num, addr)
+
+  def getChainTip (self):
+    """
+    Returns the hash and height of the current chain tip according
+    to the base chain (not the GSP).
+    """
+
+    info = self.node.rpc.getblockchaininfo ()
+    return info["bestblockhash"], info["blocks"]
+
+  def nameExists (self, ns, nm):
+    """
+    Returns true if the given namespace/name combination exists, and false
+    if it does not.
+    """
+
+    full = "%s/%s" % (ns, nm)
+    if self.node.rpc.name_pending (full):
+      return True
+
+    try:
+      self.node.rpc.name_show (full)
+      return True
+    except Exception as exc:
+      return False
+
+  def register (self, ns, nm):
+    """
+    Registers a new name with the given namespace and base name.  Returns the
+    transaction ID.
+    """
+
+    return self.node.rpc.name_register ("%s/%s" % (ns, nm))
+
+  def move (self, ns, nm, strval, options={}):
+    """
+    Sends a move with the given name, which is supposed to be existing
+    already.  The move data is already encoded as a string.
+    Returns the transaction ID.
+
+    Arguments beyond strval are non-standard and can be specific to
+    a particular environment.
+    """
+
+    return self.node.rpc.name_update ("%s/%s" % (ns, nm), strval, options)
+
+  def getGspArguments (self):
+    """
+    Returns the Xaya RPC URL and any potential extra arguments that should
+    be used to link a GSP to this environment.
+    """
+
+    return self.node.rpcurl, []


### PR DESCRIPTION
This abstracts out the concept of a "base-chain environment" in the integration-testing framework.  Instead of assuming that we will always run a single Xaya Core instance and link the GSP to it, the environment can take care of running something else replacing Xaya Core, for instance a Xaya X instance with some base chain (which could be Xaya Core again, or something else).