### PR TITLE
Decouple core channel code from RPC connections

### DIFF
--- a/gamechannel/Makefile.am
+++ b/gamechannel/Makefile.am
@@ -96,14 +96,28 @@ pyproto_PYTHON = proto/__init__.py $(PROTOPY)
 AM_TESTS_ENVIRONMENT = \
   PYTHONPATH=$(top_srcdir)
 
+check_LTLIBRARIES = libtestutils.la
 check_PROGRAMS = tests test_rpcbroadcast
 TESTS = tests $(PYTHONTESTS)
+
+libtestutils_la_CXXFLAGS = \
+  -I$(top_srcdir) \
+  $(GLOG_CFLAGS) $(GTEST_CFLAGS)
+libtestutils_la_LIBADD = \
+  $(builddir)/libgamechannel.la \
+  $(top_builddir)/xayautil/libxayautil.la \
+  $(GLOG_LIBS) $(GTEST_LIBS)
+libtestutils_la_SOURCES = \
+  testutils.cpp
+TESTUTILHEADERS = \
+  testutils.hpp
 
 tests_CXXFLAGS = \
   -I$(top_srcdir) \
   $(JSONCPP_CFLAGS) $(JSONRPCCLIENT_CFLAGS) $(JSONRPCSERVER_CFLAGS) \
   $(GLOG_CFLAGS) $(GTEST_CFLAGS) $(SQLITE3_CFLAGS) $(PROTOBUF_CFLAGS)
 tests_LDADD = \
+  $(builddir)/libtestutils.la \
   $(builddir)/libgamechannel.la \
   $(top_builddir)/xayautil/libxayautil.la \
   $(top_builddir)/xayagame/libxayagame.la \
@@ -128,10 +142,12 @@ tests_SOURCES = \
   testgame_tests.cpp \
   \
   testgame.cpp
-check_HEADERS = \
+TESTHEADERS = \
   channelmanager_tests.hpp \
   \
   testgame.hpp
+
+check_HEADERS = $(TESTUTILHEADERS) $(TESTHEADERS)
 
 test_rpcbroadcast_CXXFLAGS = \
   -I$(top_srcdir) \

--- a/gamechannel/boardrules.hpp
+++ b/gamechannel/boardrules.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 The Xaya developers
+// Copyright (C) 2019-2022 The Xaya developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -8,7 +8,6 @@
 #include "proto/metadata.pb.h"
 #include "protoversion.hpp"
 
-#include <xayagame/rpc-stubs/xayarpcclient.h>
 #include <xayautil/uint256.hpp>
 
 #include <json/json.h>
@@ -141,8 +140,7 @@ public:
    * not represent a move at all, or because the move is invalid in the
    * context of the given old state).
    */
-  virtual bool ApplyMove (XayaRpcClient& rpc, const BoardMove& mv,
-                          BoardState& newState) const = 0;
+  virtual bool ApplyMove (const BoardMove& mv, BoardState& newState) const = 0;
 
   /**
    * Returns a JSON representation of the current board state.  This is used

--- a/gamechannel/channelgame.hpp
+++ b/gamechannel/channelgame.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2020 The Xaya developers
+// Copyright (C) 2019-2022 The Xaya developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -7,6 +7,7 @@
 
 #include "boardrules.hpp"
 #include "database.hpp"
+#include "signatures.hpp"
 
 #include "proto/metadata.pb.h"
 #include "proto/stateproof.pb.h"
@@ -26,6 +27,15 @@ namespace xaya
  */
 class ChannelGame : public SQLiteGame
 {
+
+private:
+
+  /**
+   * The default signature verifier based on the game's underlying
+   * RPC connection.  This is lazy constructed on first request (and then
+   * uses GetXayaRpc() under the hood).
+   */
+  std::unique_ptr<RpcSignatureVerifier> verifier;
 
 protected:
 
@@ -61,6 +71,13 @@ protected:
    * in that case, the on-chain state will simply be updated.
    */
   bool ProcessResolution (ChannelData& ch, const proto::StateProof& proof);
+
+  /**
+   * Returns the signature verifier to be used for the game's state proofs.
+   * By default, it uses verification based on the Xaya RPC "verifymessage",
+   * but that can be overridden by subclasses if desired.
+   */
+  virtual const SignatureVerifier& GetSignatureVerifier ();
 
   /**
    * This method needs to be overridden to provide an instance of BoardRules

--- a/gamechannel/channelgame_tests.cpp
+++ b/gamechannel/channelgame_tests.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2020 The Xaya developers
+// Copyright (C) 2019-2022 The Xaya developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -52,9 +52,9 @@ protected:
     meta.add_participants ()->set_address ("addr0");
     meta.add_participants ()->set_address ("addr1");
 
-    ValidSignature ("sgn0", "addr0");
-    ValidSignature ("sgn1", "addr1");
-    ValidSignature ("sgn42", "addr42");
+    verifier.SetValid ("sgn0", "addr0");
+    verifier.SetValid ("sgn1", "addr1");
+    verifier.SetValid ("sgn42", "addr42");
   }
 
   /**

--- a/gamechannel/channelgame_tests.cpp
+++ b/gamechannel/channelgame_tests.cpp
@@ -451,8 +451,9 @@ protected:
   PendingMovesTests ()
     : proc(game)
   {
-    proc.InitialiseGameContext (Chain::MAIN, "add",
-                                &mockXayaServer.GetClient ());
+    /* All tests work without requiring a signature verifier, thus we
+       do not need to set a mock Xaya RPC server.  */
+    proc.InitialiseGameContext (Chain::MAIN, "add", nullptr);
   }
 
   /**

--- a/gamechannel/channelmanager.cpp
+++ b/gamechannel/channelmanager.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2021 The Xaya developers
+// Copyright (C) 2019-2022 The Xaya developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -30,10 +30,10 @@ ChannelManager::DisputeData::DisputeData ()
 }
 
 ChannelManager::ChannelManager (const BoardRules& r, OpenChannel& oc,
-                                XayaRpcClient& c, XayaWalletRpcClient& w,
+                                const SignatureVerifier& v, SignatureSigner& s,
                                 const uint256& id, const std::string& name)
-  : rules(r), game(oc), rpc(c), wallet(w), channelId(id), playerName(name),
-    boardStates(rules, rpc, channelId)
+  : rules(r), game(oc), verifier(v), signer(s), channelId(id), playerName(name),
+    boardStates(rules, verifier, channelId)
 {
   blockHash.SetNull ();
   pendingPutStateOnChain.SetNull ();
@@ -312,7 +312,7 @@ ChannelManager::ApplyLocalMove (const BoardMove& mv)
   CHECK (!stopped && exists);
 
   proto::StateProof newProof;
-  if (!ExtendStateProof (rpc, wallet, rules, channelId,
+  if (!ExtendStateProof (verifier, signer, rules, channelId,
                          boardStates.GetMetadata (),
                          boardStates.GetStateProof (), mv, newProof))
     {

--- a/gamechannel/channelmanager.hpp
+++ b/gamechannel/channelmanager.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2021 The Xaya developers
+// Copyright (C) 2019-2022 The Xaya developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -10,11 +10,10 @@
 #include "movesender.hpp"
 #include "openchannel.hpp"
 #include "rollingstate.hpp"
+#include "signatures.hpp"
 
 #include "proto/stateproof.pb.h"
 
-#include <xayagame/rpc-stubs/xayarpcclient.h>
-#include <xayagame/rpc-stubs/xayawalletrpcclient.h>
 #include <xayautil/uint256.hpp>
 
 #include <json/json.h>
@@ -96,11 +95,10 @@ private:
   /** OpenChannel instance for this game.  */
   OpenChannel& game;
 
-  /** RPC connection to Xaya Core used for verifying signatures.  */
-  XayaRpcClient& rpc;
-
-  /** RPC connection to the Xaya wallet used for signing local moves.  */
-  XayaWalletRpcClient& wallet;
+  /** Verification provider for signatures.  */
+  const SignatureVerifier& verifier;
+  /** Message signer for this user.  */
+  SignatureSigner& signer;
 
   /** The ID of the managed channel.  */
   const uint256 channelId;
@@ -226,7 +224,8 @@ public:
   static constexpr int WAITFORCHANGE_ALWAYS_BLOCK = 0;
 
   explicit ChannelManager (const BoardRules& r, OpenChannel& oc,
-                           XayaRpcClient& c, XayaWalletRpcClient& w,
+                           const SignatureVerifier& v,
+                           SignatureSigner& s,
                            const uint256& id, const std::string& name);
 
   ~ChannelManager ();

--- a/gamechannel/channelmanager_tests.cpp
+++ b/gamechannel/channelmanager_tests.cpp
@@ -116,14 +116,12 @@ class ChannelManagerTests : public ChannelManagerTestFixture
 
 protected:
 
+  MockTransactionSender txSender;
   MoveSender onChain;
   MockOffChainBroadcast offChain;
 
   ChannelManagerTests ()
-    : onChain("game id", channelId, "player",
-              mockXayaServer.GetClient (),
-              mockXayaWallet.GetClient (),
-              game.channel),
+    : onChain("game id", channelId, "player", txSender, game.channel),
       offChain(cm)
   {
     cm.SetMoveSender (onChain);
@@ -131,18 +129,18 @@ protected:
   }
 
   /**
-   * Expects exactly n disputes or resolutions to be sent through the
-   * wallet with name_update's, and checks that the associated state proof
+   * Expects exactly n dispute or resolution to be sent through the
+   * mocked MoveSender, and checks that the associated state proof
    * matches that from GetBoardStates().
    *
-   * Returns the txid that moves will return.
+   * Returns the txids that those moves will return in order.
    */
-  uint256
-  ExpectMoves (const int n, const std::string& type)
+  std::vector<uint256>
+  ExpectMoves (const unsigned n, const std::string& type)
   {
-    auto isOk = [this, type] (const std::string& val)
+    const auto isOk = [this, type] (const std::string& val)
       {
-        VLOG (1) << "name_update sent: " << val;
+        VLOG (1) << "on-chain move sent: " << val;
 
         const auto parsed = ParseJson (val);
         const auto& mv = parsed["g"]["game id"];
@@ -184,12 +182,18 @@ protected:
         return true;
       };
 
-    const uint256 txid = SHA256::Hash ("txid");
-    EXPECT_CALL (*mockXayaWallet, name_update ("p/player", Truly (isOk)))
-        .Times (n)
-        .WillRepeatedly (Return (txid.ToHex ()));
+    return txSender.ExpectSuccess (n, "player", Truly (isOk));
+  }
 
-    return txid;
+  /**
+   * Expects a single move of the given type (as per ExpectMoves).
+   */
+  uint256
+  ExpectMove (const std::string& type)
+  {
+    const auto txids = ExpectMoves (1, type);
+    CHECK_EQ (txids.size (), 1);
+    return txids[0];
   }
 
   /**
@@ -254,7 +258,7 @@ TEST_F (ProcessOnChainTests, Dispute)
 
 TEST_F (ProcessOnChainTests, TriggersResolutionn)
 {
-  ExpectMoves (1, "resolution");
+  ExpectMove ("resolution");
   ProcessOnChain ("0 0", ValidProof ("10 5"), 0);
   cm.ProcessOffChain ("", ValidProof ("12 6"));
   ProcessOnChain ("0 0", ValidProof ("10 5"), 1);
@@ -273,7 +277,7 @@ TEST_F (ProcessOffChainTests, UpdatesState)
 
 TEST_F (ProcessOffChainTests, TriggersResolutionn)
 {
-  ExpectMoves (1, "resolution");
+  ExpectMove ("resolution");
   ProcessOnChain ("0 0", ValidProof ("10 5"), 1);
   cm.ProcessOffChain ("", ValidProof ("12 6"));
 }
@@ -323,7 +327,7 @@ TEST_F (ProcessLocalMoveTests, Valid)
 TEST_F (ProcessLocalMoveTests, TriggersResolution)
 {
   ExpectOneBroadcast ("11 6");
-  ExpectMoves (1, "resolution");
+  ExpectMove ("resolution");
   ProcessOnChain ("0 0", ValidProof ("10 5"), 1);
   cm.ProcessLocalMove ("1");
 }
@@ -367,7 +371,7 @@ TEST_F (AutoMoveTests, NoAutoMove)
 TEST_F (AutoMoveTests, WithDisputeResolution)
 {
   ExpectOneBroadcast ("50 6");
-  ExpectMoves (1, "resolution");
+  ExpectMove ("resolution");
   ProcessOnChain ("0 0", ValidProof ("48 5"), 1);
   EXPECT_EQ (GetLatestState (), "50 6");
 }
@@ -435,8 +439,7 @@ protected:
   ExpectOnChainMove ()
   {
     const std::string expectedVal = R"({"g":{"game id":"100"}})";
-    EXPECT_CALL (*mockXayaWallet, name_update ("p/player", expectedVal))
-        .WillOnce (Return (SHA256::Hash ("txid").ToHex ()));
+    txSender.ExpectSuccess ("player", expectedVal);
   }
 
 };
@@ -480,14 +483,14 @@ using ResolveDisputeTests = ChannelManagerTests;
 
 TEST_F (ResolveDisputeTests, SendsResolution)
 {
-  ExpectMoves (1, "resolution");
+  ExpectMove ("resolution");
   ProcessOnChain ("0 0", ValidProof ("10 5"), 1);
   cm.ProcessOffChain ("", ValidProof ("12 6"));
 }
 
 TEST_F (ResolveDisputeTests, ChannelDoesNotExist)
 {
-  ExpectMoves (0, "resolution");
+  /* No moves are expected.  */
   ProcessOnChain ("0 0", ValidProof ("10 5"), 1);
   ProcessOnChainNonExistant ();
   cm.ProcessOffChain ("", ValidProof ("12 6"));
@@ -495,7 +498,7 @@ TEST_F (ResolveDisputeTests, ChannelDoesNotExist)
 
 TEST_F (ResolveDisputeTests, AlreadyPending)
 {
-  ExpectMoves (1, "resolution");
+  ExpectMove ("resolution");
   ProcessOnChain ("0 0", ValidProof ("10 5"), 1);
   cm.ProcessOffChain ("", ValidProof ("12 6"));
   cm.ProcessOffChain ("", ValidProof ("14 8"));
@@ -503,33 +506,32 @@ TEST_F (ResolveDisputeTests, AlreadyPending)
 
 TEST_F (ResolveDisputeTests, OtherPlayer)
 {
-  ExpectMoves (0, "resolution");
+  /* No moves are expected.  */
   ProcessOnChain ("0 0", ValidProof ("11 5"), 1);
   cm.ProcessOffChain ("", ValidProof ("12 6"));
 }
 
 TEST_F (ResolveDisputeTests, NoBetterTurn)
 {
-  ExpectMoves (0, "resolution");
+  /* No moves are expected.  */
   ProcessOnChain ("0 0", ValidProof ("10 5"), 1);
   cm.ProcessOffChain ("", ValidProof ("12 5"));
 }
 
 TEST_F (ResolveDisputeTests, RetryAfterBlock)
 {
-  const auto txid = ExpectMoves (2, "resolution");
-
-  Json::Value pendings(Json::arrayValue);
-  pendings.append (txid.ToHex ());
-
-  EXPECT_CALL (*mockXayaServer, getrawmempool ())
-      .WillOnce (Return (pendings))
-      .WillOnce (Return (ParseJson ("[]")));
+  ExpectMoves (2, "resolution");
 
   ProcessOnChain ("0 0", ValidProof ("10 5"), 1);
   cm.ProcessOffChain ("", ValidProof ("12 6"));
+
+  /* The previous resolution is still pending, so this will do nothing.  */
   ProcessOnChain ("0 0", ValidProof ("10 5"), 1);
   cm.ProcessOffChain ("", ValidProof ("14 8"));
+
+  /* Mark it as confirmed.  The ProcessOnChain will notice that, and the
+     subsequent ProcessOffChain will then retry.  */
+  txSender.ClearMempool ();
   ProcessOnChain ("0 0", ValidProof ("10 5"), 1);
   cm.ProcessOffChain ("", ValidProof ("14 8"));
 }
@@ -540,7 +542,7 @@ using PutStateOnChainTests = ChannelManagerTests;
 
 TEST_F (PutStateOnChainTests, Successful)
 {
-  const auto txid = ExpectMoves (1, "resolution");
+  const auto txid = ExpectMove ("resolution");
   ProcessOnChain ("0 0", ValidProof ("10 5"), 0);
   cm.ProcessOffChain ("", ValidProof ("12 6"));
   EXPECT_EQ (cm.PutStateOnChain (), txid);
@@ -548,7 +550,7 @@ TEST_F (PutStateOnChainTests, Successful)
 
 TEST_F (PutStateOnChainTests, ChannelDoesNotExist)
 {
-  ExpectMoves (0, "resolution");
+  /* No moves are expected.  */
   ProcessOnChainNonExistant ();
   cm.ProcessOffChain ("", ValidProof ("12 6"));
   EXPECT_TRUE (cm.PutStateOnChain ().IsNull ());
@@ -556,7 +558,7 @@ TEST_F (PutStateOnChainTests, ChannelDoesNotExist)
 
 TEST_F (PutStateOnChainTests, BestStateAlreadyOnChain)
 {
-  ExpectMoves (0, "resolution");
+  /* No moves are expected.  */
   ProcessOnChain ("0 0", ValidProof ("10 5"), 0);
   cm.ProcessOffChain ("", ValidProof ("12 5"));
   EXPECT_TRUE (cm.PutStateOnChain ().IsNull ());
@@ -564,14 +566,16 @@ TEST_F (PutStateOnChainTests, BestStateAlreadyOnChain)
 
 TEST_F (PutStateOnChainTests, MultipleUpdates)
 {
-  const auto txid = ExpectMoves (2, "resolution");
+  const auto txids = ExpectMoves (2, "resolution");
+  ASSERT_EQ (txids.size (), 2);
+
   ProcessOnChain ("0 0", ValidProof ("10 5"), 0);
 
   cm.ProcessOffChain ("", ValidProof ("12 6"));
-  EXPECT_EQ (cm.PutStateOnChain (), txid);
+  EXPECT_EQ (cm.PutStateOnChain (), txids[0]);
 
   cm.ProcessOffChain ("", ValidProof ("20 7"));
-  EXPECT_EQ (cm.PutStateOnChain (), txid);
+  EXPECT_EQ (cm.PutStateOnChain (), txids[1]);
 }
 
 /* ************************************************************************** */
@@ -580,28 +584,28 @@ using FileDisputeTests = ChannelManagerTests;
 
 TEST_F (FileDisputeTests, Successful)
 {
-  const auto txid = ExpectMoves (1, "dispute");
+  const auto txid = ExpectMove ("dispute");
   ProcessOnChain ("0 0", ValidProof ("10 5"), 0);
   EXPECT_EQ (cm.FileDispute (), txid);
 }
 
 TEST_F (FileDisputeTests, ChannelDoesNotExist)
 {
-  ExpectMoves (0, "dispute");
+  /* No moves are expected.  */
   ProcessOnChainNonExistant ();
   EXPECT_TRUE (cm.FileDispute ().IsNull ());
 }
 
 TEST_F (FileDisputeTests, HasOtherDispute)
 {
-  ExpectMoves (0, "dispute");
+  /* No moves are expected.  */
   ProcessOnChain ("0 0", ValidProof ("10 5"), 10);
   EXPECT_TRUE (cm.FileDispute ().IsNull ());
 }
 
 TEST_F (FileDisputeTests, AlreadyPending)
 {
-  const auto txid = ExpectMoves (1, "dispute");
+  const auto txid = ExpectMove ("dispute");
   ProcessOnChain ("0 0", ValidProof ("10 5"), 0);
   EXPECT_EQ (cm.FileDispute (), txid);
   EXPECT_TRUE (cm.FileDispute ().IsNull ());
@@ -609,21 +613,20 @@ TEST_F (FileDisputeTests, AlreadyPending)
 
 TEST_F (FileDisputeTests, RetryAfterBlock)
 {
-  const auto txid = ExpectMoves (2, "dispute");
-
-  Json::Value pendings(Json::arrayValue);
-  pendings.append (txid.ToHex ());
-
-  EXPECT_CALL (*mockXayaServer, getrawmempool ())
-      .WillOnce (Return (pendings))
-      .WillOnce (Return (ParseJson ("[]")));
+  const auto txids = ExpectMoves (2, "dispute");
+  ASSERT_EQ (txids.size (), 2);
 
   ProcessOnChain ("0 0", ValidProof ("10 5"), 0);
-  EXPECT_EQ (cm.FileDispute (), txid);
+  EXPECT_EQ (cm.FileDispute (), txids[0]);
+
+  /* The previous dispute is still pending.  */
   ProcessOnChain ("0 0", ValidProof ("10 5"), 0);
   EXPECT_TRUE (cm.FileDispute ().IsNull ());
+
+  /* Mark it as not pending.  This will retry.  */
+  txSender.ClearMempool ();
   ProcessOnChain ("0 0", ValidProof ("10 5"), 0);
-  EXPECT_EQ (cm.FileDispute (), txid);
+  EXPECT_EQ (cm.FileDispute (), txids[1]);
 }
 
 /* ************************************************************************** */
@@ -704,7 +707,7 @@ TEST_F (ChannelToJsonTests, Dispute)
 
 TEST_F (ChannelToJsonTests, PendingPutStateOnChain)
 {
-  const auto txid = ExpectMoves (1, "resolution");
+  const auto txid = ExpectMove ("resolution");
   ProcessOnChain ("0 0", ValidProof ("10 5"), 0);
   cm.ProcessOffChain ("", ValidProof ("12 6"));
   cm.PutStateOnChain ();
@@ -716,7 +719,7 @@ TEST_F (ChannelToJsonTests, PendingPutStateOnChain)
 
 TEST_F (ChannelToJsonTests, PendingDispute)
 {
-  const auto txid = ExpectMoves (1, "dispute");
+  const auto txid = ExpectMove ("dispute");
   ProcessOnChain ("0 0", ValidProof ("10 5"), 0);
   cm.FileDispute ();
 
@@ -727,7 +730,7 @@ TEST_F (ChannelToJsonTests, PendingDispute)
 
 TEST_F (ChannelToJsonTests, PendingResolution)
 {
-  const auto txid = ExpectMoves (1, "resolution");
+  const auto txid = ExpectMove ("resolution");
   ProcessOnChain ("0 0", ValidProof ("10 5"), 1);
   cm.ProcessOffChain ("", ValidProof ("12 6"));
 

--- a/gamechannel/channeltest.py
+++ b/gamechannel/channeltest.py
@@ -32,14 +32,16 @@ class Daemon ():
   but other games can use it as well if their channel daemons:
 
   * Have the --xaya_rpc_url, --gsp_rpc_url, --broadcast_rpc_url,
-    --rpc_port, --playername and --channelid flags of ships-channel, and
+    --rpc_port, --playername, -address and --channelid flags of ships-channel,
+    and
   * provide the "stop" and "getcurrentstate" RPC methods.
   """
 
-  def __init__ (self, channelId, playerName, basedir, port, binary):
+  def __init__ (self, channelId, playerName, addr, basedir, port, binary):
     self.log = logging.getLogger ("gamechannel.channeltest.Daemon")
     self.channelId = channelId
     self.playerName = playerName
+    self.address = addr
     self.datadir = os.path.join (basedir, "channel_%s" % playerName)
     self.port = port
     self.binary = binary
@@ -64,6 +66,7 @@ class Daemon ():
     args.append ("--rpc_port=%d" % self.port)
     args.append ("--channelid=%s" % self.channelId)
     args.append ("--playername=%s" % self.playerName)
+    args.append ("--address=%s" % self.address)
     args.extend (extraArgs)
     envVars = dict (os.environ)
     envVars["GLOG_log_dir"] = self.datadir
@@ -174,15 +177,15 @@ class TestCase (XayaGameTest):
     self.broadcastThread.join ()
     super (TestCase, self).shutdown ()
 
-  def runChannelDaemon (self, channelId, playerName):
+  def runChannelDaemon (self, channelId, address, playerName):
     """
     Starts a new channel daemon for the given ID and player name.
     This returns a context manager instance, which returns the
     underlying Daemon instance when entered.
     """
 
-    daemon = Daemon (channelId, playerName, self.basedir, next (self.ports),
-                     self.args.channel_daemon)
+    daemon = Daemon (channelId, address, playerName, self.basedir,
+                     next (self.ports), self.args.channel_daemon)
 
     return DaemonContext (daemon, self.xayanode.rpcurl, self.gamenode.rpcurl,
                           self.bcurl)

--- a/gamechannel/daemon.cpp
+++ b/gamechannel/daemon.cpp
@@ -21,25 +21,21 @@ namespace
  * that typically the calls return ordinarily; but we put up a safety net
  * in case the server is messed up.
  */
-constexpr int GSP_RPC_TIMEOUT_MS = 6000;
+constexpr int GSP_RPC_TIMEOUT_MS = 6'000;
 
 } // anonymous namespace
 
-ChannelDaemon::XayaBasedInstances::XayaBasedInstances (
-    ChannelDaemon& d, const std::string& addr,
-    const std::string& rpc, const jsonrpc::clientVersion_t rpcVersion)
-  : xayaClient(rpc),
-    xayaRpc(xayaClient, rpcVersion),
-    xayaWallet(xayaClient, rpcVersion),
-    verifier(xayaRpc), signer(xayaWallet, addr),
-    txSender(xayaRpc, xayaWallet),
-    sender(d.gameId, d.channelId, d.playerName, txSender, d.channel),
+ChannelDaemon::WalletBasedInstances::WalletBasedInstances (
+    ChannelDaemon& d,
+    const SignatureVerifier& verifier, SignatureSigner& signer,
+    TransactionSender& txSender)
+  : sender(d.gameId, d.channelId, d.playerName, txSender, d.channel),
     cm(d.rules, d.channel, verifier, signer, d.channelId, d.playerName)
 {
   cm.SetMoveSender (sender);
 }
 
-ChannelDaemon::XayaBasedInstances::~XayaBasedInstances ()
+ChannelDaemon::WalletBasedInstances::~WalletBasedInstances ()
 {
   cm.StopUpdates ();
 }
@@ -47,26 +43,23 @@ ChannelDaemon::XayaBasedInstances::~XayaBasedInstances ()
 ChannelDaemon::GspFeederInstances::GspFeederInstances (ChannelDaemon& d,
                                                        const std::string& rpc)
   : gspClient(rpc), gspRpc(gspClient),
-    feeder(gspRpc, d.xayaBased->cm)
+    feeder(gspRpc, d.walletBased->cm)
 {
   gspClient.SetTimeout (GSP_RPC_TIMEOUT_MS);
 }
 
 void
-ChannelDaemon::ConnectXayaRpc (const std::string& url, const bool legacy)
+ChannelDaemon::ConnectWallet (const SignatureVerifier& v, SignatureSigner& s,
+                              TransactionSender& tx)
 {
-  CHECK (xayaBased == nullptr);
-  const auto rpcVersion = (legacy
-                            ? jsonrpc::JSONRPC_CLIENT_V1
-                            : jsonrpc::JSONRPC_CLIENT_V2);
-  xayaBased
-      = std::make_unique<XayaBasedInstances> (*this, address, url, rpcVersion);
+  CHECK (walletBased == nullptr);
+  walletBased = std::make_unique<WalletBasedInstances> (*this, v, s, tx);
 }
 
 void
 ChannelDaemon::ConnectGspRpc (const std::string& url)
 {
-  CHECK (xayaBased != nullptr);
+  CHECK (walletBased != nullptr);
   CHECK (feeder == nullptr);
   feeder = std::make_unique<GspFeederInstances> (*this, url);
 }
@@ -74,23 +67,23 @@ ChannelDaemon::ConnectGspRpc (const std::string& url)
 ChannelManager&
 ChannelDaemon::GetChannelManager ()
 {
-  CHECK (xayaBased != nullptr);
-  return xayaBased->cm;
+  CHECK (walletBased != nullptr);
+  return walletBased->cm;
 }
 
 void
 ChannelDaemon::SetOffChainBroadcast (OffChainBroadcast& b)
 {
-  CHECK (xayaBased != nullptr);
+  CHECK (walletBased != nullptr);
   CHECK (offChain == nullptr);
   offChain = &b;
-  xayaBased->cm.SetOffChainBroadcast (*offChain);
+  walletBased->cm.SetOffChainBroadcast (*offChain);
 }
 
 void
 ChannelDaemon::Start ()
 {
-  CHECK (xayaBased != nullptr);
+  CHECK (walletBased != nullptr);
   CHECK (feeder != nullptr);
   CHECK (offChain != nullptr);
   CHECK (!startedOnce);
@@ -103,14 +96,14 @@ ChannelDaemon::Start ()
 void
 ChannelDaemon::Stop ()
 {
-  CHECK (xayaBased != nullptr);
+  CHECK (walletBased != nullptr);
   CHECK (feeder != nullptr);
   CHECK (offChain != nullptr);
   CHECK (startedOnce);
 
   feeder->feeder.Stop ();
   offChain->Stop ();
-  xayaBased->cm.StopUpdates ();
+  walletBased->cm.StopUpdates ();
 }
 
 void

--- a/gamechannel/daemon.cpp
+++ b/gamechannel/daemon.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2021 The Xaya developers
+// Copyright (C) 2019-2022 The Xaya developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -26,12 +26,13 @@ constexpr int GSP_RPC_TIMEOUT_MS = 6000;
 } // anonymous namespace
 
 ChannelDaemon::XayaBasedInstances::XayaBasedInstances (
-    ChannelDaemon& d, const std::string& rpc,
-    const jsonrpc::clientVersion_t rpcVersion)
+    ChannelDaemon& d, const std::string& addr,
+    const std::string& rpc, const jsonrpc::clientVersion_t rpcVersion)
   : xayaClient(rpc),
     xayaRpc(xayaClient, rpcVersion),
     xayaWallet(xayaClient, rpcVersion),
-    cm(d.rules, d.channel, xayaRpc, xayaWallet, d.channelId, d.playerName),
+    verifier(xayaRpc), signer(xayaWallet, addr),
+    cm(d.rules, d.channel, verifier, signer, d.channelId, d.playerName),
     sender(d.gameId, d.channelId, d.playerName, xayaRpc, xayaWallet, d.channel)
 {
   cm.SetMoveSender (sender);
@@ -57,7 +58,8 @@ ChannelDaemon::ConnectXayaRpc (const std::string& url, const bool legacy)
   const auto rpcVersion = (legacy
                             ? jsonrpc::JSONRPC_CLIENT_V1
                             : jsonrpc::JSONRPC_CLIENT_V2);
-  xayaBased = std::make_unique<XayaBasedInstances> (*this, url, rpcVersion);
+  xayaBased
+      = std::make_unique<XayaBasedInstances> (*this, address, url, rpcVersion);
 }
 
 void

--- a/gamechannel/daemon.cpp
+++ b/gamechannel/daemon.cpp
@@ -32,8 +32,9 @@ ChannelDaemon::XayaBasedInstances::XayaBasedInstances (
     xayaRpc(xayaClient, rpcVersion),
     xayaWallet(xayaClient, rpcVersion),
     verifier(xayaRpc), signer(xayaWallet, addr),
-    cm(d.rules, d.channel, verifier, signer, d.channelId, d.playerName),
-    sender(d.gameId, d.channelId, d.playerName, xayaRpc, xayaWallet, d.channel)
+    txSender(xayaRpc, xayaWallet),
+    sender(d.gameId, d.channelId, d.playerName, txSender, d.channel),
+    cm(d.rules, d.channel, verifier, signer, d.channelId, d.playerName)
 {
   cm.SetMoveSender (sender);
 }

--- a/gamechannel/daemon.hpp
+++ b/gamechannel/daemon.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2021 The Xaya developers
+// Copyright (C) 2019-2022 The Xaya developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -11,6 +11,7 @@
 #include "channelmanager.hpp"
 #include "movesender.hpp"
 #include "openchannel.hpp"
+#include "signatures.hpp"
 
 #include "rpc-stubs/channelgsprpcclient.h"
 
@@ -57,6 +58,11 @@ private:
     /** The RPC client for the Xaya wallet.  */
     XayaWalletRpcClient xayaWallet;
 
+    /** Signature verifier (based on the RPC).  */
+    RpcSignatureVerifier verifier;
+    /** Signature signer based on RPC.  */
+    RpcSignatureSigner signer;
+
     /** The ChannelManager instance.  */
     ChannelManager cm;
 
@@ -67,7 +73,8 @@ private:
     XayaBasedInstances (const XayaBasedInstances&) = delete;
     void operator= (const XayaBasedInstances&) = delete;
 
-    explicit XayaBasedInstances (ChannelDaemon& daemon, const std::string& rpc,
+    explicit XayaBasedInstances (ChannelDaemon& daemon, const std::string& addr,
+                                 const std::string& rpc,
                                  jsonrpc::clientVersion_t rpcVersion);
     ~XayaBasedInstances ();
 
@@ -103,6 +110,8 @@ private:
 
   /** The player's name (without p/ prefix).  */
   const std::string playerName;
+  /** The player's signing address.  */
+  const std::string address;
 
   /** The board rules for this game.  */
   const BoardRules& rules;
@@ -135,9 +144,10 @@ private:
 public:
 
   explicit ChannelDaemon (const std::string& gid,
-                          const uint256& id, const std::string& nm,
+                          const uint256& id,
+                          const std::string& nm, const std::string& addr,
                           const BoardRules& r, OpenChannel& oc)
-    : gameId(gid), channelId(id), playerName(nm),
+    : gameId(gid), channelId(id), playerName(nm), address(addr),
       rules(r), channel(oc)
   {}
 

--- a/gamechannel/daemon.hpp
+++ b/gamechannel/daemon.hpp
@@ -63,11 +63,13 @@ private:
     /** Signature signer based on RPC.  */
     RpcSignatureSigner signer;
 
+    /** The TransactionSender based on RPC.  */
+    RpcTransactionSender txSender;
+    /** The MoveSender instance we use.  */
+    MoveSender sender;
+
     /** The ChannelManager instance.  */
     ChannelManager cm;
-
-    /** The MoveSender instance.  */
-    MoveSender sender;
 
     XayaBasedInstances () = delete;
     XayaBasedInstances (const XayaBasedInstances&) = delete;

--- a/gamechannel/movesender.cpp
+++ b/gamechannel/movesender.cpp
@@ -1,22 +1,48 @@
-// Copyright (C) 2019-2021 The Xaya developers
+// Copyright (C) 2019-2022 The Xaya developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include "movesender.hpp"
-
-#include <jsonrpccpp/common/exception.h>
 
 #include <glog/logging.h>
 
 namespace xaya
 {
 
+/* ************************************************************************** */
+
+uint256
+RpcTransactionSender::SendRawMove (const std::string& name,
+                                   const std::string& value)
+{
+  const std::string fullName = "p/" + name;
+  const std::string txidHex = wallet.name_update (fullName, value);
+
+  uint256 txid;
+  CHECK (txid.FromHex (txidHex));
+
+  return txid;
+}
+
+bool
+RpcTransactionSender::IsPending (const uint256& txid) const
+{
+  const std::string txidHex = txid.ToHex ();
+
+  const auto mempool = rpc.getrawmempool ();
+  for (const auto& tx : mempool)
+    if (tx.asString () == txidHex)
+      return true;
+
+  return false;
+}
+
+/* ************************************************************************** */
+
 MoveSender::MoveSender (const std::string& gId,
                         const uint256& chId, const std::string& nm,
-                        XayaRpcClient& r, XayaWalletRpcClient& w,
-                        OpenChannel& oc)
-  : rpc(r), wallet(w), game(oc), channelId(chId),
-    playerName("p/" + nm), gameId(gId)
+                        TransactionSender& s, OpenChannel& oc)
+  : sender(s), game(oc), channelId(chId), playerName(nm), gameId(gId)
 {
   jsonWriterBuilder["commentStyle"] = "None";
   jsonWriterBuilder["indentation"] = "";
@@ -30,21 +56,16 @@ MoveSender::SendMove (const Json::Value& mv)
   fullValue["g"][gameId] = mv;
 
   const std::string strValue = Json::writeString (jsonWriterBuilder, fullValue);
+  LOG (INFO) << "Sending move: " << playerName << "\n" << strValue;
+
   uint256 res;
   try
     {
-      LOG (INFO)
-          << "Sending move: name_update " << playerName
-          << "\n" << strValue;
-
-      const std::string txidHex = wallet.name_update (playerName, strValue);
-      LOG (INFO) << "Success, name txid = " << txidHex;
-
-      CHECK (res.FromHex (txidHex));
+      res = sender.SendRawMove (playerName, strValue);
     }
-  catch (const jsonrpc::JsonRpcException& exc)
+  catch (const std::exception& exc)
     {
-      LOG (ERROR) << "name_update failed: " << exc.what ();
+      LOG (ERROR) << "SendMoveToBlockchain failed: " << exc.what ();
       res.SetNull ();
     }
 
@@ -63,17 +84,6 @@ MoveSender::SendResolution (const proto::StateProof& proof)
   return SendMove (game.ResolutionMove (channelId, proof));
 }
 
-bool
-MoveSender::IsPending (const uint256& txid) const
-{
-  const std::string txidHex = txid.ToHex ();
-
-  const auto mempool = rpc.getrawmempool ();
-  for (const auto& tx : mempool)
-    if (tx.asString () == txidHex)
-      return true;
-
-  return false;
-}
+/* ************************************************************************** */
 
 } // namespace xaya

--- a/gamechannel/proto/signatures.proto
+++ b/gamechannel/proto/signatures.proto
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 The Xaya developers
+// Copyright (C) 2019-2022 The Xaya developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -18,7 +18,10 @@ message SignedData
 
   /**
    * The signatures made on the data by channel participants.  Each signature
-   * is the "signmessage" output of Xaya Core, but base64-decoded to binary.
+   * stores raw bytes based on the underlying message signing/verification
+   * provider used.  For instance, for signing based on Xaya Core's RPC
+   * interface with signmessage/verifymessage, the data is the base64-decoded
+   * signature string as raw binary.
    *
    * For the message, the channel's ID (uint256) is concatenated with
    * the base64-encoded reinit ID, a nul byte, a string describing what the

--- a/gamechannel/protoboard.hpp
+++ b/gamechannel/protoboard.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 The Xaya developers
+// Copyright (C) 2019-2022 The Xaya developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -8,8 +8,6 @@
 #include "boardrules.hpp"
 
 #include "proto/metadata.pb.h"
-
-#include <xayagame/rpc-stubs/xayarpcclient.h>
 
 #include <json/json.h>
 
@@ -56,8 +54,7 @@ protected:
    * it is already considered invalid before).  Any more potential
    * versioning checks need to be done by this function.
    */
-  virtual bool ApplyMoveProto (XayaRpcClient& rpc, const Move& mv,
-                               State& newState) const = 0;
+  virtual bool ApplyMoveProto (const Move& mv, State& newState) const = 0;
 
 public:
 
@@ -101,8 +98,7 @@ public:
   virtual bool IsValid () const;
 
   bool Equals (const BoardState& other) const override;
-  bool ApplyMove (XayaRpcClient& rpc, const BoardMove& mv,
-                  BoardState& newState) const override;
+  bool ApplyMove (const BoardMove& mv, BoardState& newState) const override;
 
 };
 

--- a/gamechannel/protoboard.tpp
+++ b/gamechannel/protoboard.tpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 The Xaya developers
+// Copyright (C) 2019-2022 The Xaya developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -60,8 +60,7 @@ template <typename State, typename Move>
 
 template <typename State, typename Move>
   bool
-  ProtoBoardState<State, Move>::ApplyMove (XayaRpcClient& rpc,
-                                           const BoardMove& mv,
+  ProtoBoardState<State, Move>::ApplyMove (const BoardMove& mv,
                                            BoardState& newState) const
 {
   Move pm;
@@ -77,7 +76,7 @@ template <typename State, typename Move>
     }
 
   State pn;
-  if (!ApplyMoveProto (rpc, pm, pn))
+  if (!ApplyMoveProto (pm, pn))
     return false;
 
   CHECK (pn.SerializeToString (&newState));

--- a/gamechannel/protoboard_tests.cpp
+++ b/gamechannel/protoboard_tests.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 The Xaya developers
+// Copyright (C) 2019-2022 The Xaya developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -83,7 +83,7 @@ protected:
   }
 
   bool
-  ApplyMoveProto (XayaRpcClient& rpc, const proto::TestBoardMove& mv,
+  ApplyMoveProto (const proto::TestBoardMove& mv,
                   proto::TestBoardState& newState) const override
   {
     if (!mv.has_msg ())
@@ -137,12 +137,6 @@ class ProtoBoardTests : public testing::Test
 
 protected:
 
-  /**
-   * Fake instance of XayaRpcClient, which is just a disguised null pointer.
-   * This is fine, as our board rules never need the RPC.
-   */
-  XayaRpcClient& rpc;
-
   /** Fake channel ID used in tests.  */
   const uint256 channelId = SHA256::Hash ("foo");
 
@@ -155,7 +149,6 @@ protected:
   TestRules rules;
 
   ProtoBoardTests ()
-    : rpc(*static_cast<XayaRpcClient*> (nullptr))
   {}
 
   /**
@@ -216,10 +209,10 @@ TEST_F (ProtoBoardTests, ApplyMove)
   auto p = ParseState (TextState ("msg: \"foo\""));
 
   BoardState newState;
-  EXPECT_FALSE (p->ApplyMove (rpc, "invalid", newState));
-  EXPECT_FALSE (p->ApplyMove (rpc, TextMove (""), newState));
+  EXPECT_FALSE (p->ApplyMove ("invalid", newState));
+  EXPECT_FALSE (p->ApplyMove (TextMove (""), newState));
 
-  ASSERT_TRUE (p->ApplyMove (rpc, TextMove ("msg: \"bar\""), newState));
+  ASSERT_TRUE (p->ApplyMove (TextMove ("msg: \"bar\""), newState));
   proto::TestBoardState newPb;
   ASSERT_TRUE (newPb.ParseFromString (newState));
   EXPECT_EQ (newPb.msg (), "bar");
@@ -246,11 +239,11 @@ TEST_F (ProtoBoardTests, UnknownFields)
 
   BoardState newState;
   CHECK (pbMove.SerializeToString (&serialised));
-  EXPECT_TRUE (p->ApplyMove (rpc, serialised, newState));
+  EXPECT_TRUE (p->ApplyMove (serialised, newState));
 
   AddUnknownField (pbMove);
   CHECK (pbMove.SerializeToString (&serialised));
-  EXPECT_FALSE (p->ApplyMove (rpc, serialised, newState));
+  EXPECT_FALSE (p->ApplyMove (serialised, newState));
 }
 
 } // anonymous namespace

--- a/gamechannel/rollingstate.cpp
+++ b/gamechannel/rollingstate.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2021 The Xaya developers
+// Copyright (C) 2019-2022 The Xaya developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -78,7 +78,7 @@ RollingState::UpdateOnChain (const proto::ChannelMetadata& meta,
   CHECK (CheckVersionedProto (rules, meta, proof));
 
   BoardState provenState;
-  CHECK (VerifyStateProof (rpc, rules, channelId, meta,
+  CHECK (VerifyStateProof (verifier, rules, channelId, meta,
                            reinitState, proof, provenState))
       << "State proof provided on-chain is not valid";
 
@@ -179,7 +179,7 @@ RollingState::UpdateWithMove (const std::string& updReinit,
      on-chain updates (which are filtered through the GSP), the data we get
      here comes straight from the other players and may be complete garbage.  */
   BoardState provenState;
-  if (!VerifyStateProof (rpc, rules, channelId, *entry.meta,
+  if (!VerifyStateProof (verifier, rules, channelId, *entry.meta,
                          entry.reinitState, proof, provenState))
     {
       LOG (WARNING)

--- a/gamechannel/rollingstate.hpp
+++ b/gamechannel/rollingstate.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2021 The Xaya developers
+// Copyright (C) 2019-2022 The Xaya developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -6,11 +6,11 @@
 #define GAMECHANNEL_ROLLINGSTATE_HPP
 
 #include "boardrules.hpp"
+#include "signatures.hpp"
 
 #include "proto/metadata.pb.h"
 #include "proto/stateproof.pb.h"
 
-#include <xayagame/rpc-stubs/xayarpcclient.h>
 #include <xayautil/uint256.hpp>
 
 #include <map>
@@ -75,8 +75,8 @@ private:
   /** Board rules to use for our game.  */
   const BoardRules& rules;
 
-  /** RPC client for signature verification.  */
-  XayaRpcClient& rpc;
+  /** Signature verifier for state proofs.  */
+  const SignatureVerifier& verifier;
 
   /** The ID of the channel this is for.  */
   const uint256& channelId;
@@ -93,9 +93,9 @@ private:
 
 public:
 
-  explicit RollingState (const BoardRules& r, XayaRpcClient& c,
+  explicit RollingState (const BoardRules& r, const SignatureVerifier& v,
                          const uint256& id)
-    : rules(r), rpc(c), channelId(id)
+    : rules(r), verifier(v), channelId(id)
   {}
 
   RollingState () = delete;

--- a/gamechannel/rollingstate_tests.cpp
+++ b/gamechannel/rollingstate_tests.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2021 The Xaya developers
+// Copyright (C) 2019-2022 The Xaya developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -46,7 +46,7 @@ protected:
   RollingState state;
 
   RollingStateTests ()
-    : state(game.rules, mockXayaServer.GetClient (), channelId)
+    : state(game.rules, verifier, channelId)
   {
     meta1.set_reinit ("reinit 1");
     meta1.add_participants ()->set_address ("addr 0");
@@ -56,9 +56,9 @@ protected:
     meta2.add_participants ()->set_address ("addr 0");
     meta2.add_participants ()->set_address ("addr 2");
 
-    ValidSignature ("sgn 0", "addr 0");
-    ValidSignature ("sgn 1", "addr 1");
-    ValidSignature ("sgn 2", "addr 2");
+    verifier.SetValid ("sgn 0", "addr 0");
+    verifier.SetValid ("sgn 1", "addr 1");
+    verifier.SetValid ("sgn 2", "addr 2");
   }
 
   /**

--- a/gamechannel/signatures.hpp
+++ b/gamechannel/signatures.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 The Xaya developers
+// Copyright (C) 2019-2022 The Xaya developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -17,6 +17,108 @@
 
 namespace xaya
 {
+
+/* ************************************************************************** */
+
+/**
+ * General interface for a signature scheme, implementing verification
+ * of signatures (with address recovery).  This can be implemented using
+ * Xaya Core's verifymessage RPC method, via Ethereum message signing, or
+ * in principle by any other custom scheme as well.
+ */
+class SignatureVerifier
+{
+
+public:
+
+  SignatureVerifier () = default;
+  virtual ~SignatureVerifier () = default;
+
+  /**
+   * Returns the address which signed a given message as per the
+   * signature.  In case the signature is entirely invalid (e.g. malformed),
+   * this should return some invalid address for the signing scheme (e.g.
+   * just the empty string or "invalid").
+   */
+  virtual std::string RecoverSigner (const std::string& msg,
+                                     const std::string& sgn) const = 0;
+
+};
+
+/**
+ * General interface for a signature scheme that supports signing
+ * of messages with a particular address (holding the corresponding key).
+ */
+class SignatureSigner
+{
+
+public:
+
+  SignatureSigner () = default;
+  virtual ~SignatureSigner () = default;
+
+  /**
+   * Returns the address for which this instance can sign.
+   */
+  virtual std::string GetAddress () const = 0;
+
+  /**
+   * Signs a message with the underlying address.
+   */
+  virtual std::string SignMessage (const std::string& msg) = 0;
+
+};
+
+/**
+ * An implementation of the verifier based on a Xaya RPC connection.
+ *
+ * This uses Xaya Core's signmessage/verifymessage scheme, but signatures
+ * returned and passed in for verification are assumed to be already base64
+ * decoded to raw bytes.
+ */
+class RpcSignatureVerifier : public SignatureVerifier
+{
+
+private:
+
+  /** The underlying RPC client for verification.  */
+  XayaRpcClient& rpc;
+
+public:
+
+  explicit RpcSignatureVerifier (XayaRpcClient& r)
+    : rpc(r)
+  {}
+
+  std::string RecoverSigner (const std::string& msg,
+                             const std::string& sgn) const override;
+
+};
+
+/**
+ * An implementation of the signer based on a Xaya RPC connection.
+ */
+class RpcSignatureSigner : public SignatureSigner
+{
+
+private:
+
+  /** The underlying RPC wallet for signing.  */
+  XayaWalletRpcClient& wallet;
+
+  /** The address used for signing (must be in the wallet).  */
+  const std::string address;
+
+public:
+
+  explicit RpcSignatureSigner (XayaWalletRpcClient& w, const std::string& addr);
+
+  std::string GetAddress () const override;
+  std::string SignMessage (const std::string& msg) override;
+
+};
+
+/* ************************************************************************** */
 
 /**
  * Constructs the message (as string) that will be passed to "signmessage"
@@ -45,7 +147,7 @@ std::string GetChannelSignatureMessage (const uint256& channelId,
  * with a game-specific BoardState and BoardMove value, respectively.  Other
  * values can be used for game-specific needs.
  */
-std::set<int> VerifyParticipantSignatures (XayaRpcClient& rpc,
+std::set<int> VerifyParticipantSignatures (const SignatureVerifier& verifier,
                                            const uint256& channelId,
                                            const proto::ChannelMetadata& meta,
                                            const std::string& topic,
@@ -53,14 +155,16 @@ std::set<int> VerifyParticipantSignatures (XayaRpcClient& rpc,
 
 /**
  * Tries to sign the given data for the given participant index, using
- * the provided Xaya wallet.  Returns true if a signature could be made.
+ * the provided signer.  Returns true if a signature could be made.
  */
-bool SignDataForParticipant (XayaWalletRpcClient& wallet,
+bool SignDataForParticipant (SignatureSigner& signer,
                              const uint256& channelId,
                              const proto::ChannelMetadata& meta,
                              const std::string& topic,
                              int index,
                              proto::SignedData& data);
+
+/* ************************************************************************** */
 
 } // namespace xaya
 

--- a/gamechannel/stateproof.cpp
+++ b/gamechannel/stateproof.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 The Xaya developers
+// Copyright (C) 2019-2022 The Xaya developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -40,7 +40,7 @@ ExtraVerifyStateTransition (XayaRpcClient& rpc, const BoardRules& rules,
     }
 
   BoardState newState;
-  if (!oldState.ApplyMove (rpc, transition.move (), newState))
+  if (!oldState.ApplyMove (transition.move (), newState))
     {
       LOG (WARNING) << "Failed to apply move of state transition";
       return false;
@@ -174,7 +174,7 @@ ExtendStateProof (XayaRpcClient& rpc, XayaWalletRpcClient& wallet,
     }
 
   BoardState newState;
-  if (!parsedOld->ApplyMove (rpc, mv, newState))
+  if (!parsedOld->ApplyMove (mv, newState))
     {
       LOG (ERROR) << "Invalid move for extending a state proof: " << mv;
       return false;

--- a/gamechannel/stateproof.hpp
+++ b/gamechannel/stateproof.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 The Xaya developers
+// Copyright (C) 2019-2022 The Xaya developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -6,12 +6,11 @@
 #define GAMECHANNEL_STATEPROOF_HPP
 
 #include "boardrules.hpp"
+#include "signatures.hpp"
 
 #include "proto/metadata.pb.h"
 #include "proto/stateproof.pb.h"
 
-#include <xayagame/rpc-stubs/xayarpcclient.h>
-#include <xayagame/rpc-stubs/xayawalletrpcclient.h>
 #include <xayautil/uint256.hpp>
 
 namespace xaya
@@ -24,7 +23,8 @@ namespace xaya
  * A state transition is valid if the move is valid from old state -> new state
  * and the player who was supposed to make that move signed the new state.
  */
-bool VerifyStateTransition (XayaRpcClient& rpc, const BoardRules& rules,
+bool VerifyStateTransition (const SignatureVerifier& verifier,
+                            const BoardRules& rules,
                             const uint256& channelId,
                             const proto::ChannelMetadata& meta,
                             const BoardState& oldState,
@@ -35,7 +35,8 @@ bool VerifyStateTransition (XayaRpcClient& rpc, const BoardRules& rules,
  * and valid, then true is returned and the resulting board state is returned
  * in endState.
  */
-bool VerifyStateProof (XayaRpcClient& rpc, const BoardRules& rules,
+bool VerifyStateProof (const SignatureVerifier& verifier,
+                       const BoardRules& rules,
                        const uint256& channelId,
                        const proto::ChannelMetadata& meta,
                        const BoardState& reinitState,
@@ -61,7 +62,8 @@ const BoardState& UnverifiedProofEndState (const proto::StateProof& proof);
  *
  * Returns true if the state proof was extended successfully.
  */
-bool ExtendStateProof (XayaRpcClient& rpc, XayaWalletRpcClient& wallet,
+bool ExtendStateProof (const SignatureVerifier& verifier,
+                       SignatureSigner& signer,
                        const BoardRules& rules,
                        const uint256& channelId,
                        const proto::ChannelMetadata& meta,

--- a/gamechannel/testgame.cpp
+++ b/gamechannel/testgame.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2020 The Xaya developers
+// Copyright (C) 2019-2022 The Xaya developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -91,8 +91,7 @@ public:
   }
 
   bool
-  ApplyMove (XayaRpcClient& rpc, const BoardMove& mv,
-             BoardState& newState) const override
+  ApplyMove (const BoardMove& mv, BoardState& newState) const override
   {
     /* The game-channel engine should never invoke ApplyMove on a 'no turn'
        situation.  Make sure to verify that.  */

--- a/gamechannel/testgame.cpp
+++ b/gamechannel/testgame.cpp
@@ -4,14 +4,8 @@
 
 #include "testgame.hpp"
 
-#include "movesender.hpp"
 #include "protoutils.hpp"
 #include "signatures.hpp"
-
-#include <xayautil/base64.hpp>
-#include <xayautil/hash.hpp>
-
-#include <gmock/gmock.h>
 
 #include <glog/logging.h>
 
@@ -24,11 +18,6 @@ namespace xaya
 
 namespace
 {
-
-using testing::_;
-using testing::InvokeWithoutArgs;
-using testing::Return;
-using testing::Throw;
 
 struct ParsedState
 {
@@ -203,95 +192,6 @@ AdditionChannel::MaybeOnChainMove (const ParsedBoardState& state,
 {
   const auto& addState = dynamic_cast<const AdditionState&> (state);
   addState.MaybeOnChainMove (sender);
-}
-
-/* ************************************************************************** */
-
-MockTransactionSender::MockTransactionSender ()
-{
-  /* By default, we expect no calls to be made.  */
-  EXPECT_CALL (*this, SendRawMove (_, _)).Times (0);
-}
-
-void
-MockTransactionSender::ExpectFailure (
-    const std::string& name, const testing::Matcher<const std::string&>& m)
-{
-  EXPECT_CALL (*this, SendRawMove (name, m))
-      .WillOnce (Throw (std::runtime_error ("faked error")));
-}
-
-std::vector<uint256>
-MockTransactionSender::ExpectSuccess (
-    const unsigned n,
-    const std::string& name, const testing::Matcher<const std::string&>& m)
-{
-  std::vector<uint256> txids;
-  for (unsigned i = 0; i < n; ++i)
-    {
-      ++cnt;
-      std::ostringstream str;
-      str << "txid " << cnt;
-      const uint256 txid = SHA256::Hash (str.str ());
-
-      txids.push_back (txid);
-      txidQueue.push (txid);
-    }
-
-  EXPECT_CALL (*this, SendRawMove (name, m))
-      .Times (n)
-      .WillRepeatedly (InvokeWithoutArgs ([&] ()
-        {
-          const uint256 txid = txidQueue.front ();
-          txidQueue.pop ();
-
-          mempool.insert (txid);
-          return txid;
-        }));
-
-  return txids;
-}
-
-uint256
-MockTransactionSender::ExpectSuccess (
-    const std::string& name, const testing::Matcher<const std::string&>& m)
-{
-  const auto txids = ExpectSuccess (1, name, m);
-  CHECK_EQ (txids.size (), 1);
-  return txids[0];
-}
-
-void
-MockTransactionSender::ClearMempool ()
-{
-  LOG (INFO) << "Clearing simulated mempool of MockTransactionSender";
-  mempool.clear ();
-}
-
-bool
-MockTransactionSender::IsPending (const uint256& txid) const
-{
-  return mempool.count (txid) > 0;
-}
-
-void
-MockSignatureVerifier::SetValid (const std::string& sgn,
-                                 const std::string& addr)
-{
-  EXPECT_CALL (*this, RecoverSigner (_, sgn)).WillRepeatedly (Return (addr));
-}
-
-void
-MockSignatureVerifier::ExpectOne (const uint256& channelId,
-                                  const proto::ChannelMetadata& meta,
-                                  const std::string& topic,
-                                  const std::string& msg,
-                                  const std::string& sgn,
-                                  const std::string& addr)
-{
-  const std::string hashed
-      = GetChannelSignatureMessage (channelId, meta, topic, msg);
-  EXPECT_CALL (*this, RecoverSigner (hashed, sgn)).WillOnce (Return (addr));
 }
 
 /* ************************************************************************** */

--- a/gamechannel/testgame_tests.cpp
+++ b/gamechannel/testgame_tests.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 The Xaya developers
+// Copyright (C) 2019-2022 The Xaya developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -58,7 +58,7 @@ protected:
     const auto po = game.rules.ParseState (channelId, meta, old);
     CHECK (po != nullptr);
 
-    return po->ApplyMove (mockXayaServer.GetClient (), mv, newState);
+    return po->ApplyMove (mv, newState);
   }
 
 };

--- a/gamechannel/testutils.cpp
+++ b/gamechannel/testutils.cpp
@@ -1,0 +1,110 @@
+// Copyright (C) 2022 The Xaya developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "testutils.hpp"
+
+#include <xayautil/hash.hpp>
+
+#include <gmock/gmock.h>
+
+#include <glog/logging.h>
+
+#include <sstream>
+
+namespace xaya
+{
+
+using testing::_;
+using testing::InvokeWithoutArgs;
+using testing::Return;
+using testing::Throw;
+
+MockTransactionSender::MockTransactionSender ()
+{
+  /* By default, we expect no calls to be made.  */
+  EXPECT_CALL (*this, SendRawMove (_, _)).Times (0);
+}
+
+void
+MockTransactionSender::ExpectFailure (
+    const std::string& name, const testing::Matcher<const std::string&>& m)
+{
+  EXPECT_CALL (*this, SendRawMove (name, m))
+      .WillOnce (Throw (std::runtime_error ("faked error")));
+}
+
+std::vector<uint256>
+MockTransactionSender::ExpectSuccess (
+    const unsigned n,
+    const std::string& name, const testing::Matcher<const std::string&>& m)
+{
+  std::vector<uint256> txids;
+  for (unsigned i = 0; i < n; ++i)
+    {
+      ++cnt;
+      std::ostringstream str;
+      str << "txid " << cnt;
+      const uint256 txid = SHA256::Hash (str.str ());
+
+      txids.push_back (txid);
+      txidQueue.push (txid);
+    }
+
+  EXPECT_CALL (*this, SendRawMove (name, m))
+      .Times (n)
+      .WillRepeatedly (InvokeWithoutArgs ([&] ()
+        {
+          const uint256 txid = txidQueue.front ();
+          txidQueue.pop ();
+
+          mempool.insert (txid);
+          return txid;
+        }));
+
+  return txids;
+}
+
+uint256
+MockTransactionSender::ExpectSuccess (
+    const std::string& name, const testing::Matcher<const std::string&>& m)
+{
+  const auto txids = ExpectSuccess (1, name, m);
+  CHECK_EQ (txids.size (), 1);
+  return txids[0];
+}
+
+void
+MockTransactionSender::ClearMempool ()
+{
+  LOG (INFO) << "Clearing simulated mempool of MockTransactionSender";
+  mempool.clear ();
+}
+
+bool
+MockTransactionSender::IsPending (const uint256& txid) const
+{
+  return mempool.count (txid) > 0;
+}
+
+void
+MockSignatureVerifier::SetValid (const std::string& sgn,
+                                 const std::string& addr)
+{
+  EXPECT_CALL (*this, RecoverSigner (_, sgn)).WillRepeatedly (Return (addr));
+}
+
+void
+MockSignatureVerifier::ExpectOne (const uint256& channelId,
+                                  const proto::ChannelMetadata& meta,
+                                  const std::string& topic,
+                                  const std::string& msg,
+                                  const std::string& sgn,
+                                  const std::string& addr)
+{
+  const std::string hashed
+      = GetChannelSignatureMessage (channelId, meta, topic, msg);
+  EXPECT_CALL (*this, RecoverSigner (hashed, sgn)).WillOnce (Return (addr));
+}
+
+} // namespace xaya

--- a/gamechannel/testutils.hpp
+++ b/gamechannel/testutils.hpp
@@ -1,0 +1,143 @@
+// Copyright (C) 2022 The Xaya developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef GAMECHANNEL_TESTUTILS_HPP
+#define GAMECHANNEL_TESTUTILS_HPP
+
+#include "movesender.hpp"
+#include "signatures.hpp"
+
+#include "proto/metadata.pb.h"
+
+#include <xayautil/uint256.hpp>
+
+#include <gmock/gmock.h>
+
+#include <queue>
+#include <string>
+#include <vector>
+
+namespace xaya
+{
+
+/**
+ * Mock signature verifier.
+ */
+class MockSignatureVerifier : public SignatureVerifier
+{
+
+public:
+
+  MOCK_METHOD (std::string, RecoverSigner,
+               (const std::string&, const std::string&), (const, override));
+
+  /**
+   * Sets up the mock to validate *any* message with the given
+   * signature as belonging to the given address.
+   */
+  void SetValid (const std::string& sgn, const std::string& addr);
+
+  /**
+   * Expects exactly one call to verification with the given message
+   * and signature (both as binary).  Returns a valid response for the
+   * given address.
+   */
+  void ExpectOne (const uint256& channelId,
+                  const proto::ChannelMetadata& meta,
+                  const std::string& topic,
+                  const std::string& msg, const std::string& sgn,
+                  const std::string& addr);
+
+};
+
+/**
+ * Mock signature signer.
+ */
+class MockSignatureSigner : public SignatureSigner
+{
+
+private:
+
+  /** The address returned from GetAddress.  */
+  std::string address;
+
+public:
+
+  /**
+   * Sets the address this signer should consider itself for.
+   */
+  void
+  SetAddress (const std::string& addr)
+  {
+    address = addr;
+  }
+
+  std::string
+  GetAddress () const override
+  {
+    return address;
+  }
+
+  MOCK_METHOD (std::string, SignMessage, (const std::string&), (override));
+
+};
+
+/**
+ * Fake instance for TransactionSender for testing.
+ */
+class MockTransactionSender : public TransactionSender
+{
+
+private:
+
+  /** The current simulated "mempool".  */
+  std::set<uint256> mempool;
+
+  /** The queue of txid's to be returned.  */
+  std::queue<uint256> txidQueue;
+
+  /** Counter used to generate unique txid's.  */
+  unsigned cnt = 0;
+
+public:
+
+  MockTransactionSender ();
+
+  /**
+   * Marks the mock for expecting a call with a raw string value that satisfies
+   * the given mater.  The call will throw an error.
+   */
+  void ExpectFailure (const std::string& name,
+                      const testing::Matcher<const std::string&>& m);
+
+  /**
+   * Marks the mock for expecting n calls where the passed-in string value
+   * satisfies a gMock matcher.  It will return a list of n unique txids
+   * (generated automatically), which the move calls will return and which will
+   * also be marked as pending until ClearMempool is called the next time.
+   */
+  std::vector<uint256> ExpectSuccess (
+      unsigned n, const std::string& name,
+      const testing::Matcher<const std::string&>& m);
+
+  /**
+   * Expects exactly one successful call.
+   */
+  uint256 ExpectSuccess (const std::string& name,
+                         const testing::Matcher<const std::string&>& m);
+
+  /**
+   * Clears the internal mempool, simulating a block being mined.
+   */
+  void ClearMempool ();
+
+  MOCK_METHOD (uint256, SendRawMove,
+               (const std::string&, const std::string&), (override));
+  bool IsPending (const uint256& txid) const override;
+
+};
+
+} // namespace xaya
+
+#endif // GAMECHANNEL_TESTUTILS_HPP

--- a/ships/Makefile.am
+++ b/ships/Makefile.am
@@ -91,6 +91,7 @@ tests_LDADD = \
   $(top_builddir)/xayagame/libtestutils.la \
   $(top_builddir)/xayagame/libxayagame.la \
   $(top_builddir)/gamechannel/libgamechannel.la \
+  $(top_builddir)/gamechannel/libtestutils.la \
   $(JSONCPP_LIBS) $(GLOG_LIBS) $(GTEST_LIBS) $(PROTOBUF_LIBS)
 tests_SOURCES = \
   board_tests.cpp \

--- a/ships/board.cpp
+++ b/ships/board.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2021 The Xaya developers
+// Copyright (C) 2019-2022 The Xaya developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -668,7 +668,7 @@ ShipsBoardState::ApplyPositionReveal (const proto::PositionRevealMove& mv,
 }
 
 bool
-ShipsBoardState::ApplyMoveProto (XayaRpcClient& rpc, const proto::BoardMove& mv,
+ShipsBoardState::ApplyMoveProto (const proto::BoardMove& mv,
                                  proto::BoardState& newState) const
 {
   /* Moves do typically incremental changes, so we start by copying the

--- a/ships/board.hpp
+++ b/ships/board.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2021 The Xaya developers
+// Copyright (C) 2019-2022 The Xaya developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -10,7 +10,6 @@
 
 #include <gamechannel/protoboard.hpp>
 #include <gamechannel/proto/metadata.pb.h>
-#include <xayagame/rpc-stubs/xayarpcclient.h>
 
 #include <json/json.h>
 
@@ -103,7 +102,7 @@ private:
 
 protected:
 
-  bool ApplyMoveProto (XayaRpcClient& rpc, const proto::BoardMove& mv,
+  bool ApplyMoveProto (const proto::BoardMove& mv,
                        proto::BoardState& newState) const override;
 
 public:

--- a/ships/board_tests.cpp
+++ b/ships/board_tests.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2021 The Xaya developers
+// Copyright (C) 2019-2022 The Xaya developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -9,7 +9,6 @@
 
 #include <gamechannel/proto/metadata.pb.h>
 #include <xayagame/testutils.hpp>
-#include <xayagame/rpc-stubs/xayarpcclient.h>
 #include <xayautil/base64.hpp>
 #include <xayautil/hash.hpp>
 #include <xayautil/uint256.hpp>
@@ -17,7 +16,6 @@
 #include <google/protobuf/text_format.h>
 #include <google/protobuf/util/message_differencer.h>
 
-#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include <algorithm>
@@ -25,8 +23,6 @@
 
 using google::protobuf::TextFormat;
 using google::protobuf::util::MessageDifferencer;
-using testing::_;
-using testing::Return;
 
 namespace ships
 {
@@ -160,10 +156,10 @@ protected:
    * Exposes ShipsBoardState::ApplyMoveProto to subtests.
    */
   static bool
-  ApplyMoveProto (const ShipsBoardState& s, XayaRpcClient& rpc,
+  ApplyMoveProto (const ShipsBoardState& s,
                   const proto::BoardMove& mv, proto::BoardState& newState)
   {
-    return s.ApplyMoveProto (rpc, mv, newState);
+    return s.ApplyMoveProto (mv, newState);
   }
 
 };
@@ -645,13 +641,10 @@ private:
     auto oldState = ParseState (state);
     CHECK (oldState != nullptr) << "Old state is invalid: " << state;
 
-    return ApplyMoveProto (*oldState, mockXayaServer.GetClient (),
-                           mv, newState);
+    return ApplyMoveProto (*oldState, mv, newState);
   }
 
 protected:
-
-  xaya::HttpRpcServer<xaya::MockXayaRpcServer> mockXayaServer;
 
   /**
    * Tries to apply a move onto the given state and expects that it is invalid.

--- a/ships/channel_tests.cpp
+++ b/ships/channel_tests.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2021 The Xaya developers
+// Copyright (C) 2019-2022 The Xaya developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -32,9 +32,7 @@ namespace
 
 using google::protobuf::TextFormat;
 using google::protobuf::util::MessageDifferencer;
-using testing::_;
 using testing::Return;
-using testing::Throw;
 using testing::Truly;
 
 /**
@@ -601,8 +599,6 @@ class FullGameTests : public ChannelTests
 
 private:
 
-  xaya::HttpRpcServer<xaya::MockXayaRpcServer> mockXayaServer;
-
   /** Indexable array of the channels.  */
   ShipsChannel* channels[2];
 
@@ -680,8 +676,7 @@ protected:
     CHECK (mv.SerializeToString (&serialised));
 
     xaya::BoardState newState;
-    CHECK (state->ApplyMove (mockXayaServer.GetClient (),
-                             serialised, newState));
+    CHECK (state->ApplyMove (serialised, newState));
 
     state = rules.ParseState (channelId, meta[0], newState);
     CHECK (state != nullptr);

--- a/ships/channel_tests.cpp
+++ b/ships/channel_tests.cpp
@@ -9,13 +9,10 @@
 #include "testutils.hpp"
 
 #include <gamechannel/protoutils.hpp>
-#include <xayagame/rpc-stubs/xayarpcclient.h>
-#include <xayagame/rpc-stubs/xayawalletrpcclient.h>
+#include <gamechannel/testutils.hpp>
 #include <xayagame/testutils.hpp>
 #include <xayautil/base64.hpp>
 #include <xayautil/hash.hpp>
-
-#include <jsonrpccpp/common/exception.h>
 
 #include <google/protobuf/text_format.h>
 #include <google/protobuf/util/message_differencer.h>
@@ -32,7 +29,6 @@ namespace
 
 using google::protobuf::TextFormat;
 using google::protobuf::util::MessageDifferencer;
-using testing::Return;
 using testing::Truly;
 
 /**
@@ -143,16 +139,11 @@ class OnChainMoveTests : public ChannelTests
 
 protected:
 
-  /* FIXME: Use mocked move sender.  */
-  xaya::HttpRpcServer<xaya::MockXayaRpcServer> mockXayaServer;
-  xaya::HttpRpcServer<xaya::MockXayaWalletRpcServer> mockXayaWallet;
-
-  xaya::RpcTransactionSender txSender;
+  xaya::MockTransactionSender txSender;
   xaya::MoveSender sender;
 
   OnChainMoveTests ()
-    : txSender (mockXayaServer.GetClient (), mockXayaWallet.GetClient ()),
-      sender("xs", channelId, "player", txSender, channel)
+    : sender("xs", channelId, "player", txSender, channel)
   {}
 
   /**
@@ -289,62 +280,17 @@ TEST_F (OnChainMoveTests, MaybeOnChainMoveSending)
       const auto& mv = val["g"]["xs"];
       return IsExpectedLoss (mv, channelId, meta[0]);
     };
-  EXPECT_CALL (*mockXayaWallet, name_update ("p/player", Truly (isOk)))
-      .WillOnce (Return (xaya::SHA256::Hash ("txid").ToHex ()));
+  txSender.ExpectSuccess (2, "player", Truly (isOk));
 
   proto::BoardState state;
   state.set_winner (1);
 
   channel.MaybeOnChainMove (*ParseState (state), sender);
-}
-
-TEST_F (OnChainMoveTests, MaybeOnChainMoveAlreadyPending)
-{
-  const auto txid = xaya::SHA256::Hash ("txid");
-
-  const auto isOk = [this] (const std::string& str)
-    {
-      const auto val = ParseJson (str);
-      const auto& mv = val["g"]["xs"];
-      return IsExpectedLoss (mv, channelId, meta[0]);
-    };
-  EXPECT_CALL (*mockXayaWallet, name_update ("p/player", Truly (isOk)))
-      .WillOnce (Return (txid.ToHex ()));
-
-  Json::Value pendings(Json::arrayValue);
-  pendings.append (txid.ToHex ());
-  EXPECT_CALL (*mockXayaServer, getrawmempool ())
-      .WillOnce (Return (pendings));
-
-  proto::BoardState state;
-  state.set_winner (1);
-
+  /* No second move is sent as the one is still pending.  */
   channel.MaybeOnChainMove (*ParseState (state), sender);
   channel.MaybeOnChainMove (*ParseState (state), sender);
-}
-
-TEST_F (OnChainMoveTests, MaybeOnChainMoveNoLongerPending)
-{
-  const auto txid1 = xaya::SHA256::Hash ("txid 1");
-  const auto txid2 = xaya::SHA256::Hash ("txid 2");
-
-  const auto isOk = [this] (const std::string& str)
-    {
-      const auto val = ParseJson (str);
-      const auto& mv = val["g"]["xs"];
-      return IsExpectedLoss (mv, channelId, meta[0]);
-    };
-  EXPECT_CALL (*mockXayaWallet, name_update ("p/player", Truly (isOk)))
-      .WillOnce (Return (txid1.ToHex ()))
-      .WillOnce (Return (txid2.ToHex ()));
-
-  EXPECT_CALL (*mockXayaServer, getrawmempool ())
-      .WillOnce (Return (ParseJson ("[]")));
-
-  proto::BoardState state;
-  state.set_winner (1);
-
-  channel.MaybeOnChainMove (*ParseState (state), sender);
+  /* This one will retry.  */
+  txSender.ClearMempool ();
   channel.MaybeOnChainMove (*ParseState (state), sender);
 }
 

--- a/ships/channel_tests.cpp
+++ b/ships/channel_tests.cpp
@@ -143,16 +143,16 @@ class OnChainMoveTests : public ChannelTests
 
 protected:
 
+  /* FIXME: Use mocked move sender.  */
   xaya::HttpRpcServer<xaya::MockXayaRpcServer> mockXayaServer;
   xaya::HttpRpcServer<xaya::MockXayaWalletRpcServer> mockXayaWallet;
 
+  xaya::RpcTransactionSender txSender;
   xaya::MoveSender sender;
 
   OnChainMoveTests ()
-    : sender("xs", channelId, "player",
-             mockXayaServer.GetClient (),
-             mockXayaWallet.GetClient (),
-             channel)
+    : txSender (mockXayaServer.GetClient (), mockXayaWallet.GetClient ()),
+      sender("xs", channelId, "player", txSender, channel)
   {}
 
   /**

--- a/ships/channeltest/disputes.py
+++ b/ships/channeltest/disputes.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (C) 2019-2020 The Xaya developers
+# Copyright (C) 2019-2022 The Xaya developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -19,12 +19,12 @@ class DisputesTest (ShipsTest):
 
     # Create a test channel with two participants.
     self.mainLogger.info ("Creating test channel...")
-    channelId = self.openChannel (["foo", "bar"])
+    channelId, addr = self.openChannel (["foo", "bar"])
 
     # Start up the two channel daemons.
     self.mainLogger.info ("Starting channel daemons...")
-    with self.runChannelDaemon (channelId, "foo") as foo, \
-         self.runChannelDaemon (channelId, "bar") as bar:
+    with self.runChannelDaemon (channelId, "foo", addr[0]) as foo, \
+         self.runChannelDaemon (channelId, "bar", addr[1]) as bar:
 
       daemons = [foo, bar]
 

--- a/ships/channeltest/force_close.py
+++ b/ships/channeltest/force_close.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (C) 2021 The Xaya developers
+# Copyright (C) 2021-2022 The Xaya developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -19,11 +19,11 @@ class ForceCloseTest (ShipsTest):
     self.generate (150)
 
     self.mainLogger.info ("Creating test channel...")
-    channelId = self.openChannel (["foo", "bar"])
+    channelId, addr = self.openChannel (["foo", "bar"])
 
     self.mainLogger.info ("Starting channel daemons...")
-    with self.runChannelDaemon (channelId, "foo") as foo, \
-         self.runChannelDaemon (channelId, "bar") as bar:
+    with self.runChannelDaemon (channelId, "foo", addr[0]) as foo, \
+         self.runChannelDaemon (channelId, "bar", addr[1]) as bar:
 
       daemons = [foo, bar]
 

--- a/ships/channeltest/full_game.py
+++ b/ships/channeltest/full_game.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (C) 2019-2020 The Xaya developers
+# Copyright (C) 2019-2022 The Xaya developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -20,19 +20,20 @@ class FullGameTest (ShipsTest):
     # Create a test channel with two participants (but with the join
     # not yet confirmed on chain).
     self.mainLogger.info ("Creating test channel...")
+    addr = [self.newSigningAddress () for _ in range (2)]
     channelId = self.sendMove ("foo", {"c": {
-      "addr": self.newSigningAddress (),
+      "addr": addr[0],
     }})
     self.generate (1)
     self.sendMove ("bar", {"j": {
       "id": channelId,
-      "addr": self.newSigningAddress (),
+      "addr": addr[1],
     }})
 
     # Start up the two channel daemons.
     self.mainLogger.info ("Starting channel daemons...")
-    with self.runChannelDaemon (channelId, "foo") as foo, \
-         self.runChannelDaemon (channelId, "bar") as bar:
+    with self.runChannelDaemon (channelId, "foo", addr[0]) as foo, \
+         self.runChannelDaemon (channelId, "bar", addr[1]) as bar:
 
       daemons = [foo, bar]
       state = self.getSyncedChannelState (daemons)

--- a/ships/channeltest/pending.py
+++ b/ships/channeltest/pending.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (C) 2019-2020 The Xaya developers
+# Copyright (C) 2019-2022 The Xaya developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -17,12 +17,12 @@ class PendingTest (ShipsTest):
 
     # Create a test channel with two participants.
     self.mainLogger.info ("Creating test channel...")
-    channelId = self.openChannel (["foo", "bar"])
+    channelId, addr = self.openChannel (["foo", "bar"])
 
     # Start up the two channel daemons.
     self.mainLogger.info ("Starting channel daemons...")
-    with self.runChannelDaemon (channelId, "foo") as foo, \
-         self.runChannelDaemon (channelId, "bar") as bar:
+    with self.runChannelDaemon (channelId, "foo", addr[0]) as foo, \
+         self.runChannelDaemon (channelId, "bar", addr[1]) as bar:
 
       daemons = [foo, bar]
 

--- a/ships/channeltest/reorg.py
+++ b/ships/channeltest/reorg.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (C) 2019-2021 The Xaya developers
+# Copyright (C) 2019-2022 The Xaya developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -20,14 +20,15 @@ class ReogTest (ShipsTest):
     # where it was created and joined by the second one, so that we can
     # later invalidate those.
     self.mainLogger.info ("Creating test channel...")
+    addr = [self.newSigningAddress () for _ in range (3)]
     channelId = self.sendMove ("foo", {"c": {
-      "addr": self.newSigningAddress (),
+      "addr": addr[0],
     }})
     self.generate (1)
     createBlk = self.rpc.xaya.getbestblockhash ()
     self.sendMove ("bar", {"j": {
       "id": channelId,
-      "addr": self.newSigningAddress (),
+      "addr": addr[1],
     }})
     self.generate (1)
     joinBlk = self.rpc.xaya.getbestblockhash ()
@@ -36,9 +37,9 @@ class ReogTest (ShipsTest):
     # a third one, which will join the channel later in a reorged
     # alternate reality.
     self.mainLogger.info ("Starting channel daemons...")
-    with self.runChannelDaemon (channelId, "foo") as foo, \
-         self.runChannelDaemon (channelId, "bar") as bar, \
-         self.runChannelDaemon (channelId, "baz") as baz:
+    with self.runChannelDaemon (channelId, "foo", addr[0]) as foo, \
+         self.runChannelDaemon (channelId, "bar", addr[1]) as bar, \
+         self.runChannelDaemon (channelId, "baz", addr[2]) as baz:
 
       daemons = [foo, bar, baz]
 
@@ -82,7 +83,7 @@ class ReogTest (ShipsTest):
       self.mainLogger.info ("Alternate join...")
       self.sendMove ("baz", {"j": {
         "id": channelId,
-        "addr": self.newSigningAddress (),
+        "addr": addr[2],
       }})
       self.expectPendingMoves ("bar", [])
       self.expectPendingMoves ("baz", ["j"])

--- a/ships/channeltest/tx_fail.py
+++ b/ships/channeltest/tx_fail.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (C) 2019-2021 The Xaya developers
+# Copyright (C) 2019-2022 The Xaya developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -19,12 +19,12 @@ class TxFailTest (ShipsTest):
 
     # Create a test channel with two participants.
     self.mainLogger.info ("Creating test channel...")
-    channelId = self.openChannel (["foo", "bar"])
+    channelId, addr = self.openChannel (["foo", "bar"])
 
     # Start up the two channel daemons.
     self.mainLogger.info ("Starting channel daemons...")
-    with self.runChannelDaemon (channelId, "foo") as foo, \
-         self.runChannelDaemon (channelId, "bar") as bar:
+    with self.runChannelDaemon (channelId, "foo", addr[0]) as foo, \
+         self.runChannelDaemon (channelId, "bar", addr[1]) as bar:
 
       daemons = [foo, bar]
 

--- a/ships/channeltest/validateposition.py
+++ b/ships/channeltest/validateposition.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (C) 2019-2020 The Xaya developers
+# Copyright (C) 2019-2022 The Xaya developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -18,7 +18,8 @@ class ValidatePositionTest (ShipsTest):
     channelId = "ab" * 32
 
     self.mainLogger.info ("Starting channel daemons...")
-    with self.runChannelDaemon (channelId, "foo") as ch:
+    addr = self.newSigningAddress ()
+    with self.runChannelDaemon (channelId, "foo", addr) as ch:
       self.mainLogger.info ("Testing validateposition...")
       self.assertEqual (False, ch.rpc.validateposition ("invalid string"))
       self.assertEqual (False, ch.rpc.validateposition ("""

--- a/ships/channeltest/waitforchange.py
+++ b/ships/channeltest/waitforchange.py
@@ -111,12 +111,12 @@ class WaitForChangeTest (ShipsTest):
 
     # Create a test channel with two participants.
     self.mainLogger.info ("Creating test channel...")
-    channelId = self.openChannel (["foo", "bar"])
+    channelId, addr = self.openChannel (["foo", "bar"])
 
     # Start up the two channel daemons.
     self.mainLogger.info ("Starting channel daemons...")
-    with self.runChannelDaemon (channelId, "foo") as foo, \
-         self.runChannelDaemon (channelId, "bar") as bar, \
+    with self.runChannelDaemon (channelId, "foo", addr[0]) as foo, \
+         self.runChannelDaemon (channelId, "bar", addr[1]) as bar, \
          WaitForChangeUpdater (foo) as waiter:
 
       daemons = [foo, bar]

--- a/ships/gametest/channel_management.py
+++ b/ships/gametest/channel_management.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (C) 2019-2021 The Xaya developers
+# Copyright (C) 2019-2022 The Xaya developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -25,12 +25,10 @@ class ChannelManagementTest (ShipsTest):
 
     # Create three channels with single participants for now.
     self.mainLogger.info ("Creating two channels...")
-    addr1 = self.rpc.xaya.getnewaddress ()
-    id1 = self.sendMove ("foo", {"c": {"addr": addr1}})
-    addr2 = self.rpc.xaya.getnewaddress ()
-    id2 = self.sendMove ("bar", {"c": {"addr": addr2}})
-    addr3 = self.rpc.xaya.getnewaddress ()
-    id3 = self.sendMove ("baz", {"c": {"addr": addr3}})
+    addr = [self.newSigningAddress () for _ in range (4)]
+    id1 = self.sendMove ("foo", {"c": {"addr": addr[0]}})
+    id2 = self.sendMove ("bar", {"c": {"addr": addr[1]}})
+    id3 = self.sendMove ("baz", {"c": {"addr": addr[2]}})
     self.generate (1)
 
     state = self.getGameState ()
@@ -41,14 +39,14 @@ class ChannelManagementTest (ShipsTest):
     assert id1 in channels
     ch1 = channels[id1]
     self.assertEqual (ch1["meta"]["participants"], [
-      {"name": "foo", "address": addr1}
+      {"name": "foo", "address": addr[0]}
     ])
     self.assertEqual (ch1["state"]["parsed"]["phase"], "single participant")
 
     assert id2 in channels
     ch2 = channels[id2]
     self.assertEqual (ch2["meta"]["participants"], [
-      {"name": "bar", "address": addr2}
+      {"name": "bar", "address": addr[1]}
     ])
     self.assertEqual (ch2["state"]["parsed"]["phase"], "single participant")
 
@@ -57,15 +55,14 @@ class ChannelManagementTest (ShipsTest):
     # Perform an invalid join and abort on the channels. This should not affect
     # the state at all.
     self.mainLogger.info ("Trying invalid operations...")
-    addr3 = self.rpc.xaya.getnewaddress ()
-    self.sendMove ("foo", {"j": {"id": id1, "addr": addr3}})
+    self.sendMove ("foo", {"j": {"id": id1, "addr": addr[3]}})
     self.sendMove ("baz", {"a": {"id": id2}})
     self.generate (1)
     self.expectGameState (state)
 
     # Join one of the channels and abort the other, this time for real.
     self.mainLogger.info ("Joining and aborting the channels...")
-    self.sendMove ("baz", {"j": {"id": id1, "addr": addr3}})
+    self.sendMove ("baz", {"j": {"id": id1, "addr": addr[3]}})
     self.sendMove ("bar", {"a": {"id": id2}})
     self.generate (1)
 
@@ -77,8 +74,8 @@ class ChannelManagementTest (ShipsTest):
     assert id1 in channels
     ch1 = channels[id1]
     self.assertEqual (ch1["meta"]["participants"], [
-      {"name": "foo", "address": addr1},
-      {"name": "baz", "address": addr3},
+      {"name": "foo", "address": addr[0]},
+      {"name": "baz", "address": addr[3]},
     ])
     self.assertEqual (ch1["state"]["parsed"]["phase"], "first commitment")
 

--- a/ships/gametest/disputes.py
+++ b/ships/gametest/disputes.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (C) 2019-2020 The Xaya developers
+# Copyright (C) 2019-2022 The Xaya developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -17,9 +17,7 @@ class DisputeTest (ShipsTest):
 
     # Create a test channel with two participants.
     self.mainLogger.info ("Opening a test channel...")
-    addr1 = self.rpc.xaya.getnewaddress ()
-    addr2 = self.rpc.xaya.getnewaddress ()
-    cid = self.openChannel (["foo", "bar"], [addr1, addr2])
+    cid, _ = self.openChannel (["foo", "bar"])
     self.expectChannelState (cid, "first commitment", None)
 
     # Open a dispute.

--- a/ships/gametest/force_close.py
+++ b/ships/gametest/force_close.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (C) 2021 The Xaya developers
+# Copyright (C) 2021-2022 The Xaya developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -18,9 +18,7 @@ class ForceCloseTest (ShipsTest):
 
     # Create a test channel with two participants.
     self.mainLogger.info ("Opening a test channel...")
-    addr1 = self.rpc.xaya.getnewaddress ()
-    addr2 = self.rpc.xaya.getnewaddress ()
-    cid = self.openChannel (["foo", "bar"], [addr1, addr2])
+    cid, _ = self.openChannel (["foo", "bar"])
     self.expectChannelState (cid, "first commitment", None)
 
     # Filing a dispute at the end state doesn't work as it is a no-turn

--- a/ships/gametest/getchannel.py
+++ b/ships/gametest/getchannel.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (C) 2019-2020 The Xaya developers
+# Copyright (C) 2019-2022 The Xaya developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -21,11 +21,10 @@ class GetChannelTest (ShipsTest):
 
     # Create a test channel and join it.
     self.mainLogger.info ("Creating test channel...")
-    addr1 = self.rpc.xaya.getnewaddress ()
-    channelId = self.sendMove ("foo", {"c": {"addr": addr1}})
+    addr = [self.newSigningAddress () for _ in range (2)]
+    channelId = self.sendMove ("foo", {"c": {"addr": addr[0]}})
     self.generate (1)
-    addr2 = self.rpc.xaya.getnewaddress ()
-    self.sendMove ("bar", {"j": {"id": channelId, "addr": addr2}})
+    self.sendMove ("bar", {"j": {"id": channelId, "addr": addr[1]}})
     self.generate (1)
 
     # Verify the channel using getcurrentstate.
@@ -38,8 +37,8 @@ class GetChannelTest (ShipsTest):
     assert channelId in channels
     ch = channels[channelId]
     self.assertEqual (ch["meta"]["participants"], [
-      {"name": "foo", "address": addr1},
-      {"name": "bar", "address": addr2},
+      {"name": "foo", "address": addr[0]},
+      {"name": "bar", "address": addr[1]},
     ])
     self.assertEqual (ch["state"]["parsed"]["phase"], "first commitment")
 

--- a/ships/gametest/reorg.py
+++ b/ships/gametest/reorg.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (C) 2019-2021 The Xaya developers
+# Copyright (C) 2019-2022 The Xaya developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -17,9 +17,7 @@ class ReorgTest (ShipsTest):
 
     # Create a test channel with two participants.
     self.mainLogger.info ("Opening a test channel...")
-    addr1 = self.rpc.xaya.getnewaddress ()
-    addr2 = self.rpc.xaya.getnewaddress ()
-    cid = self.openChannel (["foo", "bar"], [addr1, addr2])
+    cid, _ = self.openChannel (["foo", "bar"])
     self.expectChannelState (cid, "first commitment", None)
 
     # Open a dispute.

--- a/ships/gametest/shipstest.py
+++ b/ships/gametest/shipstest.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2019-2021 The Xaya developers
+# Copyright (C) 2019-2022 The Xaya developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -35,13 +35,12 @@ class ShipsTest (channeltest.TestCase):
   def openChannel (self, names, addresses=None):
     """
     Creates a channel and joins it, so that we end up with a fully set-up
-    channel and two participants.  names and addresses should be arrays of
-    length two each, giving the names / addresses for the participants.
-    Returns the ID of the created channel.
+    channel and two participants.  names hould be an array of
+    length two, giving the names for the participants.
+    Returns the ID of the created channel and their signing addresses.
     """
 
-    if addresses is None:
-      addresses = [self.newSigningAddress () for _ in range (2)]
+    addresses = [self.newSigningAddress () for _ in range (2)]
 
     self.assertEqual (len (names), 2)
     self.assertEqual (len (addresses), 2)
@@ -53,7 +52,7 @@ class ShipsTest (channeltest.TestCase):
     state = self.getGameState ()
     assert cid in state["channels"]
 
-    return cid
+    return cid, addresses
 
   def getStateProof (self, cid, stateStr):
     """

--- a/ships/logic_tests.cpp
+++ b/ships/logic_tests.cpp
@@ -21,6 +21,8 @@
 
 #include <vector>
 
+/* FIXME: Replace mockXayaServer by mocked signature verifier */
+
 using google::protobuf::TextFormat;
 using testing::_;
 using testing::Return;

--- a/ships/main-channel.cpp
+++ b/ships/main-channel.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2021 The Xaya developers
+// Copyright (C) 2019-2022 The Xaya developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -47,6 +47,8 @@ DEFINE_bool (rpc_listen_locally, true,
 
 DEFINE_string (playername, "",
                "the Xaya name of the player for this channel (without p/)");
+DEFINE_string (address, "",
+               "the Xaya address used for signing on the channel");
 DEFINE_string (channelid, "", "ID of the channel to manage as hex string");
 
 } // anonymous namespace
@@ -82,6 +84,11 @@ main (int argc, char** argv)
       std::cerr << "Error: --playername must be set" << std::endl;
       return EXIT_FAILURE;
     }
+  if (FLAGS_address.empty ())
+    {
+      std::cerr << "Error: --address must be set" << std::endl;
+      return EXIT_FAILURE;
+    }
 
   xaya::uint256 channelId;
   if (!channelId.FromHex (FLAGS_channelid))
@@ -93,7 +100,8 @@ main (int argc, char** argv)
   ships::ShipsBoardRules rules;
   ships::ShipsChannel channel(FLAGS_playername);
 
-  xaya::ChannelDaemon daemon("xs", channelId, FLAGS_playername,
+  xaya::ChannelDaemon daemon("xs", channelId,
+                             FLAGS_playername, FLAGS_address,
                              rules, channel);
   daemon.ConnectXayaRpc (FLAGS_xaya_rpc_url, FLAGS_xaya_rpc_legacy_protocol);
   daemon.ConnectGspRpc (FLAGS_gsp_rpc_url);

--- a/ships/main-channel.cpp
+++ b/ships/main-channel.cpp
@@ -9,6 +9,7 @@
 
 #include <gamechannel/daemon.hpp>
 #include <gamechannel/rpcbroadcast.hpp>
+#include <xayagame/rpc-stubs/xayarpcclient.h>
 #include <xayagame/rpc-stubs/xayawalletrpcclient.h>
 
 #include <jsonrpccpp/client/connectors/httpclient.h>
@@ -97,13 +98,22 @@ main (int argc, char** argv)
       return EXIT_FAILURE;
     }
 
+  const auto rpcVersion = (FLAGS_xaya_rpc_legacy_protocol
+                              ? jsonrpc::JSONRPC_CLIENT_V1
+                              : jsonrpc::JSONRPC_CLIENT_V2);
+  jsonrpc::HttpClient xayaClient(FLAGS_xaya_rpc_url);
+  XayaRpcClient xayaRpc(xayaClient, rpcVersion);
+  XayaWalletRpcClient xayaWallet(xayaClient, rpcVersion);
+
+  const xaya::RpcSignatureVerifier verifier(xayaRpc);
+  xaya::RpcSignatureSigner signer(xayaWallet, FLAGS_address);
+  xaya::RpcTransactionSender sender(xayaRpc, xayaWallet);
+
   ships::ShipsBoardRules rules;
   ships::ShipsChannel channel(FLAGS_playername);
 
-  xaya::ChannelDaemon daemon("xs", channelId,
-                             FLAGS_playername, FLAGS_address,
-                             rules, channel);
-  daemon.ConnectXayaRpc (FLAGS_xaya_rpc_url, FLAGS_xaya_rpc_legacy_protocol);
+  xaya::ChannelDaemon daemon("xs", channelId, FLAGS_playername, rules, channel);
+  daemon.ConnectWallet (verifier, signer, sender);
   daemon.ConnectGspRpc (FLAGS_gsp_rpc_url);
 
   xaya::RpcBroadcast bc(FLAGS_broadcast_rpc_url, daemon.GetChannelManager ());

--- a/ships/testutils.cpp
+++ b/ships/testutils.cpp
@@ -26,10 +26,10 @@ ParseJson (const std::string& str)
 }
 
 InMemoryLogicFixture::InMemoryLogicFixture ()
+  : game(verifier)
 {
   game.Initialise (":memory:");
-  game.InitialiseGameContext (xaya::Chain::MAIN, "xs",
-                              &mockXayaServer.GetClient ());
+  game.InitialiseGameContext (xaya::Chain::MAIN, "xs", nullptr);
   game.GetStorage ().Initialise ();
   /* The initialisation above already sets up the database schema.  */
 }

--- a/ships/testutils.hpp
+++ b/ships/testutils.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2020 The Xaya developers
+// Copyright (C) 2019-2022 The Xaya developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -8,9 +8,10 @@
 #include "grid.hpp"
 #include "logic.hpp"
 
+#include <gamechannel/signatures.hpp>
+#include <gamechannel/testutils.hpp>
 #include <xayagame/sqlitestorage.hpp>
 #include <xayagame/testutils.hpp>
-#include <xayagame/rpc-stubs/xayarpcclient.h>
 
 #include <json/json.h>
 
@@ -34,11 +35,40 @@ Json::Value ParseJson (const std::string& str);
 class InMemoryLogicFixture : public testing::Test
 {
 
+private:
+
+  /**
+   * Helper class that is essentially a ShipsLogic but using a mock
+   * signature verifier rather than the RPC one.
+   */
+  class ShipsLogicWithVerifier : public ShipsLogic
+  {
+
+  private:
+
+    /** The verifier used.  */
+    const xaya::SignatureVerifier& verifier;
+
+  protected:
+
+    const xaya::SignatureVerifier&
+    GetSignatureVerifier () override
+    {
+      return verifier;
+    }
+
+  public:
+
+    explicit ShipsLogicWithVerifier (const xaya::SignatureVerifier& v)
+      : verifier(v)
+    {}
+
+  };
+
 protected:
 
-  xaya::HttpRpcServer<xaya::MockXayaRpcServer> mockXayaServer;
-
-  ShipsLogic game;
+  xaya::MockSignatureVerifier verifier;
+  ShipsLogicWithVerifier game;
 
   /**
    * Initialises the test case.  This connects the game instance to an


### PR DESCRIPTION
This is a first step in decoupling / simplifying the code game-channels code.  In particular, this code was very deeply depending on an RPC connection to Xaya Core to handle signing/verification of moves, and triggering of on-chain moves for disputes and resolutions.  This set of changes introduces abstract interfaces for these tasks, and replaces the direct use of RPC connections with those interfaces in many places.  The production-implementation of the interfaces is still based on the same RPC calls as before.  But with this structure, it will be possible to e.g. introduce direct signing/verification code instead (perhaps for Ethereum-based blockchains).

With this, the unit tests can be simplified, as they can directly mock / implement the interfaces without having to go through a real JSON-RPC server.  It will also make it easier to use the game-channel code e.g. for games on Polygon, and do things like run the channel daemon in a browser with wasm.