### PR TITLE
Test environment for Ethereum-based chain

### DIFF
--- a/xayagame/game.hpp
+++ b/xayagame/game.hpp
@@ -117,8 +117,13 @@ private:
    * first call to GetInitialState, so that we can avoid calling it all
    * over again on each block before we reach the genesis height.
    */
-  unsigned genesisHeight;
-  /** The game's genesis hash, if already known (zero otherwise).  */
+  int genesisHeight;
+  /**
+   * The game's genesis hash, if already known (zero otherwise).  Games may
+   * specify only a genesisHeight and no hash, in which case the hash will be
+   * zero until we leave PREGENESIS phase and get the actual hash for the
+   * block height from the blockchain daemon.
+   */
   uint256 genesisHash;
 
   /**

--- a/xayagame/gamelogic.hpp
+++ b/xayagame/gamelogic.hpp
@@ -227,7 +227,10 @@ protected:
 
   /**
    * Returns the initial state (as well as the associated block height
-   * and block hash in big-endian hex) for the game.
+   * and block hash in big-endian hex) for the game.  The returned hashHex
+   * may be the empty string, in which case only the genesis height is
+   * specified and any block hash at that height is accepted.  This is useful
+   * e.g. for testing chains that don't have a fixed genesis hash.
    */
   virtual GameStateData GetInitialStateInternal (unsigned& height,
                                                  std::string& hashHex) = 0;

--- a/xayagame/sqlitegame.cpp
+++ b/xayagame/sqlitegame.cpp
@@ -312,7 +312,7 @@ SQLiteGame::Storage::CheckCurrentState (const SQLiteDatabase& db,
   unsigned height;
   std::string initialHashHex;
   game.GetInitialStateBlock (height, initialHashHex);
-  if (hashHex != initialHashHex)
+  if (!initialHashHex.empty () && hashHex != initialHashHex)
     {
       VLOG (1)
           << "Current best block in the database (" << hashHex

--- a/xayagame/sqlitegame_tests.cpp
+++ b/xayagame/sqlitegame_tests.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2020 The Xaya developers
+// Copyright (C) 2018-2021 The Xaya developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -381,7 +381,7 @@ protected:
     rules.Initialise (":memory:");
     rules.InitialiseGameContext (Chain::MAIN, GAME_ID, nullptr);
 
-    SetStartingBlock (GenesisHash ());
+    SetStartingBlock (GENESIS_HEIGHT, GenesisHash ());
 
     game.SetStorage (rules.GetStorage ());
     game.SetGameLogic (rules);
@@ -752,7 +752,7 @@ protected:
 
     CreateChatGame (false);
 
-    SetStartingBlock (GenesisHash ());
+    SetStartingBlock (GENESIS_HEIGHT, GenesisHash ());
     InitialiseState (game, *rules);
     ForceState (game, State::UP_TO_DATE);
   }

--- a/xayagame/testutils.cpp
+++ b/xayagame/testutils.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2019 The Xaya developers
+// Copyright (C) 2018-2021 The Xaya developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -122,8 +122,10 @@ GameTestFixture::CallPendingMove (Game& g, const Json::Value& mv) const
 }
 
 void
-GameTestWithBlockchain::SetStartingBlock (const uint256& hash)
+GameTestWithBlockchain::SetStartingBlock (const unsigned height,
+                                          const uint256& hash)
 {
+  heightOffset = height;
   blockHashes = {hash};
   moveStack.clear ();
 }
@@ -134,7 +136,8 @@ GameTestWithBlockchain::AttachBlock (Game& g, const uint256& hash,
 {
   CHECK (!blockHashes.empty ()) << "No starting block has been set";
   CallBlockAttach (g, "",
-                   blockHashes.back (), hash, blockHashes.size () + 1,
+                   blockHashes.back (), hash,
+                   heightOffset + blockHashes.size (),
                    moves, false);
   blockHashes.push_back (hash);
   moveStack.push_back (moves);
@@ -149,7 +152,8 @@ GameTestWithBlockchain::DetachBlock (Game& g)
   const uint256 hash = blockHashes.back ();
   blockHashes.pop_back ();
   CallBlockDetach (g, "",
-                   blockHashes.back (), hash, blockHashes.size () + 1,
+                   blockHashes.back (), hash,
+                   heightOffset + blockHashes.size (),
                    moveStack.back (), false);
   moveStack.pop_back ();
 }

--- a/xayagame/testutils.hpp
+++ b/xayagame/testutils.hpp
@@ -346,8 +346,15 @@ class GameTestWithBlockchain : public GameTestFixture
 
 private:
 
+  /**
+   * Height offset on top of block hashes, which is effectively the height
+   * that the first entry in blockHashes is at.
+   */
+  unsigned heightOffset;
+
   /** Stack of attached block hashes.  */
   std::vector<uint256> blockHashes;
+
   /**
    * Stack of corresponding move objects (the bottom-most entry in
    * blockHashes was set by SetStartingBlock and doesn't have any moves
@@ -364,7 +371,7 @@ public:
    * the real genesis block, it is just the block from where the next attach
    * will be done).
    */
-  void SetStartingBlock (const uint256& hash);
+  void SetStartingBlock (unsigned height, const uint256& hash);
 
   /**
    * Attaches the given next block on top of the current blockchain stack.

--- a/xayagametest/testcase.py
+++ b/xayagametest/testcase.py
@@ -12,7 +12,6 @@ from . import xaya
 
 import argparse
 from contextlib import contextmanager
-import copy
 import json
 import logging
 import os.path
@@ -360,7 +359,7 @@ class XayaGameTest (object):
 
     return self.env.move (ns, base, value, *args, **kwargs)
 
-  def sendMove (self, name, move, options={}, burn=0):
+  def sendMove (self, name, move, *args, **kwargs):
     """
     Sends a given move for the name.  This calls name_register or name_update,
     depending on whether the name exists already.  It also builds up the
@@ -368,19 +367,9 @@ class XayaGameTest (object):
     """
 
     value = json.dumps ({"g": {self.gameId: move}})
+    return self.registerOrUpdateName ("p/" + name, value, *args, **kwargs)
 
-    opt = copy.deepcopy (options)
-
-    if burn > 0:
-      if "burn" not in opt:
-        opt["burn"] = {}
-      key = "g/%s" % self.gameId
-      assert key not in opt["burn"]
-      opt["burn"][key] = burn
-
-    return self.registerOrUpdateName ("p/" + name, value, opt)
-
-  def adminCommand (self, cmd, options={}):
+  def adminCommand (self, cmd, *args, **kwargs):
     """
     Sends an admin command with the given value.  This calls name_register or
     name_update, depending on whether or not the g/ name for the game being
@@ -388,7 +377,8 @@ class XayaGameTest (object):
     """
 
     value = json.dumps ({"cmd": cmd})
-    return self.registerOrUpdateName ("g/" + self.gameId, value, options)
+    return self.registerOrUpdateName ("g/" + self.gameId, value,
+                                      *args, **kwargs)
 
   def getCustomState (self, field, method, *args, **kwargs):
     """

--- a/xayagametest/testcase.py
+++ b/xayagametest/testcase.py
@@ -28,6 +28,7 @@ from jsonrpclib import ProtocolError
 
 XAYAD_BINARY_DEFAULT = "/usr/local/bin/xayad"
 XCORE_BINARY_DEFAULT = "/usr/local/bin/xayax-core"
+XETH_BINARY_DEFAULT = "/usr/local/bin/xayax-eth"
 DEFAULT_DIR = "/tmp"
 DIR_PREFIX = "xayagametest_"
 
@@ -66,6 +67,8 @@ class XayaGameTest (object):
                          help="xayad binary to use in the test")
     parser.add_argument ("--xcore_binary", default=XCORE_BINARY_DEFAULT,
                          help="xayax-core binary to use")
+    parser.add_argument ("--xeth_binary", default=XETH_BINARY_DEFAULT,
+                         help="xayax-eth binary to use")
     parser.add_argument ("--game_daemon", default=gameBinaryDefault,
                          help="game daemon binary to use in the test")
     parser.add_argument ("--run_game_with", default="",
@@ -303,6 +306,26 @@ class XayaGameTest (object):
     with env.run ():
       self.xayanode = env.xayanode
       self.rpc.xaya = env.xayanode.rpc
+      yield env
+
+  @contextmanager
+  def runXayaXEthEnvironment (self):
+    """
+    Runs a base-chain environment that uses Xaya X to link to an
+    Ethereum-like test chain (based on Ganache).
+    """
+
+    if self.zmqPending != "one socket":
+      raise AssertionError ("Xaya-X-Eth only supports one-socket pending")
+
+    from xayax import eth
+    env = eth.Environment (self.basedir, self.ports, self.args.xeth_binary)
+
+    with env.run ():
+      self.ethnode = env.ganache
+      self.contracts = env.contracts
+      self.rpc.eth = env.createGanacheRpc ()
+      self.w3 = env.ganache.w3
       yield env
 
   ##############################################################################

--- a/xayagametest/xaya.py
+++ b/xayagametest/xaya.py
@@ -7,6 +7,7 @@ Code for running the Xaya Core daemon as component in an integration test.
 """
 
 from contextlib import contextmanager
+import copy
 import jsonrpclib
 import logging
 import os
@@ -197,7 +198,7 @@ class Environment:
 
     return self.node.rpc.name_register ("%s/%s" % (ns, nm))
 
-  def move (self, ns, nm, strval, options={}):
+  def move (self, ns, nm, strval, options={}, burn=0):
     """
     Sends a move with the given name, which is supposed to be existing
     already.  The move data is already encoded as a string.
@@ -207,7 +208,16 @@ class Environment:
     a particular environment.
     """
 
-    return self.node.rpc.name_update ("%s/%s" % (ns, nm), strval, options)
+    opt = copy.deepcopy (options)
+
+    if burn > 0:
+      if "burn" not in opt:
+        opt["burn"] = {}
+      key = "g/%s" % self.gameId
+      assert key not in opt["burn"]
+      opt["burn"][key] = burn
+
+    return self.node.rpc.name_update ("%s/%s" % (ns, nm), strval, opt)
 
   def getGspArguments (self):
     """


### PR DESCRIPTION
Implement a test environment (in xayagametest) for an Ethereum-based chain (using [Xaya X](https://github.com/xaya/xayax) and Ganache).

The main change here is to optionally allow games to specify just a genesis height without a corresponding hash, in which case the hash will be taken from the blockchain and any hash is accepted at the specified height.  This is required since Ganache's genesis block does not have a fixed block hash.