### PR TITLE
Remove threading from core game-channel code

### DIFF
--- a/gamechannel/broadcast.cpp
+++ b/gamechannel/broadcast.cpp
@@ -73,8 +73,9 @@ OffChainBroadcast::ProcessIncoming (ChannelManager& m,
 
 /* ************************************************************************** */
 
-ReceivingOffChainBroadcast::ReceivingOffChainBroadcast (ChannelManager& cm)
-  : OffChainBroadcast(cm.GetChannelId ()), manager(&cm)
+ReceivingOffChainBroadcast::ReceivingOffChainBroadcast (
+    SynchronisedChannelManager& cm)
+  : OffChainBroadcast(cm.Read ()->GetChannelId ()), manager(&cm)
 {}
 
 ReceivingOffChainBroadcast::ReceivingOffChainBroadcast (const uint256& i)
@@ -143,7 +144,8 @@ ReceivingOffChainBroadcast::FeedMessage (const std::string& msg)
 {
   CHECK (manager != nullptr)
       << "Without ChannelManager, FeedMessage must be overridden";
-  ProcessIncoming (*manager, msg);
+  auto cmLocked = manager->Access ();
+  ProcessIncoming (*cmLocked, msg);
 }
 
 /* ************************************************************************** */

--- a/gamechannel/broadcast.hpp
+++ b/gamechannel/broadcast.hpp
@@ -21,6 +21,7 @@ namespace xaya
 {
 
 class ChannelManager;
+class SynchronisedChannelManager;
 
 /**
  * This class handles the off-chain broadcast of messages within a channel.
@@ -137,7 +138,7 @@ private:
    * For testing purposes it can be null, in which case we require that
    * FeedMessage is overridden in a subclass to handle the messages directly.
    */
-  ChannelManager* manager;
+  SynchronisedChannelManager* manager;
 
   /** The currently running wait loop, if any.  */
   std::unique_ptr<std::thread> loop;
@@ -187,7 +188,7 @@ public:
    * Constructs an instance for normal use.  It will feed messages into
    * the given ChannelManager.
    */
-  explicit ReceivingOffChainBroadcast (ChannelManager& cm);
+  explicit ReceivingOffChainBroadcast (SynchronisedChannelManager& cm);
 
   ~ReceivingOffChainBroadcast ();
 

--- a/gamechannel/broadcast.hpp
+++ b/gamechannel/broadcast.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2021 The Xaya developers
+// Copyright (C) 2019-2022 The Xaya developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -12,7 +12,6 @@
 
 #include <atomic>
 #include <memory>
-#include <mutex>
 #include <set>
 #include <string>
 #include <thread>
@@ -29,34 +28,19 @@ class ChannelManager;
  * exchanging messages (e.g. via a server, XMPP, IRC, P2P, ...) have to
  * subclass OffChainBroadcaster and implement their logic.
  *
- * For sending messages (local moves to everyone else in the channel),
- * subclasses need to implement the SendMessage function.  Receiving
- * messages is more complex, as that needs to take care of waiting for
- * incoming messages.
+ * The core interface in this class provides functionality to send
+ * mossages (local moves to everyone else in the channel).  This is what
+ * gets directly used by the ChannelManager and must be provided to it.
  *
- * There are two general architectures that implementations can use for
- * that:  If they have their own event loop, then they should override the
- * Start and Stop methods, and feed messages they receive to FeedMessage.
- *
- * Alternatively, the default implementation of Start and Stop will run
- * a waiting loop in a new thread, and repeatedly call GetMessages to
- * retrieve the next message in a blocking call.
+ * Receiving messages and feeding them into ChannelManager::ProcessOffChain
+ * is a separate task, which is not directly handled by this class.
  */
 class OffChainBroadcast
 {
 
 private:
 
-  /**
-   * The ChannelManager instance that is updated with received messges.
-   *
-   * For testing purposes it can be null, in which case the channel ID
-   * is directly set and we require that FeedMessage is overridden
-   * in a subclass to handle the messages directly.
-   */
-  ChannelManager* manager;
-
-  /** The corresponding channel ID.  */
+  /** The channel ID this is for.  */
   const uint256 id;
 
   /**
@@ -67,12 +51,93 @@ private:
    */
   std::set<std::string> participants;
 
+protected:
+
   /**
-   * Lock for shared state, in particular participants.  This lock is held
-   * while SendNewState is running.  It is not held through the receive
-   * cycle, though.
+   * Sends a given encoded message to all participants in the channel.
    */
-  mutable std::mutex mut;
+  virtual void SendMessage (const std::string& msg) = 0;
+
+public:
+
+  /**
+   * Constructs an instance for the given channel ID.
+   */
+  explicit OffChainBroadcast (const uint256& i)
+    : id(i)
+  {}
+
+  virtual ~OffChainBroadcast () = default;
+
+  OffChainBroadcast () = delete;
+  OffChainBroadcast (const OffChainBroadcast&) = delete;
+  void operator= (const OffChainBroadcast&) = delete;
+
+  /**
+   * Returns the ID of the channel for which this is.  Can be used by
+   * implementations if they need it.
+   */
+  const uint256&
+  GetChannelId () const
+  {
+    return id;
+  }
+
+  /**
+   * Sends a new state (presumably after the player made a move) to all
+   * channel participants.
+   */
+  void SendNewState (const std::string& reinitId,
+                     const proto::StateProof& proof);
+
+  /**
+   * Returns the current list of participants.  This may be used by
+   * subclasses for their implementation of SendMessage.
+   */
+  const std::set<std::string>&
+  GetParticipants () const
+  {
+    return participants;
+  }
+
+  /**
+   * Updates the list of channel participants when the on-chain state changes.
+   */
+  void SetParticipants (const proto::ChannelMetadata& meta);
+
+  /**
+   * Decodes a message and feeds the corresponding state into the
+   * ChannelManager's ProcessOffChain method.  It is assumed that
+   * this instance is used as OffChainBroadcast on the channel manager m.
+   */
+  void ProcessIncoming (ChannelManager& m, const std::string& msg) const;
+
+};
+
+/**
+ * A subclass of OffChainBroadcast, which also takes care of an event loop
+ * for receiving messages.
+ *
+ * There are two general architectures that implementations can use for
+ * that:  If they have their own event loop, then they should override the
+ * Start and Stop methods, and feed messages they receive to FeedMessage.
+ *
+ * Alternatively, the default implementation of Start and Stop will run
+ * a waiting loop in a new thread, and repeatedly call GetMessages to
+ * retrieve the next message in a blocking call.
+ */
+class ReceivingOffChainBroadcast : public OffChainBroadcast
+{
+
+private:
+
+  /**
+   * The ChannelManager instance that is updated with received messages.
+   *
+   * For testing purposes it can be null, in which case we require that
+   * FeedMessage is overridden in a subclass to handle the messages directly.
+   */
+  ChannelManager* manager;
 
   /** The currently running wait loop, if any.  */
   std::unique_ptr<std::thread> loop;
@@ -88,47 +153,12 @@ private:
 protected:
 
   /**
-   * Constructs an instance for normal use.  It will feed messages into
-   * the given ChannelManager.
-   */
-  explicit OffChainBroadcast (ChannelManager& cm);
-
-  /**
    * Constructs an instance without a ChannelManager but the given explicit
    * channel ID.  This can be used for testing broadcast implementations;
    * in those tests, the FeedMessage method must be overridden to handle
    * messages directly.
    */
-  explicit OffChainBroadcast (const uint256& i);
-
-  /**
-   * Returns the current list of participants.  This may be used by
-   * subclasses for their implementation of SendMessage.  While SendMessage
-   * is running, the participants are properly synchronised.  At any other
-   * time, calling this function may lead to race conditions.
-   */
-  const std::set<std::string>&
-  GetParticipants () const
-  {
-    return participants;
-  }
-
-  /**
-   * Returns the ID of the channel for which this is.  Can be used by
-   * implementations if they need it.
-   */
-  const uint256&
-  GetChannelId () const
-  {
-    return id;
-  }
-
-  /**
-   * Sends a given encoded message to all participants in the channel.
-   * This function may be called from different threads, but it is guaranteed
-   * that it is only called by one concurrent thread at any time.
-   */
-  virtual void SendMessage (const std::string& msg) = 0;
+  explicit ReceivingOffChainBroadcast (const uint256& i);
 
   /**
    * Processes a message retrieved through the broadcast channel.  If the
@@ -153,23 +183,13 @@ protected:
 
 public:
 
-  virtual ~OffChainBroadcast ();
-
-  OffChainBroadcast () = delete;
-  OffChainBroadcast (const OffChainBroadcast&) = delete;
-  void operator= (const OffChainBroadcast&) = delete;
-
   /**
-   * Sends a new state (presumably after the player made a move) to all
-   * channel participants.
+   * Constructs an instance for normal use.  It will feed messages into
+   * the given ChannelManager.
    */
-  void SendNewState (const std::string& reinitId,
-                     const proto::StateProof& proof);
+  explicit ReceivingOffChainBroadcast (ChannelManager& cm);
 
-  /**
-   * Updates the list of channel participants when the on-chain state changes.
-   */
-  void SetParticipants (const proto::ChannelMetadata& meta);
+  ~ReceivingOffChainBroadcast ();
 
   /**
    * Starts an event loop listening for new messages and feeding them into

--- a/gamechannel/broadcast_tests.cpp
+++ b/gamechannel/broadcast_tests.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 The Xaya developers
+// Copyright (C) 2019-2022 The Xaya developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -9,6 +9,7 @@
 
 #include <google/protobuf/text_format.h>
 
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include <glog/logging.h>
@@ -22,15 +23,62 @@ namespace
 {
 
 using google::protobuf::TextFormat;
+using testing::_;
+using testing::IsEmpty;
+using testing::UnorderedElementsAre;
 
 /** Timeout for the waiters in the test broadcast.  */
 constexpr auto WAITER_TIMEOUT = std::chrono::milliseconds (50);
+
+/* ************************************************************************** */
+
+class MockBroadcast : public OffChainBroadcast
+{
+
+public:
+
+  explicit MockBroadcast (const uint256& i)
+    : OffChainBroadcast(i)
+  {
+    EXPECT_CALL (*this, SendMessage (_)).Times (0);
+  }
+
+  MOCK_METHOD (void, SendMessage, (const std::string&), (override));
+
+};
+
+class BroadcastTests : public ChannelManagerTestFixture
+{
+
+protected:
+
+  MockBroadcast offChain;
+
+  BroadcastTests ()
+    : offChain(cm.GetChannelId ())
+  {
+    cm.SetOffChainBroadcast (offChain);
+  }
+
+};
+
+TEST_F (BroadcastTests, Participants)
+{
+  ProcessOnChain ("0 0", ValidProof ("10 5"), 0);
+  EXPECT_THAT (offChain.GetParticipants (),
+               UnorderedElementsAre ("player", "other"));
+
+  ProcessOnChainNonExistant ();
+  EXPECT_THAT (offChain.GetParticipants (), IsEmpty ());
+}
+
+/* ************************************************************************** */
 
 /**
  * Implementation of OffChainBroadcast that simply feeds sent messages back
  * to GetMessages using a condition variable.
  */
-class FeedBackBroadcast : public OffChainBroadcast
+class FeedBackBroadcast : public ReceivingOffChainBroadcast
 {
 
 private:
@@ -63,10 +111,8 @@ protected:
 public:
 
   explicit FeedBackBroadcast (ChannelManager& cm)
-    : OffChainBroadcast(cm)
+    : ReceivingOffChainBroadcast(cm)
   {}
-
-  using OffChainBroadcast::GetParticipants;
 
   /**
    * Forwards the queued messages (by notifying the waiting thread).
@@ -80,46 +126,28 @@ public:
 
 };
 
-class BroadcastTests : public ChannelManagerTestFixture
+class ReceivingBroadcastTests : public ChannelManagerTestFixture
 {
 
 protected:
 
   FeedBackBroadcast offChain;
 
-  BroadcastTests ()
+  ReceivingBroadcastTests ()
     : offChain(cm)
   {
     cm.SetOffChainBroadcast (offChain);
     offChain.Start ();
   }
 
-  ~BroadcastTests ()
+  ~ReceivingBroadcastTests ()
   {
     offChain.Stop ();
   }
 
-  /**
-   * Expects the given list of participants.
-   */
-  void
-  ExpectParticipants (const std::set<std::string>& expected)
-  {
-    EXPECT_EQ (offChain.GetParticipants (), expected);
-  }
-
 };
 
-TEST_F (BroadcastTests, Participants)
-{
-  ProcessOnChain ("0 0", ValidProof ("10 5"), 0);
-  ExpectParticipants ({"player", "other"});
-
-  ProcessOnChainNonExistant ();
-  ExpectParticipants ({});
-}
-
-TEST_F (BroadcastTests, FeedingMoves)
+TEST_F (ReceivingBroadcastTests, FeedingMoves)
 {
   meta.set_reinit ("reinit");
   ProcessOnChain ("0 0", ValidProof ("1 2"), 0);
@@ -142,7 +170,7 @@ TEST_F (BroadcastTests, FeedingMoves)
   EXPECT_EQ (GetLatestState (), "9 10");
 }
 
-TEST_F (BroadcastTests, BeyondTimeout)
+TEST_F (ReceivingBroadcastTests, BeyondTimeout)
 {
   ProcessOnChain ("0 0", ValidProof ("0 0"), 0);
   offChain.SendNewState ("", ValidProof ("10 5"));
@@ -152,6 +180,8 @@ TEST_F (BroadcastTests, BeyondTimeout)
   std::this_thread::sleep_for (2 * WAITER_TIMEOUT);
   EXPECT_EQ (GetLatestState (), "10 5");
 }
+
+/* ************************************************************************** */
 
 } // anonymous namespace
 } // namespace xaya

--- a/gamechannel/broadcast_tests.cpp
+++ b/gamechannel/broadcast_tests.cpp
@@ -110,7 +110,7 @@ protected:
 
 public:
 
-  explicit FeedBackBroadcast (ChannelManager& cm)
+  explicit FeedBackBroadcast (SynchronisedChannelManager& cm)
     : ReceivingOffChainBroadcast(cm)
   {}
 
@@ -131,10 +131,18 @@ class ReceivingBroadcastTests : public ChannelManagerTestFixture
 
 protected:
 
+  /**
+   * SynchronisedChannelManager based on the fixture's manager.  We need that
+   * so we can instantiate the ReceivingOffChainBroadcast.  Otherwise we do
+   * not use the lock here, as the offchain broadcast's loop doesn't actually
+   * access the channel manager in any way.
+   */
+  SynchronisedChannelManager scm;
+
   FeedBackBroadcast offChain;
 
   ReceivingBroadcastTests ()
-    : offChain(cm)
+    : scm(cm), offChain(scm)
   {
     cm.SetOffChainBroadcast (offChain);
     offChain.Start ();

--- a/gamechannel/chaintochannel.hpp
+++ b/gamechannel/chaintochannel.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018 The Xaya developers
+// Copyright (C) 2018-2022 The Xaya developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -31,7 +31,10 @@ private:
   ChannelGspRpcClient& rpc;
 
   /** The ChannelManager that is updated.  */
-  ChannelManager& manager;
+  SynchronisedChannelManager& manager;
+
+  /** The channel ID in hex.  */
+  std::string channelIdHex;
 
   /** The running thread (if any).  */
   std::unique_ptr<std::thread> loop;
@@ -65,7 +68,8 @@ public:
    * be used from a separate thread and must thus not be used anywhere else
    * at the same time.
    */
-  explicit ChainToChannelFeeder (ChannelGspRpcClient& r, ChannelManager& cm);
+  explicit ChainToChannelFeeder (ChannelGspRpcClient& r,
+                                 SynchronisedChannelManager& cm);
 
   ~ChainToChannelFeeder ();
 

--- a/gamechannel/chaintochannel_tests.cpp
+++ b/gamechannel/chaintochannel_tests.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2020 The Xaya developers
+// Copyright (C) 2019-2022 The Xaya developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -194,11 +194,19 @@ class ChainToChannelFeederTests : public ChannelManagerTestFixture
 
 protected:
 
+  /**
+   * The Synchronised manager is needed to instantiate the chain-to-channel
+   * feeder for the test.  In the actual tests, the feeder is not running
+   * at the same time as the main thread is doing changes to the channel
+   * manager, though, so we don't actually have to use its lock in the tests.
+   */
+  SynchronisedChannelManager scm;
+
   ChainToChannelFeeder feeder;
   HttpRpcServer<TestGspServer> gspServer;
 
   ChainToChannelFeederTests ()
-    : feeder(gspServer.GetClient (), cm),
+    : scm(cm), feeder(gspServer.GetClient (), scm),
       gspServer(channelId, meta, GetDb (), game)
   {
     gspServer.GetClientConnector ().SetTimeout (RPC_TIMEOUT_MS);

--- a/gamechannel/channelmanager.tpp
+++ b/gamechannel/channelmanager.tpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2021 The Xaya developers
+// Copyright (C) 2019-2022 The Xaya developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -9,19 +9,17 @@
 namespace xaya
 {
 
-template <typename State, typename Fcn>
-  auto
-  ChannelManager::ReadLatestState (const Fcn& cb) const
+template <typename State>
+  const State*
+  ChannelManager::GetBoardState () const
 {
-  std::lock_guard<std::mutex> lock(mut);
-
   if (!exists)
-    return cb (nullptr);
+    return nullptr;
 
   const auto& state = boardStates.GetLatestState ();
   const auto* typedState = dynamic_cast<const State*> (&state);
   CHECK (typedState != nullptr);
-  return cb (typedState);
+  return typedState;
 }
 
 } // namespace xaya

--- a/gamechannel/channelmanager_tests.cpp
+++ b/gamechannel/channelmanager_tests.cpp
@@ -100,8 +100,8 @@ class MockOffChainBroadcast : public OffChainBroadcast
 
 public:
 
-  MockOffChainBroadcast (ChannelManager& cm)
-    : OffChainBroadcast(cm)
+  MockOffChainBroadcast (const uint256& i)
+    : OffChainBroadcast(i)
   {
     /* Expect no calls by default.  */
     EXPECT_CALL (*this, SendMessage (_)).Times (0);
@@ -122,7 +122,7 @@ protected:
 
   ChannelManagerTests ()
     : onChain("game id", channelId, "player", txSender, game.channel),
-      offChain(cm)
+      offChain(cm.GetChannelId ())
   {
     cm.SetMoveSender (onChain);
     cm.SetOffChainBroadcast (offChain);

--- a/gamechannel/channelmanager_tests.cpp
+++ b/gamechannel/channelmanager_tests.cpp
@@ -67,11 +67,6 @@ ChannelManagerTestFixture::ChannelManagerTestFixture ()
   EXPECT_CALL (signer, SignMessage (_)).WillRepeatedly (Return ("sgn"));
 }
 
-ChannelManagerTestFixture::~ChannelManagerTestFixture ()
-{
-  cm.StopUpdates ();
-}
-
 void
 ChannelManagerTestFixture::ProcessOnChain (const BoardState& reinitState,
                                            const proto::StateProof& proof,
@@ -760,11 +755,19 @@ private:
 
 protected:
 
+  /** Our synchronised manager for waiting.  */
+  SynchronisedChannelManager scm;
+
+  WaitForChangeTests ()
+    : scm(cm)
+  {}
+
   /**
    * Calls WaitForChange on a newly started thread.
    */
   void
-  CallWaitForChange (int known = ChannelManager::WAITFORCHANGE_ALWAYS_BLOCK)
+  CallWaitForChange (
+      int known = SynchronisedChannelManager::WAITFORCHANGE_ALWAYS_BLOCK)
   {
     CHECK (waiter == nullptr);
     waiter = std::make_unique<std::thread> ([this, known] ()
@@ -774,7 +777,7 @@ protected:
           std::lock_guard<std::mutex> lock(mut);
           waiting = true;
         }
-        returnedJson = cm.WaitForChange (known);
+        returnedJson = scm.WaitForChange (known);
         {
           std::lock_guard<std::mutex> lock(mut);
           waiting = false;
@@ -853,7 +856,7 @@ TEST_F (WaitForChangeTests, OffChainNoChange)
   SleepSome ();
   EXPECT_TRUE (IsWaiting ());
 
-  cm.StopUpdates ();
+  scm.StopUpdates ();
   JoinWaiter ();
 }
 
@@ -869,7 +872,7 @@ TEST_F (WaitForChangeTests, LocalMove)
 
 TEST_F (WaitForChangeTests, WhenStopped)
 {
-  cm.StopUpdates ();
+  scm.StopUpdates ();
   CallWaitForChange ();
   JoinWaiter ();
 }
@@ -877,7 +880,7 @@ TEST_F (WaitForChangeTests, WhenStopped)
 TEST_F (WaitForChangeTests, StopNotifies)
 {
   CallWaitForChange ();
-  cm.StopUpdates ();
+  scm.StopUpdates ();
   JoinWaiter ();
 }
 
@@ -899,53 +902,6 @@ TEST_F (WaitForChangeTests, UpToDateKnownVersion)
 
   ProcessOnChain ("0 0", ValidProof ("10 5"), 0);
   JoinWaiter ();
-}
-
-/* ************************************************************************** */
-
-using StopUpdatesTests = ChannelManagerTests;
-
-TEST_F (StopUpdatesTests, OnChain)
-{
-  ProcessOnChain ("0 0", ValidProof ("10 5"), 0);
-  cm.StopUpdates ();
-  ProcessOnChain ("0 0", ValidProof ("20 6"), 0);
-  EXPECT_EQ (GetLatestState (), "10 5");
-}
-
-TEST_F (StopUpdatesTests, OnChainNonExistant)
-{
-  ProcessOnChain ("0 0", ValidProof ("10 5"), 0);
-  cm.StopUpdates ();
-  ProcessOnChainNonExistant ();
-  EXPECT_TRUE (GetExists ());
-}
-
-TEST_F (StopUpdatesTests, OffChain)
-{
-  ProcessOnChain ("0 0", ValidProof ("10 5"), 0);
-  cm.StopUpdates ();
-  cm.ProcessOffChain ("", ValidProof ("12 6"));
-  EXPECT_EQ (GetLatestState (), "10 5");
-}
-
-TEST_F (StopUpdatesTests, LocalMove)
-{
-  ProcessOnChain ("0 0", ValidProof ("10 5"), 0);
-  cm.StopUpdates ();
-  cm.ProcessLocalMove ("1");
-  EXPECT_EQ (GetLatestState (), "10 5");
-}
-
-TEST_F (StopUpdatesTests, TriggerAutoMoves)
-{
-  game.channel.SetAutomovesEnabled (false);
-  ProcessOnChain ("0 0", ValidProof ("8 5"), 0);
-
-  cm.StopUpdates ();
-  game.channel.SetAutomovesEnabled (true);
-  cm.TriggerAutoMoves ();
-  EXPECT_EQ (GetLatestState (), "8 5");
 }
 
 /* ************************************************************************** */

--- a/gamechannel/channelmanager_tests.hpp
+++ b/gamechannel/channelmanager_tests.hpp
@@ -35,7 +35,6 @@ protected:
   ChannelManager cm;
 
   ChannelManagerTestFixture ();
-  ~ChannelManagerTestFixture ();
 
   /**
    * Processes an on-chain update with fixed block hash and height, our

--- a/gamechannel/daemon.cpp
+++ b/gamechannel/daemon.cpp
@@ -72,7 +72,7 @@ ChannelDaemon::GetChannelManager ()
 }
 
 void
-ChannelDaemon::SetOffChainBroadcast (OffChainBroadcast& b)
+ChannelDaemon::SetOffChainBroadcast (ReceivingOffChainBroadcast& b)
 {
   CHECK (walletBased != nullptr);
   CHECK (offChain == nullptr);

--- a/gamechannel/daemon.hpp
+++ b/gamechannel/daemon.hpp
@@ -118,7 +118,7 @@ private:
   std::unique_ptr<GspFeederInstances> feeder;
 
   /** The broadcast instance we use.  */
-  OffChainBroadcast* offChain = nullptr;
+  ReceivingOffChainBroadcast* offChain = nullptr;
 
   /**
    * Set to true when the daemon is started for the first time.  Since we
@@ -165,7 +165,7 @@ public:
    * starting.  The instance must be constructed and managed externally
    * (based on the desired broadcast system).
    */
-  void SetOffChainBroadcast (OffChainBroadcast& b);
+  void SetOffChainBroadcast (ReceivingOffChainBroadcast& b);
 
   /**
    * Requests the mainloop to stop, e.g. from an RPC.

--- a/gamechannel/daemon.hpp
+++ b/gamechannel/daemon.hpp
@@ -54,8 +54,10 @@ private:
     /** The MoveSender instance we use.  */
     MoveSender sender;
 
-    /** The ChannelManager instance.  */
-    ChannelManager cm;
+    /** The ChannelManager instance used.  */
+    ChannelManager realCm;
+    /** The lock wrapper around the channel manager.  */
+    SynchronisedChannelManager cm;
 
     WalletBasedInstances () = delete;
     WalletBasedInstances (const WalletBasedInstances&) = delete;
@@ -158,7 +160,7 @@ public:
    * Returns a reference to the underlying ChannelManager, which can be used
    * for constructing the OffChainBroadcast and/or RPC server externally.
    */
-  ChannelManager& GetChannelManager ();
+  SynchronisedChannelManager& GetChannelManager ();
 
   /**
    * Sets the off-chain broadcast instance.  This must be called before

--- a/gamechannel/rpcbroadcast.cpp
+++ b/gamechannel/rpcbroadcast.cpp
@@ -11,7 +11,8 @@
 namespace xaya
 {
 
-RpcBroadcast::RpcBroadcast (const std::string& rpcUrl, ChannelManager& cm)
+RpcBroadcast::RpcBroadcast (const std::string& rpcUrl,
+                            SynchronisedChannelManager& cm)
   : ReceivingOffChainBroadcast(cm),
     sendConnector(rpcUrl), receiveConnector(rpcUrl),
     sendRpc(sendConnector), receiveRpc(receiveConnector)

--- a/gamechannel/rpcbroadcast.cpp
+++ b/gamechannel/rpcbroadcast.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2021 The Xaya developers
+// Copyright (C) 2019-2022 The Xaya developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -12,13 +12,13 @@ namespace xaya
 {
 
 RpcBroadcast::RpcBroadcast (const std::string& rpcUrl, ChannelManager& cm)
-  : OffChainBroadcast(cm),
+  : ReceivingOffChainBroadcast(cm),
     sendConnector(rpcUrl), receiveConnector(rpcUrl),
     sendRpc(sendConnector), receiveRpc(receiveConnector)
 {}
 
 RpcBroadcast::RpcBroadcast (const std::string& rpcUrl, const uint256& id)
-  : OffChainBroadcast(id),
+  : ReceivingOffChainBroadcast(id),
     sendConnector(rpcUrl), receiveConnector(rpcUrl),
     sendRpc(sendConnector), receiveRpc(receiveConnector)
 {}
@@ -44,7 +44,7 @@ void
 RpcBroadcast::Start ()
 {
   InitialiseSequence ();
-  OffChainBroadcast::Start ();
+  ReceivingOffChainBroadcast::Start ();
 }
 
 void

--- a/gamechannel/rpcbroadcast.hpp
+++ b/gamechannel/rpcbroadcast.hpp
@@ -76,7 +76,8 @@ protected:
 
 public:
 
-  explicit RpcBroadcast (const std::string& rpcUrl, ChannelManager& cm);
+  explicit RpcBroadcast (const std::string& rpcUrl,
+                         SynchronisedChannelManager& cm);
 
   /**
    * Starts the broadcast channel.  We use the default event loop, but override

--- a/gamechannel/rpcbroadcast.hpp
+++ b/gamechannel/rpcbroadcast.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2021 The Xaya developers
+// Copyright (C) 2019-2022 The Xaya developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -30,7 +30,7 @@ namespace xaya
  * for sending and receiving messages.  The server manages the individual
  * channels and takes care of distributing the messages to clients.
  */
-class RpcBroadcast : public OffChainBroadcast
+class RpcBroadcast : public ReceivingOffChainBroadcast
 {
 
 private:

--- a/ships/channelrpc.hpp
+++ b/ships/channelrpc.hpp
@@ -14,7 +14,6 @@
 #include <json/json.h>
 #include <jsonrpccpp/server.h>
 
-#include <mutex>
 #include <string>
 
 namespace ships
@@ -38,24 +37,18 @@ private:
   xaya::ChannelDaemon& daemon;
 
   /**
-   * Mutex for synchronising access particularly to the ShipsChannel.
-   * The ChannelManager has its own synchronisation in place for processing
-   * updates, but the RPC server uses the ShipsChannel instance before
-   * passing any updates to ChannelManager.  Thus we need our own lock
-   * with a  "wider scope".
-   */
-  mutable std::mutex mut;
-
-  /**
-   * Processes a local move given as proto.
-   */
-  void ProcessLocalMove (const proto::BoardMove& mv);
-
-  /**
    * Extends a given state JSON by extra data from the ShipsChannel directly
    * (i.e. the player's own position if set).
    */
   Json::Value ExtendStateJson (Json::Value&& state) const;
+
+  /**
+   * Processes a local move given as proto.  When this method gets called,
+   * we already hold the lock on the channel manager, and pass the instance
+   * in directly.
+   */
+  static void ProcessLocalMove (xaya::ChannelManager& cm,
+                                const proto::BoardMove& mv);
 
 public:
 


### PR DESCRIPTION
This set of changes refactors the `ChannelManager` class (together with a few others around it), so that all threading and synchronisation is removed.  Instead, the `ChannelManager` is now purely logic for handling the various possible updates (e.g. through `ProcessOnChain`, `ProcessOffChain` and `ProcessLocalMove`) and triggering corresponding callbacks (like on-chain transactions or off-chain moves).

All of the actual event loops (for the chain-to-channel feeder or off-chain broadcast receiving) are moved to another level, and synchronisation as well as "wait-for-change" functionality are now in a new class `SynchronisedChannelManager`.

With this change, the core game-channel logic works without any threading, locks and (in combination with the previous #115) networking.  This makes it suitable to be run in other environments, e.g. as wasm in a browser-based frontend.