### PR TITLE
Websocket server

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,3 +1,5 @@
 ACLOCAL_AMFLAGS = ${ACLOCAL_FLAGS} -Im4
 
-SUBDIRS = xayautil xayagame xayagametest mover nonfungible gamechannel ships
+SUBDIRS = \
+  xayautil xayagame xayagametest websocket \
+  mover nonfungible gamechannel ships

--- a/configure.ac
+++ b/configure.ac
@@ -68,6 +68,7 @@ AC_CONFIG_FILES([
   ships/Makefile \
   ships/channeltest/Makefile \
   ships/gametest/Makefile \
+  websocket/Makefile \
   xayagame/Makefile \
   xayagametest/Makefile \
   xayautil/Makefile \

--- a/websocket/Dockerfile
+++ b/websocket/Dockerfile
@@ -1,0 +1,18 @@
+# Builds a Docker image that has the GSP websocket server installed
+# and ready to run.
+
+FROM alpine
+RUN apk add --no-cache \
+  python3 \
+  py3-jsonrpclib \
+  py3-pip
+
+COPY websocket/gsp-websocket-server.py /usr/local/bin/
+
+RUN addgroup -S runner && adduser -S runner -G runner
+USER runner
+
+RUN pip3 install websocket-server
+
+LABEL description="Image with the GSP websocket server script"
+ENTRYPOINT ["/usr/local/bin/gsp-websocket-server.py"]

--- a/websocket/Makefile.am
+++ b/websocket/Makefile.am
@@ -1,0 +1,1 @@
+bin_SCRIPTS = gsp-websocket-server.py

--- a/websocket/README.md
+++ b/websocket/README.md
@@ -1,0 +1,6 @@
+# Websocket Notification Server
+
+This directory contains a simple Websocket server which can connect to
+a GSP built with libxayagame.  It uses the `waitforchange` RPC method
+to poll the GSP for updates, and pushes notifications to all connected
+clients whenever a new best block is found.

--- a/websocket/gsp-websocket-server.py
+++ b/websocket/gsp-websocket-server.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2021 The Xaya developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+import argparse
+from contextlib import contextmanager
+import json
+import logging
+import threading
+
+import jsonrpclib
+from websocket_server import WebsocketServer
+
+
+class Server:
+  """
+  A Websocket server that polls a GSP's waitforchange RPC interface and
+  pushes notifications to connected clients.
+  """
+
+  def __init__ (self, host, port, gspRpcUrl):
+    self.srv = WebsocketServer (host=host, port=port, loglevel=logging.INFO)
+    self.rpc = jsonrpclib.ServerProxy (gspRpcUrl)
+
+  def run (self):
+    """
+    Starts the server, GSP polling thread and blocks forever while
+    the server is running.
+    """
+
+    with self.pollingWorker ():
+      self.srv.run_forever ()
+
+  @contextmanager
+  def pollingWorker (self):
+    """
+    Runs a new polling worker task in a managed context.  When the context
+    is exited, the worker is stopped.
+    """
+
+    mut = threading.Lock ()
+    shouldStop = False
+
+    def loop ():
+      knownBlock = ""
+      while True:
+        newBlock = self.rpc.waitforchange (knownBlock)
+        if newBlock != knownBlock:
+          self.pushNewBlock (newBlock)
+          knownBlock = newBlock
+        with mut:
+          if shouldStop:
+            return
+
+    thread = threading.Thread (target=loop)
+    thread.start ()
+
+    try:
+      yield
+    finally:
+      with mut:
+        shouldStop = True
+      thread.join ()
+
+  def pushNewBlock (self, blockHash):
+    data = {
+      "jsonrpc": "2.0",
+      "method": "newblock",
+      "params": [blockHash],
+    }
+    msg = json.dumps (data, separators=(",", ":"))
+    self.srv.send_message_to_all (msg)
+
+
+if __name__ == "__main__":
+  desc = "Runs a Websocket server that forwards notifications from a GSP to" \
+         " connected clients."
+  parser = argparse.ArgumentParser (description=desc)
+  parser.add_argument ("--port", required=True, type=int,
+                       help="Port to listen on for Websocket connections")
+  parser.add_argument ("--host", default="0.0.0.0",
+                       help="Host to listen on for Websocket connections")
+  parser.add_argument ("--gsp_rpc_url", required=True,
+                       help="URL for the GSP's JSON-RPC interface")
+  args = parser.parse_args ()
+
+  srv = Server (args.host, args.port, args.gsp_rpc_url)
+  srv.run ()


### PR DESCRIPTION
This adds a simple Python script based on [`python-websocket-server`](https://github.com/Pithikos/python-websocket-server), which runs a websocket server that pushes new-block-notifications from a GSP (from `waitforchange`) to a websocket client.  This is useful for web-based client applications like SME.