### PR TITLE
Split game-channel library in two

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ for testing [Democrit](https://github.com/xaya/democrit) but also as an actual
 application on Xaya for issuing and trading fungible and non-fungible tokens.
 
 This repository also contains a framework for [**game
-channels**](http://www.ledgerjournal.org/ojs/index.php/ledger/article/view/15)
+channels**](https://www.ledgerjournal.org/ojs/index.php/ledger/article/view/15)
 as well as [Xayaships](ships/README.md), which is an example game for
 channels.
 

--- a/configure.ac
+++ b/configure.ac
@@ -73,6 +73,7 @@ AC_CONFIG_FILES([
   xayagametest/Makefile \
   xayautil/Makefile \
   \
+  gamechannel/channelcore.pc \
   gamechannel/gamechannel.pc \
   xayagame/libxayagame.pc \
   xayautil/libxayautil.pc

--- a/gamechannel/Makefile.am
+++ b/gamechannel/Makefile.am
@@ -60,6 +60,7 @@ libgamechannel_la_SOURCES = \
   schema.cpp \
   signatures.cpp \
   stateproof.cpp \
+  syncmanager.cpp \
   $(PROTOSOURCES)
 gamechannel_HEADERS = \
   boardrules.hpp \
@@ -82,7 +83,8 @@ gamechannel_HEADERS = \
   rpcwallet.hpp \
   schema.hpp \
   signatures.hpp \
-  stateproof.hpp
+  stateproof.hpp \
+  syncmanager.hpp
 rpcstub_HEADERS = $(RPC_STUBS)
 proto_HEADERS = $(PROTOHEADERS)
 
@@ -144,6 +146,7 @@ tests_SOURCES = \
   schema_tests.cpp \
   signatures_tests.cpp \
   stateproof_tests.cpp \
+  syncmanager_tests.cpp \
   testgame_tests.cpp \
   \
   testgame.cpp

--- a/gamechannel/Makefile.am
+++ b/gamechannel/Makefile.am
@@ -1,4 +1,4 @@
-lib_LTLIBRARIES = libgamechannel.la
+lib_LTLIBRARIES = libchannelcore.la libgamechannel.la
 dist_bin_SCRIPTS = rpc-channel-server.py
 dist_data_DATA = rpc-stubs/channel-gsp-rpc.json
 gamechanneldir = $(includedir)/gamechannel
@@ -7,7 +7,7 @@ protodir = $(gamechanneldir)/proto
 pydir = $(pythondir)/gamechannel
 pyprotodir = $(pydir)/proto
 
-pkgconfig_DATA = gamechannel.pc
+pkgconfig_DATA = channelcore.pc gamechannel.pc
 
 RPC_STUBS = \
   rpc-stubs/channelgsprpcclient.h \
@@ -31,62 +31,74 @@ EXTRA_DIST = $(PROTOS) \
 BUILT_SOURCES = $(RPC_STUBS) $(PROTOHEADERS) $(PROTOPY)
 CLEANFILES = $(RPC_STUBS) $(PROTOHEADERS) $(PROTOSOURCES) $(PROTOPY) schema.cpp
 
-libgamechannel_la_CXXFLAGS = \
+libchannelcore_la_CXXFLAGS = \
   -I$(top_srcdir) \
-  $(JSONCPP_CFLAGS) $(JSONRPCCLIENT_CFLAGS) $(JSONRPCSERVER_CFLAGS) \
-  $(GLOG_CFLAGS) $(SQLITE3_CFLAGS) $(PROTOBUF_CFLAGS)
-libgamechannel_la_LIBADD = \
+  $(JSONCPP_CFLAGS) $(GLOG_CFLAGS) $(PROTOBUF_CFLAGS)
+libchannelcore_la_LIBADD = \
   $(top_builddir)/xayautil/libxayautil.la \
-  $(top_builddir)/xayagame/libxayagame.la \
-  $(JSONCPP_LIBS) $(JSONRPCCLIENT_LIBS) $(JSONRPCSERVER_LIBS) \
-  $(GLOG_LIBS) $(SQLITE3_LIBS) $(PROTOBUF_LIBS)
-libgamechannel_la_SOURCES = \
+  $(JSONCPP_LIBS) $(GLOG_LIBS) $(PROTOBUF_LIBS)
+libchannelcore_la_SOURCES = \
   boardrules.cpp \
   broadcast.cpp \
-  channelgame.cpp \
   channelmanager.cpp \
   channelstatejson.cpp \
-  chaintochannel.cpp \
-  daemon.cpp \
-  database.cpp \
-  gamestatejson.cpp \
-  gsprpc.cpp \
   movesender.cpp \
   openchannel.cpp \
   protoversion.cpp \
-  recvbroadcast.cpp \
   rollingstate.cpp \
-  rpcbroadcast.cpp \
-  rpcwallet.cpp \
-  schema.cpp \
   signatures.cpp \
   stateproof.cpp \
-  syncmanager.cpp \
   $(PROTOSOURCES)
-gamechannel_HEADERS = \
+CHANNELCOREHEADERS = \
   boardrules.hpp \
   broadcast.hpp \
-  channelgame.hpp \
   channelmanager.hpp channelmanager.tpp \
   channelstatejson.hpp \
-  chaintochannel.hpp \
-  daemon.hpp \
-  database.hpp \
-  gamestatejson.hpp \
-  gsprpc.hpp \
   movesender.hpp \
   openchannel.hpp \
   protoboard.hpp protoboard.tpp \
   protoutils.hpp protoutils.tpp \
   protoversion.hpp \
-  recvbroadcast.hpp \
   rollingstate.hpp \
+  signatures.hpp \
+  stateproof.hpp
+
+libgamechannel_la_CXXFLAGS = \
+  -I$(top_srcdir) \
+  $(JSONCPP_CFLAGS) $(JSONRPCCLIENT_CFLAGS) $(JSONRPCSERVER_CFLAGS) \
+  $(GLOG_CFLAGS) $(SQLITE3_CFLAGS) $(PROTOBUF_CFLAGS)
+libgamechannel_la_LIBADD = \
+  $(builddir)/libchannelcore.la \
+  $(top_builddir)/xayautil/libxayautil.la \
+  $(top_builddir)/xayagame/libxayagame.la \
+  $(JSONCPP_LIBS) $(JSONRPCCLIENT_LIBS) $(JSONRPCSERVER_LIBS) \
+  $(GLOG_LIBS) $(SQLITE3_LIBS) $(PROTOBUF_LIBS)
+libgamechannel_la_SOURCES = \
+  channelgame.cpp \
+  chaintochannel.cpp \
+  daemon.cpp \
+  database.cpp \
+  gamestatejson.cpp \
+  gsprpc.cpp \
+  recvbroadcast.cpp \
+  rpcbroadcast.cpp \
+  rpcwallet.cpp \
+  schema.cpp \
+  syncmanager.cpp
+GAMECHANNELHEADERS = \
+  channelgame.hpp \
+  chaintochannel.hpp \
+  daemon.hpp \
+  database.hpp \
+  gamestatejson.hpp \
+  gsprpc.hpp \
+  recvbroadcast.hpp \
   rpcbroadcast.hpp \
   rpcwallet.hpp \
   schema.hpp \
-  signatures.hpp \
-  stateproof.hpp \
   syncmanager.hpp
+
+gamechannel_HEADERS = $(CHANNELCOREHEADERS) $(GAMECHANNELHEADERS)
 rpcstub_HEADERS = $(RPC_STUBS)
 proto_HEADERS = $(PROTOHEADERS)
 
@@ -113,6 +125,7 @@ libtestutils_la_CXXFLAGS = \
   $(GLOG_CFLAGS) $(GTEST_CFLAGS)
 libtestutils_la_LIBADD = \
   $(builddir)/libgamechannel.la \
+  $(builddir)/libchannelcore.la \
   $(top_builddir)/xayautil/libxayautil.la \
   $(GLOG_LIBS) $(GTEST_LIBS)
 libtestutils_la_SOURCES = \
@@ -127,6 +140,7 @@ tests_CXXFLAGS = \
 tests_LDADD = \
   $(builddir)/libtestutils.la \
   $(builddir)/libgamechannel.la \
+  $(builddir)/libchannelcore.la \
   $(top_builddir)/xayautil/libxayautil.la \
   $(top_builddir)/xayagame/libxayagame.la \
   $(top_builddir)/xayagame/libtestutils.la \
@@ -167,6 +181,7 @@ test_rpcbroadcast_CXXFLAGS = \
   $(GLOG_CFLAGS) $(GFLAGS_CFLAGS) $(PROTOBUF_CFLAGS)
 test_rpcbroadcast_LDADD = \
   $(builddir)/libgamechannel.la \
+  $(builddir)/libchannelcore.la \
   $(top_builddir)/xayautil/libxayautil.la \
   $(top_builddir)/xayagame/libxayagame.la \
   $(JSONCPP_LIBS) $(JSONRPCCLIENT_LIBS) $(JSONRPCSERVER_LIBS) \

--- a/gamechannel/Makefile.am
+++ b/gamechannel/Makefile.am
@@ -53,6 +53,7 @@ libgamechannel_la_SOURCES = \
   movesender.cpp \
   openchannel.cpp \
   protoversion.cpp \
+  recvbroadcast.cpp \
   rollingstate.cpp \
   rpcbroadcast.cpp \
   rpcwallet.cpp \
@@ -75,6 +76,7 @@ gamechannel_HEADERS = \
   protoboard.hpp protoboard.tpp \
   protoutils.hpp protoutils.tpp \
   protoversion.hpp \
+  recvbroadcast.hpp \
   rollingstate.hpp \
   rpcbroadcast.hpp \
   rpcwallet.hpp \
@@ -137,6 +139,7 @@ tests_SOURCES = \
   protoboard_tests.cpp \
   protoutils_tests.cpp \
   protoversion_tests.cpp \
+  recvbroadcast_tests.cpp \
   rollingstate_tests.cpp \
   schema_tests.cpp \
   signatures_tests.cpp \

--- a/gamechannel/Makefile.am
+++ b/gamechannel/Makefile.am
@@ -55,6 +55,7 @@ libgamechannel_la_SOURCES = \
   protoversion.cpp \
   rollingstate.cpp \
   rpcbroadcast.cpp \
+  rpcwallet.cpp \
   schema.cpp \
   signatures.cpp \
   stateproof.cpp \
@@ -76,6 +77,7 @@ gamechannel_HEADERS = \
   protoversion.hpp \
   rollingstate.hpp \
   rpcbroadcast.hpp \
+  rpcwallet.hpp \
   schema.hpp \
   signatures.hpp \
   stateproof.hpp

--- a/gamechannel/Makefile.am
+++ b/gamechannel/Makefile.am
@@ -45,6 +45,7 @@ libgamechannel_la_SOURCES = \
   broadcast.cpp \
   channelgame.cpp \
   channelmanager.cpp \
+  channelstatejson.cpp \
   chaintochannel.cpp \
   daemon.cpp \
   database.cpp \
@@ -67,6 +68,7 @@ gamechannel_HEADERS = \
   broadcast.hpp \
   channelgame.hpp \
   channelmanager.hpp channelmanager.tpp \
+  channelstatejson.hpp \
   chaintochannel.hpp \
   daemon.hpp \
   database.hpp \
@@ -134,6 +136,7 @@ tests_SOURCES = \
   broadcast_tests.cpp \
   channelgame_tests.cpp \
   channelmanager_tests.cpp \
+  channelstatejson_tests.cpp \
   chaintochannel_tests.cpp \
   database_tests.cpp \
   gamestatejson_tests.cpp \
@@ -152,6 +155,7 @@ tests_SOURCES = \
   testgame.cpp
 TESTHEADERS = \
   channelmanager_tests.hpp \
+  channelstatejson_tests.hpp \
   \
   testgame.hpp
 

--- a/gamechannel/README.md
+++ b/gamechannel/README.md
@@ -1,0 +1,39 @@
+# Game Channels
+
+[Game
+Channels](https://www.ledgerjournal.org/ojs/index.php/ledger/article/view/15)
+are a technique for handling interactions between participants in a game
+(or other application) in a very scalable, off-chain and almost real-time
+fashion.
+
+This folder contains a flexible implementation of the core framework
+necessary to build applications that use them.  The starting point for
+building a game-channel-enabled application is the [`BoardRules`
+interface](https://github.com/xaya/libxayagame/blob/master/gamechannel/boardrules.hpp),
+which defines the concrete rules by which interactions on a channel are done.
+
+## Channel Core
+
+The `channelcore` library contains the main parts of the general framework,
+where the
+[`ChannelManager`](https://github.com/xaya/libxayagame/blob/master/gamechannel/channelmanager.hpp)
+is the main class that applications should use.  It handles all the core
+tasks necessary for a channel application, like
+constructing and verifying state proofs, handling disputes and resolutions, and
+in general managing the state associated to a channel and handling the
+actions necessary whenever input is received (on-chain, off-chain or from
+a local frontend).
+
+This library is relatively light-weight.  In particular, it does not
+use any networking, JSON-RPC, threading or other complex dependencies.
+As such, it can be used in contexts like web-based frontends (e.g. with wasm)
+relatively easily, and also can be used to build channels that are not
+necessarily linked to a Xaya GSP.
+
+## Game-Channels on Xaya
+
+More advanced tasks are implemented in the `gamechannel` library:  They
+contain, for instance, event loops that automatically poll the state of
+a channel from a Xaya GSP to update the local state, or provide the
+tools necessary to build the on-chain parts for a channel-application easily
+based on a Xaya GSP.

--- a/gamechannel/broadcast.cpp
+++ b/gamechannel/broadcast.cpp
@@ -16,8 +16,6 @@
 namespace xaya
 {
 
-/* ************************************************************************** */
-
 void
 OffChainBroadcast::SetParticipants (const proto::ChannelMetadata& meta)
 {
@@ -70,84 +68,5 @@ OffChainBroadcast::ProcessIncoming (ChannelManager& m,
 
   m.ProcessOffChain (pb.reinit (), pb.proof ());
 }
-
-/* ************************************************************************** */
-
-ReceivingOffChainBroadcast::ReceivingOffChainBroadcast (
-    SynchronisedChannelManager& cm)
-  : OffChainBroadcast(cm.Read ()->GetChannelId ()), manager(&cm)
-{}
-
-ReceivingOffChainBroadcast::ReceivingOffChainBroadcast (const uint256& i)
-  : OffChainBroadcast(i), manager(nullptr)
-{
-  LOG_FIRST_N (WARNING, 1)
-      << "Using ReceivingOffChainBroadcast without ChannelManager,"
-         " this should only happen in tests";
-}
-
-ReceivingOffChainBroadcast::~ReceivingOffChainBroadcast ()
-{
-  Stop ();
-}
-
-std::vector<std::string>
-ReceivingOffChainBroadcast::GetMessages ()
-{
-  LOG (FATAL)
-      << "Subclasses should either override GetMessages()"
-         " or ensure that their own Start/Stop event loop does not"
-         " call GetMessages";
-}
-
-void
-ReceivingOffChainBroadcast::Start ()
-{
-  LOG (INFO) << "Starting default event loop...";
-  CHECK (loop == nullptr) << "The event loop is already running";
-
-  stopLoop = false;
-  loop = std::make_unique<std::thread> ([this] ()
-    {
-      RunLoop ();
-    });
-}
-
-void
-ReceivingOffChainBroadcast::Stop ()
-{
-  if (loop == nullptr)
-    return;
-
-  LOG (INFO) << "Stopping default event loop...";
-  stopLoop = true;
-  loop->join ();
-  loop.reset ();
-}
-
-void
-ReceivingOffChainBroadcast::RunLoop ()
-{
-  LOG (INFO) << "Running default event loop...";
-  while (!stopLoop)
-    {
-      const auto messages = GetMessages ();
-      VLOG_IF (1, !messages.empty ())
-          << "Received " << messages.size () << " messages";
-      for (const auto& msg : messages)
-        FeedMessage (msg);
-    }
-}
-
-void
-ReceivingOffChainBroadcast::FeedMessage (const std::string& msg)
-{
-  CHECK (manager != nullptr)
-      << "Without ChannelManager, FeedMessage must be overridden";
-  auto cmLocked = manager->Access ();
-  ProcessIncoming (*cmLocked, msg);
-}
-
-/* ************************************************************************** */
 
 } // namespace xaya

--- a/gamechannel/broadcast.hpp
+++ b/gamechannel/broadcast.hpp
@@ -10,18 +10,13 @@
 
 #include <xayautil/uint256.hpp>
 
-#include <atomic>
-#include <memory>
 #include <set>
 #include <string>
-#include <thread>
-#include <vector>
 
 namespace xaya
 {
 
 class ChannelManager;
-class SynchronisedChannelManager;
 
 /**
  * This class handles the off-chain broadcast of messages within a channel.
@@ -112,100 +107,6 @@ public:
    * this instance is used as OffChainBroadcast on the channel manager m.
    */
   void ProcessIncoming (ChannelManager& m, const std::string& msg) const;
-
-};
-
-/**
- * A subclass of OffChainBroadcast, which also takes care of an event loop
- * for receiving messages.
- *
- * There are two general architectures that implementations can use for
- * that:  If they have their own event loop, then they should override the
- * Start and Stop methods, and feed messages they receive to FeedMessage.
- *
- * Alternatively, the default implementation of Start and Stop will run
- * a waiting loop in a new thread, and repeatedly call GetMessages to
- * retrieve the next message in a blocking call.
- */
-class ReceivingOffChainBroadcast : public OffChainBroadcast
-{
-
-private:
-
-  /**
-   * The ChannelManager instance that is updated with received messages.
-   *
-   * For testing purposes it can be null, in which case we require that
-   * FeedMessage is overridden in a subclass to handle the messages directly.
-   */
-  SynchronisedChannelManager* manager;
-
-  /** The currently running wait loop, if any.  */
-  std::unique_ptr<std::thread> loop;
-
-  /** If set to true, signals the loop to stop.  */
-  std::atomic<bool> stopLoop;
-
-  /**
-   * Runs the default event loop, waiting for messages.
-   */
-  void RunLoop ();
-
-protected:
-
-  /**
-   * Constructs an instance without a ChannelManager but the given explicit
-   * channel ID.  This can be used for testing broadcast implementations;
-   * in those tests, the FeedMessage method must be overridden to handle
-   * messages directly.
-   */
-  explicit ReceivingOffChainBroadcast (const uint256& i);
-
-  /**
-   * Processes a message retrieved through the broadcast channel.  If the
-   * instance has been created with a channel ID and not a ChannelManager
-   * (for testing), then subclasses must explicitly override this method
-   * to handle messages themselves.
-   */
-  virtual void FeedMessage (const std::string& msg);
-
-  /**
-   * Tries to retrieve more messages from the underlying communication system,
-   * blocking until one is available.  If subclasses want to make use of
-   * the default Start/Stop and event loop, then they should override this
-   * method.  Calls should never block for an unlimited amount of time,
-   * but time out and return an empty vector after some delay.
-   *
-   * It is guaranteed that this function is only called by one concurrent
-   * thread at any given time (when used in combination with the default
-   * Start/Stop event loop).
-   */
-  virtual std::vector<std::string> GetMessages ();
-
-public:
-
-  /**
-   * Constructs an instance for normal use.  It will feed messages into
-   * the given ChannelManager.
-   */
-  explicit ReceivingOffChainBroadcast (SynchronisedChannelManager& cm);
-
-  ~ReceivingOffChainBroadcast ();
-
-  /**
-   * Starts an event loop listening for new messages and feeding them into
-   * FeedMessage as received.  Subclasses can override this (together with
-   * Stop) to provide their own event loop.  The default implementation will
-   * start a new thread that just calls GetMessages repeatedly.
-   */
-  virtual void Start ();
-
-  /**
-   * Stops the event loop if one is running.  If subclasses override this
-   * method, they need to ensure that it is fine to call it even if the event
-   * loop is not running at the moment.
-   */
-  virtual void Stop ();
 
 };
 

--- a/gamechannel/broadcast_tests.cpp
+++ b/gamechannel/broadcast_tests.cpp
@@ -17,31 +17,15 @@ namespace xaya
 namespace
 {
 
-using testing::_;
 using testing::IsEmpty;
 using testing::UnorderedElementsAre;
-
-class MockBroadcast : public OffChainBroadcast
-{
-
-public:
-
-  explicit MockBroadcast (const uint256& i)
-    : OffChainBroadcast(i)
-  {
-    EXPECT_CALL (*this, SendMessage (_)).Times (0);
-  }
-
-  MOCK_METHOD (void, SendMessage, (const std::string&), (override));
-
-};
 
 class BroadcastTests : public ChannelManagerTestFixture
 {
 
 protected:
 
-  MockBroadcast offChain;
+  MockOffChainBroadcast offChain;
 
   BroadcastTests ()
     : offChain(cm.GetChannelId ())

--- a/gamechannel/broadcast_tests.cpp
+++ b/gamechannel/broadcast_tests.cpp
@@ -7,30 +7,19 @@
 #include "channelmanager.hpp"
 #include "channelmanager_tests.hpp"
 
-#include <google/protobuf/text_format.h>
-
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include <glog/logging.h>
-
-#include <chrono>
-#include <condition_variable>
 
 namespace xaya
 {
 namespace
 {
 
-using google::protobuf::TextFormat;
 using testing::_;
 using testing::IsEmpty;
 using testing::UnorderedElementsAre;
-
-/** Timeout for the waiters in the test broadcast.  */
-constexpr auto WAITER_TIMEOUT = std::chrono::milliseconds (50);
-
-/* ************************************************************************** */
 
 class MockBroadcast : public OffChainBroadcast
 {
@@ -71,125 +60,6 @@ TEST_F (BroadcastTests, Participants)
   ProcessOnChainNonExistant ();
   EXPECT_THAT (offChain.GetParticipants (), IsEmpty ());
 }
-
-/* ************************************************************************** */
-
-/**
- * Implementation of OffChainBroadcast that simply feeds sent messages back
- * to GetMessages using a condition variable.
- */
-class FeedBackBroadcast : public ReceivingOffChainBroadcast
-{
-
-private:
-
-  std::mutex mut;
-  std::condition_variable cv;
-
-  /** Current list of unforwarded messages.  */
-  std::vector<std::string> messages;
-
-protected:
-
-  void
-  SendMessage (const std::string& msg) override
-  {
-    std::lock_guard<std::mutex> lock(mut);
-    messages.push_back (msg);
-  }
-
-  std::vector<std::string>
-  GetMessages () override
-  {
-    std::unique_lock<std::mutex> lock(mut);
-    if (messages.empty ())
-      cv.wait_for (lock, WAITER_TIMEOUT);
-
-    return std::move (messages);
-  }
-
-public:
-
-  explicit FeedBackBroadcast (SynchronisedChannelManager& cm)
-    : ReceivingOffChainBroadcast(cm)
-  {}
-
-  /**
-   * Forwards the queued messages (by notifying the waiting thread).
-   */
-  void
-  Notify ()
-  {
-    std::lock_guard<std::mutex> lock(mut);
-    cv.notify_all ();
-  }
-
-};
-
-class ReceivingBroadcastTests : public ChannelManagerTestFixture
-{
-
-protected:
-
-  /**
-   * SynchronisedChannelManager based on the fixture's manager.  We need that
-   * so we can instantiate the ReceivingOffChainBroadcast.  Otherwise we do
-   * not use the lock here, as the offchain broadcast's loop doesn't actually
-   * access the channel manager in any way.
-   */
-  SynchronisedChannelManager scm;
-
-  FeedBackBroadcast offChain;
-
-  ReceivingBroadcastTests ()
-    : scm(cm), offChain(scm)
-  {
-    cm.SetOffChainBroadcast (offChain);
-    offChain.Start ();
-  }
-
-  ~ReceivingBroadcastTests ()
-  {
-    offChain.Stop ();
-  }
-
-};
-
-TEST_F (ReceivingBroadcastTests, FeedingMoves)
-{
-  meta.set_reinit ("reinit");
-  ProcessOnChain ("0 0", ValidProof ("1 2"), 0);
-
-  meta.clear_reinit ();
-  ProcessOnChain ("0 0", ValidProof ("0 0"), 0);
-
-  offChain.SendNewState ("", ValidProof ("10 5"));
-  offChain.SendNewState ("reinit", ValidProof ("9 10"));
-
-  SleepSome ();
-  EXPECT_EQ (GetLatestState (), "0 0");
-
-  offChain.Notify ();
-  SleepSome ();
-  EXPECT_EQ (GetLatestState (), "10 5");
-
-  meta.set_reinit ("reinit");
-  ProcessOnChain ("0 0", ValidProof ("1 2"), 0);
-  EXPECT_EQ (GetLatestState (), "9 10");
-}
-
-TEST_F (ReceivingBroadcastTests, BeyondTimeout)
-{
-  ProcessOnChain ("0 0", ValidProof ("0 0"), 0);
-  offChain.SendNewState ("", ValidProof ("10 5"));
-
-  /* Even without a notification, we will get the new state because the
-     waiter thread times out and recalls GetMessages.  */
-  std::this_thread::sleep_for (2 * WAITER_TIMEOUT);
-  EXPECT_EQ (GetLatestState (), "10 5");
-}
-
-/* ************************************************************************** */
 
 } // anonymous namespace
 } // namespace xaya

--- a/gamechannel/chaintochannel.hpp
+++ b/gamechannel/chaintochannel.hpp
@@ -5,7 +5,7 @@
 #ifndef GAMECHANNEL_CHAINTOCHANNEL_HPP
 #define GAMECHANNEL_CHAINTOCHANNEL_HPP
 
-#include "channelmanager.hpp"
+#include "syncmanager.hpp"
 
 #include "rpc-stubs/channelgsprpcclient.h"
 

--- a/gamechannel/chaintochannel_tests.cpp
+++ b/gamechannel/chaintochannel_tests.cpp
@@ -13,8 +13,6 @@
 
 #include <xayautil/hash.hpp>
 
-#include <jsonrpccpp/common/exception.h>
-
 #include <google/protobuf/text_format.h>
 
 #include <gmock/gmock.h>

--- a/gamechannel/channelcore.pc.in
+++ b/gamechannel/channelcore.pc.in
@@ -3,14 +3,13 @@ exec_prefix=@exec_prefix@
 libdir=@libdir@
 includedir=@includedir@
 
-Name: libxayautil
+Name: channelcore
 Version: @PACKAGE_VERSION@
 
-Description: A library of basic utilities for games on the Xaya platform.
+Description: Core library for any game-channel applications.
 URL: https://github.com/xaya/libxayagame
 
-Requires: jsoncpp
-Requires.private: libglog openssl zlib
+Requires: jsoncpp libglog protobuf libxayautil
 
 Cflags: -I${includedir}
-Libs: -L${libdir} -lxayautil
+Libs: -L${libdir} -lchannelcore

--- a/gamechannel/channelgame.hpp
+++ b/gamechannel/channelgame.hpp
@@ -7,6 +7,7 @@
 
 #include "boardrules.hpp"
 #include "database.hpp"
+#include "rpcwallet.hpp"
 #include "signatures.hpp"
 
 #include "proto/metadata.pb.h"

--- a/gamechannel/channelmanager.cpp
+++ b/gamechannel/channelmanager.cpp
@@ -4,7 +4,7 @@
 
 #include "channelmanager.hpp"
 
-#include "gamestatejson.hpp"
+#include "channelstatejson.hpp"
 #include "stateproof.hpp"
 
 namespace xaya

--- a/gamechannel/channelmanager.cpp
+++ b/gamechannel/channelmanager.cpp
@@ -8,6 +8,7 @@
 #include "stateproof.hpp"
 
 #include <chrono>
+#include <thread>
 
 namespace xaya
 {

--- a/gamechannel/channelmanager.cpp
+++ b/gamechannel/channelmanager.cpp
@@ -7,25 +7,8 @@
 #include "gamestatejson.hpp"
 #include "stateproof.hpp"
 
-#include <chrono>
-#include <thread>
-
 namespace xaya
 {
-
-namespace
-{
-
-/**
- * Timeout for WaitForChange (i.e. return after this time even if there
- * has not been any change).  Having a timeout in the first place avoids
- * collecting more and more blocked threads in the worst case.
- */
-constexpr auto WAITFORCHANGE_TIMEOUT = std::chrono::seconds (5);
-
-} // anonymous namespace
-
-/* ************************************************************************** */
 
 ChannelManager::DisputeData::DisputeData ()
 {
@@ -477,96 +460,5 @@ ChannelManager::UnregisterCallback (Callbacks& cb)
 {
   callbacks.erase (&cb);
 }
-
-/* ************************************************************************** */
-
-SynchronisedChannelManager::SynchronisedChannelManager (ChannelManager& c)
-  : cm(c)
-{
-  cm.RegisterCallback (*this);
-}
-
-SynchronisedChannelManager::~SynchronisedChannelManager ()
-{
-  StopUpdates ();
-
-  std::unique_lock<std::mutex> lock(mut);
-  cm.UnregisterCallback (*this);
-
-  /* Wait for all active waiter threads to finish before we let the instance
-     be destructed.  This is just an extra sanity measure and usually updates
-     should have been stopped (and event loops calling into waitforchange
-     explicitly joined) already before the instance is destructed anyway.
-
-     Using a condition variable here just for signalling possible changes to
-     the waiting counter seems overkill in this situation, so we just sleep
-     as needed (which in practice won't be at all).  */
-  while (waiting > 0)
-    {
-      LOG_FIRST_N (WARNING, 1)
-          << "There are still " << waiting << " waiters active, sleeping";
-      lock.unlock ();
-      std::this_thread::sleep_for (std::chrono::milliseconds (1));
-      lock.lock ();
-    }
-}
-
-void
-SynchronisedChannelManager::StateChanged ()
-{
-  cvStateChanged.notify_all ();
-}
-
-SynchronisedChannelManager::Locked<ChannelManager>
-SynchronisedChannelManager::Access ()
-{
-  return Locked<ChannelManager> (*this);
-}
-
-SynchronisedChannelManager::Locked<const ChannelManager>
-SynchronisedChannelManager::Read () const
-{
-  return Locked<const ChannelManager> (*this);
-}
-
-void
-SynchronisedChannelManager::StopUpdates ()
-{
-  std::lock_guard<std::mutex> lock(mut);
-  stopped = true;
-  cvStateChanged.notify_all ();
-}
-
-Json::Value
-SynchronisedChannelManager::WaitForChange (const int knownVersion) const
-{
-  std::unique_lock<std::mutex> lock(mut);
-
-  if (knownVersion != WAITFORCHANGE_ALWAYS_BLOCK
-          && knownVersion != cm.GetStateVersion ())
-    {
-      VLOG (1)
-          << "Known version " << knownVersion
-          << " differs from current one (" << cm.GetStateVersion ()
-          << "), returning immediately from WaitForChange";
-      return cm.ToJson ();
-    }
-
-  if (stopped)
-    VLOG (1) << "ChannelManager is stopped, not waiting for changes";
-  else
-    {
-      VLOG (1) << "Waiting for state change on condition variable...";
-      ++waiting;
-      cvStateChanged.wait_for (lock, WAITFORCHANGE_TIMEOUT);
-      CHECK_GT (waiting, 0);
-      --waiting;
-      VLOG (1) << "Potential state change detected in WaitForChange";
-    }
-
-  return cm.ToJson ();
-}
-
-/* ************************************************************************** */
 
 } // namespace xaya

--- a/gamechannel/channelmanager.hpp
+++ b/gamechannel/channelmanager.hpp
@@ -18,16 +18,12 @@
 
 #include <json/json.h>
 
-#include <condition_variable>
 #include <memory>
-#include <mutex>
 #include <set>
 #include <string>
 
 namespace xaya
 {
-
-/* ************************************************************************** */
 
 /**
  * The main logic for a channel daemon.  This class keeps track of the
@@ -321,168 +317,6 @@ public:
   {}
 
 };
-
-/* ************************************************************************** */
-
-/**
- * A ChannelManager reference together with a mutex, so that it can be accessed
- * from multiple threads (e.g. update event loops and an RPC server).
- * This class also supports a waitforchange-like interface for handling
- * state changes.
- */
-class SynchronisedChannelManager : private ChannelManager::Callbacks
-{
-
-private:
-
-  template <typename T>
-    class Locked;
-
-  /** The actual ChannelManager instance used.  */
-  ChannelManager& cm;
-
-  /**
-   * Mutex for synchronising the internal channel manager.  Also used as
-   * lock for the waitforchange condition variable.
-   */
-  mutable std::mutex mut;
-
-  /**
-   * Condition variable that gets signalled when the state is changed due
-   * to on-chain updates, off-chain updates or local moves.  This is used
-   * for waitforchange.
-   */
-  mutable std::condition_variable cvStateChanged;
-
-  /**
-   * If set to true, then future waitforchange calls will not block anymore.
-   * We use this to ensure we can properly wake all waiters up when shutting
-   * down, without them re-calling.
-   */
-  bool stopped = false;
-
-  /**
-   * Number of currently blocked waiter calls.
-   */
-  mutable unsigned waiting = 0;
-
-  void StateChanged () override;
-
-public:
-
-  /**
-   * Special value for the known version in WaitForChange that tells the
-   * function to always block.
-   */
-  static constexpr int WAITFORCHANGE_ALWAYS_BLOCK = 0;
-
-  explicit SynchronisedChannelManager (ChannelManager& c);
-  ~SynchronisedChannelManager ();
-
-  SynchronisedChannelManager () = delete;
-  SynchronisedChannelManager (const SynchronisedChannelManager&) = delete;
-  void operator= (const SynchronisedChannelManager&) = delete;
-
-  /**
-   * Returns a "locked instance" of the underlying ChannelManager.  This is
-   * a movable instance that holds the underlying mutex while it exists
-   * (like a std::unique_lock) and can be dereferenced to yield the
-   * ChannelManager.
-   *
-   * This method returns a mutable instance of the ChannelManager.
-   */
-  Locked<ChannelManager> Access ();
-
-  /**
-   * Returns a read-only locked ChannelManager (similar to Access).
-   */
-  Locked<const ChannelManager> Read () const;
-
-  /**
-   * Disables processing of updates in the future.  This should be called
-   * when shutting down the channel daemon.  It makes sure that all waiting
-   * callers to WaitForChange are woken up, and no more callers will block
-   * in the future.  Thus, this mechanism ensures that we can properly
-   * shut down WaitForChange.
-   *
-   * This function must be called before a ChannelManager instance is
-   * destructed.  Otherwise the destructor will CHECK-fail.
-   */
-  void StopUpdates ();
-
-  /**
-   * Blocks the calling thread until the state of the channel has (probably)
-   * been changed.  This can be used by frontends to implement long-polling
-   * RPC methods like waitforchange.  Note that the function may return
-   * spuriously even if there is no new state.
-   *
-   * If the passed-in version is different from the current state version
-   * already when starting the call, the function returns immediately.  Ideally,
-   * clients should pass in the version they currently know (as returned
-   * in the JSON state in "version"), so that we can avoid race conditions
-   * when a change happens between two calls to WaitForChange.
-   *
-   * When WAITFORCHANGE_ALWAYS_BLOCK is passed as the known version, then the
-   * function will always block until the next update.
-   *
-   * On return, the current (i.e. likely new) state is returned in the same
-   * format as ToJson() would return.
-   */
-  Json::Value WaitForChange (int knownVersion) const;
-
-};
-
-/**
- * A "locked" ChannelManager instance.  While an object exists, it will
- * hold the mutex of an underlying SynchronisedChannelManager, and give
- * access to its ChannelManager.
- *
- * The type T is either "ChannelManager" or "const ChannelManager".
- */
-template <typename T>
-  class SynchronisedChannelManager::Locked
-{
-
-private:
-
-  /** The underlying instance that can be accessed.  */
-  T& instance;
-
-  /** The lock on the mutex held by this instance.  */
-  std::unique_lock<std::mutex> lock;
-
-public:
-
-  /**
-   * Constructs a new instance, based on the underlying
-   * SynchronisedChannelManager instance.
-   */
-  template <typename CM>
-    explicit Locked (CM& underlying)
-    : instance(underlying.cm), lock(underlying.mut)
-  {}
-
-  Locked (Locked&&) = default;
-  Locked& operator= (Locked&&) = default;
-
-  Locked (const Locked&) = delete;
-  void operator= (const Locked&) = delete;
-
-  T*
-  operator-> ()
-  {
-    return &instance;
-  }
-
-  T&
-  operator* ()
-  {
-    return instance;
-  }
-
-};
-
-/* ************************************************************************** */
 
 } // namespace xaya
 

--- a/gamechannel/channelmanager_tests.cpp
+++ b/gamechannel/channelmanager_tests.cpp
@@ -17,8 +17,6 @@
 
 #include <glog/logging.h>
 
-#include <thread>
-
 using google::protobuf::TextFormat;
 using google::protobuf::util::MessageDifferencer;
 using testing::_;
@@ -27,6 +25,8 @@ using testing::Truly;
 
 namespace xaya
 {
+
+/* ************************************************************************** */
 
 proto::StateProof
 ValidProof (const std::string& state)
@@ -43,7 +43,8 @@ ValidProof (const std::string& state)
 ChannelManagerTestFixture::ChannelManagerTestFixture ()
   : cm(game.rules, game.channel,
        verifier, signer,
-       channelId, "player")
+       channelId, "player"),
+    onChain("game id", cm.GetChannelId (), "player", txSender, game.channel)
 {
   CHECK (TextFormat::ParseFromString (R"(
     participants:
@@ -63,6 +64,8 @@ ChannelManagerTestFixture::ChannelManagerTestFixture ()
 
   signer.SetAddress ("my addr");
   EXPECT_CALL (signer, SignMessage (_)).WillRepeatedly (Return ("sgn"));
+
+  cm.SetMoveSender (onChain);
 }
 
 void
@@ -85,39 +88,21 @@ ChannelManagerTestFixture::GetLatestState () const
   return UnverifiedProofEndState (cm.boardStates.GetStateProof ());
 }
 
+/* ************************************************************************** */
+
 namespace
 {
-
-class MockOffChainBroadcast : public OffChainBroadcast
-{
-
-public:
-
-  MockOffChainBroadcast (const uint256& i)
-    : OffChainBroadcast(i)
-  {
-    /* Expect no calls by default.  */
-    EXPECT_CALL (*this, SendMessage (_)).Times (0);
-  }
-
-  MOCK_METHOD1 (SendMessage, void (const std::string& msg));
-
-};
 
 class ChannelManagerTests : public ChannelManagerTestFixture
 {
 
 protected:
 
-  MockTransactionSender txSender;
-  MoveSender onChain;
   MockOffChainBroadcast offChain;
 
   ChannelManagerTests ()
-    : onChain("game id", channelId, "player", txSender, game.channel),
-      offChain(cm.GetChannelId ())
+    : offChain(cm.GetChannelId ())
   {
-    cm.SetMoveSender (onChain);
     cm.SetOffChainBroadcast (offChain);
   }
 
@@ -730,176 +715,6 @@ TEST_F (ChannelToJsonTests, PendingResolution)
   auto expected = Json::Value (Json::objectValue);
   expected["resolution"] = txid.ToHex ();
   EXPECT_EQ (cm.ToJson ()["pending"], expected);
-}
-
-/* ************************************************************************** */
-
-class WaitForChangeTests : public ChannelManagerTests
-{
-
-private:
-
-  /** The thread that is used to call WaitForChange.  */
-  std::unique_ptr<std::thread> waiter;
-
-  /** Set to true while the thread is actively waiting.  */
-  bool waiting;
-
-  /** Lock for waiting.  */
-  mutable std::mutex mut;
-
-  /** The JSON value returned from WaitForChange.  */
-  Json::Value returnedJson;
-
-protected:
-
-  /** Our synchronised manager for waiting.  */
-  SynchronisedChannelManager scm;
-
-  WaitForChangeTests ()
-    : scm(cm)
-  {}
-
-  /**
-   * Calls WaitForChange on a newly started thread.
-   */
-  void
-  CallWaitForChange (
-      int known = SynchronisedChannelManager::WAITFORCHANGE_ALWAYS_BLOCK)
-  {
-    CHECK (waiter == nullptr);
-    waiter = std::make_unique<std::thread> ([this, known] ()
-      {
-        LOG (INFO) << "Calling WaitForChange...";
-        {
-          std::lock_guard<std::mutex> lock(mut);
-          waiting = true;
-        }
-        returnedJson = scm.WaitForChange (known);
-        {
-          std::lock_guard<std::mutex> lock(mut);
-          waiting = false;
-        }
-        LOG (INFO) << "WaitForChange returned";
-      });
-
-    /* Make sure the thread had time to start and make the call.  */
-    SleepSome ();
-  }
-
-  /**
-   * Waits for the waiter thread to return and checks that the JSON value
-   * from it matches the then-correct ToJson output.  Also expects that the
-   * thread is finished "soon" (rather than timeout later).
-   */
-  void
-  JoinWaiter ()
-  {
-    CHECK (waiter != nullptr);
-
-    SleepSome ();
-    EXPECT_FALSE (IsWaiting ());
-
-    LOG (INFO) << "Joining the waiter thread...";
-    waiter->join ();
-    LOG (INFO) << "Waiter thread finished";
-    waiter.reset ();
-    ASSERT_EQ (returnedJson, cm.ToJson ());
-  }
-
-  /**
-   * Returns true if the thread is currently waiting.
-   */
-  bool
-  IsWaiting () const
-  {
-    CHECK (waiter != nullptr);
-
-    std::lock_guard<std::mutex> lock(mut);
-    return waiting;
-  }
-
-};
-
-TEST_F (WaitForChangeTests, OnChain)
-{
-  CallWaitForChange ();
-  ProcessOnChain ("0 0", ValidProof ("10 5"), 0);
-  JoinWaiter ();
-}
-
-TEST_F (WaitForChangeTests, OnChainNonExistant)
-{
-  CallWaitForChange ();
-  ProcessOnChainNonExistant ();
-  JoinWaiter ();
-}
-
-TEST_F (WaitForChangeTests, OffChain)
-{
-  ProcessOnChain ("0 0", ValidProof ("10 5"), 0);
-
-  CallWaitForChange ();
-  cm.ProcessOffChain ("", ValidProof ("12 6"));
-  JoinWaiter ();
-}
-
-TEST_F (WaitForChangeTests, OffChainNoChange)
-{
-  ProcessOnChain ("0 0", ValidProof ("10 5"), 0);
-
-  CallWaitForChange ();
-  cm.ProcessOffChain ("", ValidProof ("10 5"));
-
-  SleepSome ();
-  EXPECT_TRUE (IsWaiting ());
-
-  scm.StopUpdates ();
-  JoinWaiter ();
-}
-
-TEST_F (WaitForChangeTests, LocalMove)
-{
-  ExpectOneBroadcast ("11 6");
-  ProcessOnChain ("0 0", ValidProof ("10 5"), 0);
-
-  CallWaitForChange ();
-  cm.ProcessLocalMove ("1");
-  JoinWaiter ();
-}
-
-TEST_F (WaitForChangeTests, WhenStopped)
-{
-  scm.StopUpdates ();
-  CallWaitForChange ();
-  JoinWaiter ();
-}
-
-TEST_F (WaitForChangeTests, StopNotifies)
-{
-  CallWaitForChange ();
-  scm.StopUpdates ();
-  JoinWaiter ();
-}
-
-TEST_F (WaitForChangeTests, OutdatedKnownVersion)
-{
-  const int known = cm.ToJson ()["version"].asInt ();
-  ProcessOnChain ("0 0", ValidProof ("10 5"), 0);
-  CallWaitForChange (known);
-  JoinWaiter ();
-}
-
-TEST_F (WaitForChangeTests, UpToDateKnownVersion)
-{
-  const int known = cm.ToJson ()["version"].asInt ();
-  CallWaitForChange (known);
-
-  SleepSome ();
-  EXPECT_TRUE (IsWaiting ());
-
-  ProcessOnChain ("0 0", ValidProof ("10 5"), 0);
-  JoinWaiter ();
 }
 
 /* ************************************************************************** */

--- a/gamechannel/channelmanager_tests.cpp
+++ b/gamechannel/channelmanager_tests.cpp
@@ -9,8 +9,6 @@
 
 #include "proto/broadcast.pb.h"
 
-#include <jsonrpccpp/common/exception.h>
-
 #include <google/protobuf/text_format.h>
 #include <google/protobuf/util/message_differencer.h>
 

--- a/gamechannel/channelmanager_tests.hpp
+++ b/gamechannel/channelmanager_tests.hpp
@@ -7,9 +7,10 @@
 
 #include "channelmanager.hpp"
 
+#include "movesender.hpp"
 #include "testgame.hpp"
+#include "testutils.hpp"
 
-#include <xayautil/base64.hpp>
 #include <xayautil/hash.hpp>
 
 namespace xaya
@@ -33,6 +34,9 @@ protected:
   proto::ChannelMetadata meta;
 
   ChannelManager cm;
+
+  MockTransactionSender txSender;
+  MoveSender onChain;
 
   ChannelManagerTestFixture ();
 

--- a/gamechannel/channelstatejson.cpp
+++ b/gamechannel/channelstatejson.cpp
@@ -1,0 +1,63 @@
+// Copyright (C) 2019-2022 The Xaya developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "channelstatejson.hpp"
+
+#include "protoutils.hpp"
+
+#include <xayautil/base64.hpp>
+
+#include <glog/logging.h>
+
+namespace xaya
+{
+
+Json::Value
+ChannelMetadataToJson (const proto::ChannelMetadata& meta)
+{
+  Json::Value res(Json::objectValue);
+
+  Json::Value participants(Json::arrayValue);
+  for (const auto& p : meta.participants ())
+    {
+      Json::Value cur(Json::objectValue);
+      cur["name"] = p.name ();
+      cur["address"] = p.address ();
+      participants.append (cur);
+    }
+  res["participants"] = participants;
+
+  res["reinit"] = EncodeBase64 (meta.reinit ());
+  res["proto"] = ProtoToBase64 (meta);
+
+  return res;
+}
+
+Json::Value
+BoardStateToJson (const BoardRules& r,
+                  const uint256& channelId, const proto::ChannelMetadata& meta,
+                  const BoardState& state)
+{
+  Json::Value res(Json::objectValue);
+  res["base64"] = EncodeBase64 (state);
+
+  auto parsed = r.ParseState (channelId, meta, state);
+  CHECK (parsed != nullptr)
+      << "Channel " << channelId.ToHex () << " has invalid state: "
+      << state;
+
+  const Json::Value parsedJson = parsed->ToJson ();
+  if (!parsedJson.isNull ())
+    res["parsed"] = parsedJson;
+
+  res["whoseturn"] = Json::Value ();
+  const int turn = parsed->WhoseTurn ();
+  if (turn != ParsedBoardState::NO_TURN)
+    res["whoseturn"] = turn;
+  res["turncount"] = static_cast<int> (parsed->TurnCount ());
+
+  return res;
+}
+
+} // namespace xaya

--- a/gamechannel/channelstatejson.hpp
+++ b/gamechannel/channelstatejson.hpp
@@ -1,0 +1,32 @@
+// Copyright (C) 2019-2022 The Xaya developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef GAMECHANNEL_CHANNELSTATEJSON_HPP
+#define GAMECHANNEL_CHANNELSTATEJSON_HPP
+
+#include "boardrules.hpp"
+#include "proto/metadata.pb.h"
+
+#include <xayautil/uint256.hpp>
+
+#include <json/json.h>
+
+namespace xaya
+{
+
+/**
+ * Encodes a metadata proto into JSON.
+ */
+Json::Value ChannelMetadataToJson (const proto::ChannelMetadata& meta);
+
+/**
+ * Encodes a given state as JSON.
+ */
+Json::Value BoardStateToJson (const BoardRules& r, const uint256& channelId,
+                              const proto::ChannelMetadata& meta,
+                              const BoardState& state);
+
+} // namespace xaya
+
+#endif // GAMECHANNEL_CHANNELSTATEJSON_HPP

--- a/gamechannel/channelstatejson_tests.cpp
+++ b/gamechannel/channelstatejson_tests.cpp
@@ -1,0 +1,110 @@
+// Copyright (C) 2019-2022 The Xaya developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "channelstatejson_tests.hpp"
+
+#include "protoutils.hpp"
+
+#include <xayautil/base64.hpp>
+
+#include <google/protobuf/text_format.h>
+#include <google/protobuf/util/message_differencer.h>
+
+#include <glog/logging.h>
+
+using google::protobuf::TextFormat;
+using google::protobuf::util::MessageDifferencer;
+
+namespace xaya
+{
+
+void
+CheckChannelJson (Json::Value actual, const std::string& expected,
+                  const uint256& id, const proto::ChannelMetadata& meta,
+                  const BoardState& reinitState,
+                  const BoardState& proofState)
+{
+  ASSERT_EQ (actual["id"].asString (), id.ToHex ());
+  actual.removeMember ("id");
+
+  /* Metadata serialisation is checked separately, so ignore it for testing
+     the full channels (just to avoid the need for duplicating the code that
+     handles the encoded fields).  */
+  actual.removeMember ("meta");
+
+  ASSERT_EQ (actual["reinit"]["base64"].asString (),
+             EncodeBase64 (reinitState));
+  actual["reinit"].removeMember ("base64");
+
+  ASSERT_EQ (actual["state"]["base64"].asString (), EncodeBase64 (proofState));
+  actual["state"].removeMember ("base64");
+
+  proto::StateProof proof;
+  ASSERT_TRUE (ProtoFromBase64 (actual["state"]["proof"].asString (), proof));
+  ASSERT_EQ (proof.initial_state ().data (), proofState);
+  actual["state"].removeMember ("proof");
+
+  ASSERT_EQ (actual, ParseJson (expected));
+}
+
+ChannelStateJsonTests::ChannelStateJsonTests ()
+{
+  CHECK (TextFormat::ParseFromString (R"(
+    participants:
+      {
+        name: "foo"
+        address: "addr 1"
+      }
+    participants:
+      {
+        name: "bar"
+        address: "addr 2"
+      }
+  )", &meta1));
+
+  meta2 = meta1;
+  meta2.mutable_participants (1)->set_name ("baz");
+  meta2.set_reinit ("reinit id");
+}
+
+namespace
+{
+
+TEST_F (ChannelStateJsonTests, ChannelMetadataToJson)
+{
+  auto actual = ChannelMetadataToJson (meta2);
+
+  ASSERT_EQ (actual["reinit"], EncodeBase64 (meta2.reinit ()));
+  actual.removeMember ("reinit");
+
+  proto::ChannelMetadata actualMeta;
+  ASSERT_TRUE (ProtoFromBase64 (actual["proto"].asString (), actualMeta));
+  ASSERT_TRUE (MessageDifferencer::Equals (actualMeta, meta2));
+  actual.removeMember ("proto");
+
+  EXPECT_EQ (actual, ParseJson (R"({
+    "participants":
+      [
+        {"name": "foo", "address": "addr 1"},
+        {"name": "baz", "address": "addr 2"}
+      ]
+  })"));
+}
+
+TEST_F (ChannelStateJsonTests, BoardStateToJson)
+{
+  auto actual = BoardStateToJson (game.rules, id1, meta1, "10 5");
+
+  ASSERT_EQ (actual["base64"].asString (), EncodeBase64 ("10 5"));
+  actual.removeMember ("base64");
+
+  EXPECT_EQ (actual, ParseJson (R"({
+    "parsed": {"count": 5, "number": 10},
+    "turncount": 5,
+    "whoseturn": 0
+  })"));
+}
+
+} // anonymous namespace
+} // namespace xaya

--- a/gamechannel/channelstatejson_tests.hpp
+++ b/gamechannel/channelstatejson_tests.hpp
@@ -1,0 +1,47 @@
+// Copyright (C) 2019-2022 The Xaya developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "channelstatejson.hpp"
+
+#include "testgame.hpp"
+
+#include <xayautil/hash.hpp>
+
+namespace xaya
+{
+
+/**
+ * Checks if the given actual game-state JSON for a channel matches the
+ * expected one, taking into account potential differences in protocol buffer
+ * serialisation for the metadata and stateproof.  Those are verified by
+ * comparing the protocol buffers themselves.
+ */
+void
+CheckChannelJson (Json::Value actual, const std::string& expected,
+                  const uint256& id, const proto::ChannelMetadata& meta,
+                  const BoardState& reinitState,
+                  const BoardState& proofState);
+
+class ChannelStateJsonTests : public TestGameFixture
+{
+
+protected:
+
+  /** First test channel.  */
+  const uint256 id1 = SHA256::Hash ("channel 1");
+
+  /** Metadata for channel 1.  */
+  proto::ChannelMetadata meta1;
+
+  /** Second test channel.  */
+  const uint256 id2 = SHA256::Hash ("channel 2");
+
+  /** Metadata for channel 2.  */
+  proto::ChannelMetadata meta2;
+
+  ChannelStateJsonTests ();
+
+};
+
+} // anonymous namespace

--- a/gamechannel/daemon.hpp
+++ b/gamechannel/daemon.hpp
@@ -6,11 +6,11 @@
 #define GAMECHANNEL_DAEMON_HPP
 
 #include "boardrules.hpp"
-#include "broadcast.hpp"
 #include "chaintochannel.hpp"
 #include "channelmanager.hpp"
 #include "movesender.hpp"
 #include "openchannel.hpp"
+#include "recvbroadcast.hpp"
 #include "signatures.hpp"
 
 #include "rpc-stubs/channelgsprpcclient.h"

--- a/gamechannel/daemon.hpp
+++ b/gamechannel/daemon.hpp
@@ -12,6 +12,7 @@
 #include "openchannel.hpp"
 #include "recvbroadcast.hpp"
 #include "signatures.hpp"
+#include "syncmanager.hpp"
 
 #include "rpc-stubs/channelgsprpcclient.h"
 

--- a/gamechannel/gamechannel.pc.in
+++ b/gamechannel/gamechannel.pc.in
@@ -9,8 +9,8 @@ Version: @PACKAGE_VERSION@
 Description: A library for Xaya games with game channels.
 URL: https://github.com/xaya/libxayagame
 
-Requires: @AX_PACKAGE_REQUIRES@ libxayautil
+Requires: @AX_PACKAGE_REQUIRES@ channelcore libxayagame libxayautil
 Requires.private: @AX_PACKAGE_REQUIRES_PRIVATE@
 
 Cflags: -I${includedir}
-Libs: -L${libdir} -lgamechannel -lxayagame
+Libs: -L${libdir} -lgamechannel

--- a/gamechannel/gamestatejson.cpp
+++ b/gamechannel/gamestatejson.cpp
@@ -1,60 +1,14 @@
+// Copyright (C) 2019-2022 The Xaya developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #include "gamestatejson.hpp"
 
+#include "channelstatejson.hpp"
 #include "protoutils.hpp"
-
-#include <xayautil/base64.hpp>
-
-#include <glog/logging.h>
 
 namespace xaya
 {
-
-Json::Value
-ChannelMetadataToJson (const proto::ChannelMetadata& meta)
-{
-  Json::Value res(Json::objectValue);
-
-  Json::Value participants(Json::arrayValue);
-  for (const auto& p : meta.participants ())
-    {
-      Json::Value cur(Json::objectValue);
-      cur["name"] = p.name ();
-      cur["address"] = p.address ();
-      participants.append (cur);
-    }
-  res["participants"] = participants;
-
-  res["reinit"] = EncodeBase64 (meta.reinit ());
-  res["proto"] = ProtoToBase64 (meta);
-
-  return res;
-}
-
-Json::Value
-BoardStateToJson (const BoardRules& r,
-                  const uint256& channelId, const proto::ChannelMetadata& meta,
-                  const BoardState& state)
-{
-  Json::Value res(Json::objectValue);
-  res["base64"] = EncodeBase64 (state);
-
-  auto parsed = r.ParseState (channelId, meta, state);
-  CHECK (parsed != nullptr)
-      << "Channel " << channelId.ToHex () << " has invalid state: "
-      << state;
-
-  const Json::Value parsedJson = parsed->ToJson ();
-  if (!parsedJson.isNull ())
-    res["parsed"] = parsedJson;
-
-  res["whoseturn"] = Json::Value ();
-  const int turn = parsed->WhoseTurn ();
-  if (turn != ParsedBoardState::NO_TURN)
-    res["whoseturn"] = turn;
-  res["turncount"] = static_cast<int> (parsed->TurnCount ());
-
-  return res;
-}
 
 Json::Value
 ChannelToGameStateJson (const ChannelData& ch, const BoardRules& r)

--- a/gamechannel/gamestatejson.hpp
+++ b/gamechannel/gamestatejson.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 The Xaya developers
+// Copyright (C) 2019-2022 The Xaya developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -7,26 +7,11 @@
 
 #include "boardrules.hpp"
 #include "database.hpp"
-#include "proto/metadata.pb.h"
-
-#include <xayautil/uint256.hpp>
 
 #include <json/json.h>
 
 namespace xaya
 {
-
-/**
- * Encodes a metadata proto into JSON.
- */
-Json::Value ChannelMetadataToJson (const proto::ChannelMetadata& meta);
-
-/**
- * Encodes a given state as JSON.
- */
-Json::Value BoardStateToJson (const BoardRules& r, const uint256& channelId,
-                              const proto::ChannelMetadata& meta,
-                              const BoardState& state);
 
 /**
  * Converts the game-state data for a given channel into JSON format.

--- a/gamechannel/gamestatejson_tests.cpp
+++ b/gamechannel/gamestatejson_tests.cpp
@@ -1,114 +1,31 @@
-// Copyright (C) 2019-2020 The Xaya developers
+// Copyright (C) 2019-2022 The Xaya developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include "gamestatejson.hpp"
 
-#include "protoutils.hpp"
-#include "testgame.hpp"
-
-#include <xayautil/base64.hpp>
-#include <xayautil/hash.hpp>
-#include <xayautil/uint256.hpp>
-
-#include <gtest/gtest.h>
-
-#include <google/protobuf/text_format.h>
-#include <google/protobuf/util/message_differencer.h>
-
-#include <glog/logging.h>
-
-#include <sstream>
-
-using google::protobuf::TextFormat;
-using google::protobuf::util::MessageDifferencer;
+#include "channelstatejson_tests.hpp"
 
 namespace xaya
 {
 namespace
 {
 
-/**
- * Checks if the given actual game-state JSON for a channel matches the
- * expected one, taking into account potential differences in protocol buffer
- * serialisation for the metadata and stateproof.  Those are verified by
- * comparing the protocol buffers themselves.
- */
-void
-CheckChannelJson (Json::Value actual, const std::string& expected,
-                  const uint256& id, const proto::ChannelMetadata& meta,
-                  const BoardState& reinitState,
-                  const BoardState& proofState)
-{
-  ASSERT_EQ (actual["id"].asString (), id.ToHex ());
-  actual.removeMember ("id");
-
-  /* Metadata serialisation is checked separately, so ignore it for testing
-     the full channels (just to avoid the need for duplicating the code that
-     handles the encoded fields).  */
-  actual.removeMember ("meta");
-
-  ASSERT_EQ (actual["reinit"]["base64"].asString (),
-             EncodeBase64 (reinitState));
-  actual["reinit"].removeMember ("base64");
-
-  ASSERT_EQ (actual["state"]["base64"].asString (), EncodeBase64 (proofState));
-  actual["state"].removeMember ("base64");
-
-  proto::StateProof proof;
-  ASSERT_TRUE (ProtoFromBase64 (actual["state"]["proof"].asString (), proof));
-  ASSERT_EQ (proof.initial_state ().data (), proofState);
-  actual["state"].removeMember ("proof");
-
-  ASSERT_EQ (actual, ParseJson (expected));
-}
-
-class GameStateJsonTests : public TestGameFixture
+class GameStateJsonTests : public ChannelStateJsonTests
 {
 
 protected:
 
   ChannelsTable tbl;
 
-  /** Test channel set up with state (100, 2).   */
-  const uint256 id1 = SHA256::Hash ("channel 1");
-
-  /** Metadata for channel 1.  */
-  proto::ChannelMetadata meta1;
-
-  /**
-   * Test channel set up with state (50, 20), reinit state (40, 10)
-   * and a dispute.
-   */
-  const uint256 id2 = SHA256::Hash ("channel 2");
-
-  /** Metadata for channel 2.  */
-  proto::ChannelMetadata meta2;
-
   GameStateJsonTests ()
     : tbl(GetDb ())
   {
-    CHECK (TextFormat::ParseFromString (R"(
-      participants:
-        {
-          name: "foo"
-          address: "addr 1"
-        }
-      participants:
-        {
-          name: "bar"
-          address: "addr 2"
-        }
-    )", &meta1));
-
     auto h = tbl.CreateNew (id1);
     h->Reinitialise (meta1, "100 2");
     h.reset ();
 
     h = tbl.CreateNew (id2);
-    meta2 = meta1;
-    meta2.mutable_participants (1)->set_name ("baz");
-    meta2.set_reinit ("reinit id");
     h->SetDisputeHeight (55);
     h->Reinitialise (meta2, "40 10");
     proto::StateProof proof;
@@ -118,41 +35,6 @@ protected:
   }
 
 };
-
-TEST_F (GameStateJsonTests, ChannelMetadataToJson)
-{
-  auto actual = ChannelMetadataToJson (meta2);
-
-  ASSERT_EQ (actual["reinit"], EncodeBase64 (meta2.reinit ()));
-  actual.removeMember ("reinit");
-
-  proto::ChannelMetadata actualMeta;
-  ASSERT_TRUE (ProtoFromBase64 (actual["proto"].asString (), actualMeta));
-  ASSERT_TRUE (MessageDifferencer::Equals (actualMeta, meta2));
-  actual.removeMember ("proto");
-
-  EXPECT_EQ (actual, ParseJson (R"({
-    "participants":
-      [
-        {"name": "foo", "address": "addr 1"},
-        {"name": "baz", "address": "addr 2"}
-      ]
-  })"));
-}
-
-TEST_F (GameStateJsonTests, BoardStateToJson)
-{
-  auto actual = BoardStateToJson (game.rules, id1, meta1, "10 5");
-
-  ASSERT_EQ (actual["base64"].asString (), EncodeBase64 ("10 5"));
-  actual.removeMember ("base64");
-
-  EXPECT_EQ (actual, ParseJson (R"({
-    "parsed": {"count": 5, "number": 10},
-    "turncount": 5,
-    "whoseturn": 0
-  })"));
-}
 
 TEST_F (GameStateJsonTests, WithoutDispute)
 {

--- a/gamechannel/movesender.cpp
+++ b/gamechannel/movesender.cpp
@@ -9,36 +9,6 @@
 namespace xaya
 {
 
-/* ************************************************************************** */
-
-uint256
-RpcTransactionSender::SendRawMove (const std::string& name,
-                                   const std::string& value)
-{
-  const std::string fullName = "p/" + name;
-  const std::string txidHex = wallet.name_update (fullName, value);
-
-  uint256 txid;
-  CHECK (txid.FromHex (txidHex));
-
-  return txid;
-}
-
-bool
-RpcTransactionSender::IsPending (const uint256& txid) const
-{
-  const std::string txidHex = txid.ToHex ();
-
-  const auto mempool = rpc.getrawmempool ();
-  for (const auto& tx : mempool)
-    if (tx.asString () == txidHex)
-      return true;
-
-  return false;
-}
-
-/* ************************************************************************** */
-
 MoveSender::MoveSender (const std::string& gId,
                         const uint256& chId, const std::string& nm,
                         TransactionSender& s, OpenChannel& oc)
@@ -83,7 +53,5 @@ MoveSender::SendResolution (const proto::StateProof& proof)
 {
   return SendMove (game.ResolutionMove (channelId, proof));
 }
-
-/* ************************************************************************** */
 
 } // namespace xaya

--- a/gamechannel/movesender.hpp
+++ b/gamechannel/movesender.hpp
@@ -8,8 +8,6 @@
 #include "openchannel.hpp"
 #include "proto/stateproof.pb.h"
 
-#include <xayagame/rpc-stubs/xayarpcclient.h>
-#include <xayagame/rpc-stubs/xayawalletrpcclient.h>
 #include <xayautil/uint256.hpp>
 
 #include <json/writer.h>
@@ -46,33 +44,6 @@ public:
    * by the same instance) is still pending.
    */
   virtual bool IsPending (const uint256& txid) const = 0;
-
-};
-
-/**
- * A concrete implementation of TransactionSender that uses a Xaya Core RPC
- * connection with name_update.
- */
-class RpcTransactionSender : public TransactionSender
-{
-
-private:
-
-  /** Xaya RPC connection to use.  */
-  XayaRpcClient& rpc;
-
-  /** Xaya wallet RPC that we use.  */
-  XayaWalletRpcClient& wallet;
-
-public:
-
-  explicit RpcTransactionSender (XayaRpcClient& r, XayaWalletRpcClient& w)
-    : rpc(r), wallet(w)
-  {}
-
-  uint256 SendRawMove (const std::string& name,
-                       const std::string& value) override;
-  bool IsPending (const uint256& txid) const override;
 
 };
 

--- a/gamechannel/movesender_tests.cpp
+++ b/gamechannel/movesender_tests.cpp
@@ -8,8 +8,6 @@
 
 #include <xayautil/hash.hpp>
 
-#include <jsonrpccpp/common/exception.h>
-
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 

--- a/gamechannel/recvbroadcast.cpp
+++ b/gamechannel/recvbroadcast.cpp
@@ -1,0 +1,87 @@
+// Copyright (C) 2019-2022 The Xaya developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "recvbroadcast.hpp"
+
+#include <glog/logging.h>
+
+namespace xaya
+{
+
+ReceivingOffChainBroadcast::ReceivingOffChainBroadcast (
+    SynchronisedChannelManager& cm)
+  : OffChainBroadcast(cm.Read ()->GetChannelId ()), manager(&cm)
+{}
+
+ReceivingOffChainBroadcast::ReceivingOffChainBroadcast (const uint256& i)
+  : OffChainBroadcast(i), manager(nullptr)
+{
+  LOG_FIRST_N (WARNING, 1)
+      << "Using ReceivingOffChainBroadcast without ChannelManager,"
+         " this should only happen in tests";
+}
+
+ReceivingOffChainBroadcast::~ReceivingOffChainBroadcast ()
+{
+  Stop ();
+}
+
+std::vector<std::string>
+ReceivingOffChainBroadcast::GetMessages ()
+{
+  LOG (FATAL)
+      << "Subclasses should either override GetMessages()"
+         " or ensure that their own Start/Stop event loop does not"
+         " call GetMessages";
+}
+
+void
+ReceivingOffChainBroadcast::Start ()
+{
+  LOG (INFO) << "Starting default event loop...";
+  CHECK (loop == nullptr) << "The event loop is already running";
+
+  stopLoop = false;
+  loop = std::make_unique<std::thread> ([this] ()
+    {
+      RunLoop ();
+    });
+}
+
+void
+ReceivingOffChainBroadcast::Stop ()
+{
+  if (loop == nullptr)
+    return;
+
+  LOG (INFO) << "Stopping default event loop...";
+  stopLoop = true;
+  loop->join ();
+  loop.reset ();
+}
+
+void
+ReceivingOffChainBroadcast::RunLoop ()
+{
+  LOG (INFO) << "Running default event loop...";
+  while (!stopLoop)
+    {
+      const auto messages = GetMessages ();
+      VLOG_IF (1, !messages.empty ())
+          << "Received " << messages.size () << " messages";
+      for (const auto& msg : messages)
+        FeedMessage (msg);
+    }
+}
+
+void
+ReceivingOffChainBroadcast::FeedMessage (const std::string& msg)
+{
+  CHECK (manager != nullptr)
+      << "Without ChannelManager, FeedMessage must be overridden";
+  auto cmLocked = manager->Access ();
+  ProcessIncoming (*cmLocked, msg);
+}
+
+} // namespace xaya

--- a/gamechannel/recvbroadcast.hpp
+++ b/gamechannel/recvbroadcast.hpp
@@ -1,0 +1,116 @@
+// Copyright (C) 2019-2022 The Xaya developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef GAMECHANNEL_RECVBROADCAST_HPP
+#define GAMECHANNEL_RECVBROADCAST_HPP
+
+#include "broadcast.hpp"
+#include "channelmanager.hpp"
+
+#include <atomic>
+#include <memory>
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace xaya
+{
+
+/**
+ * A subclass of OffChainBroadcast, which also takes care of an event loop
+ * for receiving messages.
+ *
+ * There are two general architectures that implementations can use for
+ * that:  If they have their own event loop, then they should override the
+ * Start and Stop methods, and feed messages they receive to FeedMessage.
+ *
+ * Alternatively, the default implementation of Start and Stop will run
+ * a waiting loop in a new thread, and repeatedly call GetMessages to
+ * retrieve the next message in a blocking call.
+ */
+class ReceivingOffChainBroadcast : public OffChainBroadcast
+{
+
+private:
+
+  /**
+   * The ChannelManager instance that is updated with received messages.
+   *
+   * For testing purposes it can be null, in which case we require that
+   * FeedMessage is overridden in a subclass to handle the messages directly.
+   */
+  SynchronisedChannelManager* manager;
+
+  /** The currently running wait loop, if any.  */
+  std::unique_ptr<std::thread> loop;
+
+  /** If set to true, signals the loop to stop.  */
+  std::atomic<bool> stopLoop;
+
+  /**
+   * Runs the default event loop, waiting for messages.
+   */
+  void RunLoop ();
+
+protected:
+
+  /**
+   * Constructs an instance without a ChannelManager but the given explicit
+   * channel ID.  This can be used for testing broadcast implementations;
+   * in those tests, the FeedMessage method must be overridden to handle
+   * messages directly.
+   */
+  explicit ReceivingOffChainBroadcast (const uint256& i);
+
+  /**
+   * Processes a message retrieved through the broadcast channel.  If the
+   * instance has been created with a channel ID and not a ChannelManager
+   * (for testing), then subclasses must explicitly override this method
+   * to handle messages themselves.
+   */
+  virtual void FeedMessage (const std::string& msg);
+
+  /**
+   * Tries to retrieve more messages from the underlying communication system,
+   * blocking until one is available.  If subclasses want to make use of
+   * the default Start/Stop and event loop, then they should override this
+   * method.  Calls should never block for an unlimited amount of time,
+   * but time out and return an empty vector after some delay.
+   *
+   * It is guaranteed that this function is only called by one concurrent
+   * thread at any given time (when used in combination with the default
+   * Start/Stop event loop).
+   */
+  virtual std::vector<std::string> GetMessages ();
+
+public:
+
+  /**
+   * Constructs an instance for normal use.  It will feed messages into
+   * the given ChannelManager.
+   */
+  explicit ReceivingOffChainBroadcast (SynchronisedChannelManager& cm);
+
+  ~ReceivingOffChainBroadcast ();
+
+  /**
+   * Starts an event loop listening for new messages and feeding them into
+   * FeedMessage as received.  Subclasses can override this (together with
+   * Stop) to provide their own event loop.  The default implementation will
+   * start a new thread that just calls GetMessages repeatedly.
+   */
+  virtual void Start ();
+
+  /**
+   * Stops the event loop if one is running.  If subclasses override this
+   * method, they need to ensure that it is fine to call it even if the event
+   * loop is not running at the moment.
+   */
+  virtual void Stop ();
+
+};
+
+} // namespace xaya
+
+#endif // GAMECHANNEL_RECVBROADCAST_HPP

--- a/gamechannel/recvbroadcast.hpp
+++ b/gamechannel/recvbroadcast.hpp
@@ -6,7 +6,7 @@
 #define GAMECHANNEL_RECVBROADCAST_HPP
 
 #include "broadcast.hpp"
-#include "channelmanager.hpp"
+#include "syncmanager.hpp"
 
 #include <atomic>
 #include <memory>

--- a/gamechannel/recvbroadcast_tests.cpp
+++ b/gamechannel/recvbroadcast_tests.cpp
@@ -1,0 +1,142 @@
+// Copyright (C) 2019-2022 The Xaya developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "recvbroadcast.hpp"
+
+#include "channelmanager.hpp"
+#include "channelmanager_tests.hpp"
+
+#include <gtest/gtest.h>
+
+#include <glog/logging.h>
+
+#include <chrono>
+#include <condition_variable>
+#include <mutex>
+
+namespace xaya
+{
+namespace
+{
+
+/** Timeout for the waiters in the test broadcast.  */
+constexpr auto WAITER_TIMEOUT = std::chrono::milliseconds (50);
+
+/**
+ * Implementation of OffChainBroadcast that simply feeds sent messages back
+ * to GetMessages using a condition variable.
+ */
+class FeedBackBroadcast : public ReceivingOffChainBroadcast
+{
+
+private:
+
+  std::mutex mut;
+  std::condition_variable cv;
+
+  /** Current list of unforwarded messages.  */
+  std::vector<std::string> messages;
+
+protected:
+
+  void
+  SendMessage (const std::string& msg) override
+  {
+    std::lock_guard<std::mutex> lock(mut);
+    messages.push_back (msg);
+  }
+
+  std::vector<std::string>
+  GetMessages () override
+  {
+    std::unique_lock<std::mutex> lock(mut);
+    if (messages.empty ())
+      cv.wait_for (lock, WAITER_TIMEOUT);
+
+    return std::move (messages);
+  }
+
+public:
+
+  explicit FeedBackBroadcast (SynchronisedChannelManager& cm)
+    : ReceivingOffChainBroadcast(cm)
+  {}
+
+  /**
+   * Forwards the queued messages (by notifying the waiting thread).
+   */
+  void
+  Notify ()
+  {
+    std::lock_guard<std::mutex> lock(mut);
+    cv.notify_all ();
+  }
+
+};
+
+class ReceivingBroadcastTests : public ChannelManagerTestFixture
+{
+
+protected:
+
+  /**
+   * SynchronisedChannelManager based on the fixture's manager.  We need that
+   * so we can instantiate the ReceivingOffChainBroadcast.  Otherwise we do
+   * not use the lock here, as the offchain broadcast's loop doesn't actually
+   * access the channel manager in any way.
+   */
+  SynchronisedChannelManager scm;
+
+  FeedBackBroadcast offChain;
+
+  ReceivingBroadcastTests ()
+    : scm(cm), offChain(scm)
+  {
+    cm.SetOffChainBroadcast (offChain);
+    offChain.Start ();
+  }
+
+  ~ReceivingBroadcastTests ()
+  {
+    offChain.Stop ();
+  }
+
+};
+
+TEST_F (ReceivingBroadcastTests, FeedingMoves)
+{
+  meta.set_reinit ("reinit");
+  ProcessOnChain ("0 0", ValidProof ("1 2"), 0);
+
+  meta.clear_reinit ();
+  ProcessOnChain ("0 0", ValidProof ("0 0"), 0);
+
+  offChain.SendNewState ("", ValidProof ("10 5"));
+  offChain.SendNewState ("reinit", ValidProof ("9 10"));
+
+  SleepSome ();
+  EXPECT_EQ (GetLatestState (), "0 0");
+
+  offChain.Notify ();
+  SleepSome ();
+  EXPECT_EQ (GetLatestState (), "10 5");
+
+  meta.set_reinit ("reinit");
+  ProcessOnChain ("0 0", ValidProof ("1 2"), 0);
+  EXPECT_EQ (GetLatestState (), "9 10");
+}
+
+TEST_F (ReceivingBroadcastTests, BeyondTimeout)
+{
+  ProcessOnChain ("0 0", ValidProof ("0 0"), 0);
+  offChain.SendNewState ("", ValidProof ("10 5"));
+
+  /* Even without a notification, we will get the new state because the
+     waiter thread times out and recalls GetMessages.  */
+  std::this_thread::sleep_for (2 * WAITER_TIMEOUT);
+  EXPECT_EQ (GetLatestState (), "10 5");
+}
+
+} // anonymous namespace
+} // namespace xaya

--- a/gamechannel/rpcbroadcast.hpp
+++ b/gamechannel/rpcbroadcast.hpp
@@ -5,7 +5,7 @@
 #ifndef GAMECHANNEL_RPCBROADCAST_HPP
 #define GAMECHANNEL_RPCBROADCAST_HPP
 
-#include "broadcast.hpp"
+#include "recvbroadcast.hpp"
 #include "channelmanager.hpp"
 
 #include "rpc-stubs/rpcbroadcastclient.h"

--- a/gamechannel/rpcwallet.cpp
+++ b/gamechannel/rpcwallet.cpp
@@ -1,0 +1,76 @@
+// Copyright (C) 2019-2022 The Xaya developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "rpcwallet.hpp"
+
+#include <xayagame/signatures.hpp>
+#include <xayautil/base64.hpp>
+
+#include <glog/logging.h>
+
+namespace xaya
+{
+
+std::string
+RpcSignatureVerifier::RecoverSigner (const std::string& msg,
+                                     const std::string& sgn) const
+{
+  return VerifyMessage (rpc, msg, EncodeBase64 (sgn));
+}
+
+RpcSignatureSigner::RpcSignatureSigner (XayaWalletRpcClient& w,
+                                        const std::string& addr)
+  : wallet(w), address(addr)
+{
+  const auto info = wallet.getaddressinfo (address);
+  CHECK (info.isObject ());
+  const auto& mineVal = info["ismine"];
+  CHECK (mineVal.isBool ());
+  CHECK (mineVal.asBool ())
+      << "Address " << address
+      << " for signing is not owned by wallet RPC client";
+}
+
+std::string
+RpcSignatureSigner::GetAddress () const
+{
+  return address;
+}
+
+std::string
+RpcSignatureSigner::SignMessage (const std::string& msg)
+{
+  const std::string sgn = wallet.signmessage (address, msg);
+  std::string decoded;
+  CHECK (DecodeBase64 (sgn, decoded));
+  return decoded;
+}
+
+uint256
+RpcTransactionSender::SendRawMove (const std::string& name,
+                                   const std::string& value)
+{
+  const std::string fullName = "p/" + name;
+  const std::string txidHex = wallet.name_update (fullName, value);
+
+  uint256 txid;
+  CHECK (txid.FromHex (txidHex));
+
+  return txid;
+}
+
+bool
+RpcTransactionSender::IsPending (const uint256& txid) const
+{
+  const std::string txidHex = txid.ToHex ();
+
+  const auto mempool = rpc.getrawmempool ();
+  for (const auto& tx : mempool)
+    if (tx.asString () == txidHex)
+      return true;
+
+  return false;
+}
+
+} // namespace xaya

--- a/gamechannel/rpcwallet.hpp
+++ b/gamechannel/rpcwallet.hpp
@@ -1,0 +1,97 @@
+// Copyright (C) 2019-2022 The Xaya developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef GAMECHANNEL_RPCWALLET_HPP
+#define GAMECHANNEL_RPCWALLET_HPP
+
+#include "movesender.hpp"
+#include "signatures.hpp"
+
+#include <xayagame/rpc-stubs/xayarpcclient.h>
+#include <xayagame/rpc-stubs/xayawalletrpcclient.h>
+
+#include <string>
+
+namespace xaya
+{
+
+/**
+ * An implementation of the verifier based on a Xaya RPC connection.
+ *
+ * This uses Xaya Core's signmessage/verifymessage scheme, but signatures
+ * returned and passed in for verification are assumed to be already base64
+ * decoded to raw bytes.
+ */
+class RpcSignatureVerifier : public SignatureVerifier
+{
+
+private:
+
+  /** The underlying RPC client for verification.  */
+  XayaRpcClient& rpc;
+
+public:
+
+  explicit RpcSignatureVerifier (XayaRpcClient& r)
+    : rpc(r)
+  {}
+
+  std::string RecoverSigner (const std::string& msg,
+                             const std::string& sgn) const override;
+
+};
+
+/**
+ * An implementation of the signer based on a Xaya RPC connection.
+ */
+class RpcSignatureSigner : public SignatureSigner
+{
+
+private:
+
+  /** The underlying RPC wallet for signing.  */
+  XayaWalletRpcClient& wallet;
+
+  /** The address used for signing (must be in the wallet).  */
+  const std::string address;
+
+public:
+
+  explicit RpcSignatureSigner (XayaWalletRpcClient& w, const std::string& addr);
+
+  std::string GetAddress () const override;
+  std::string SignMessage (const std::string& msg) override;
+
+};
+
+/**
+ * A concrete implementation of TransactionSender that uses a Xaya Core RPC
+ * connection with name_update.
+ */
+class RpcTransactionSender : public TransactionSender
+{
+
+private:
+
+  /** Xaya RPC connection to use.  */
+  XayaRpcClient& rpc;
+
+  /** Xaya wallet RPC that we use.  */
+  XayaWalletRpcClient& wallet;
+
+public:
+
+  explicit RpcTransactionSender (XayaRpcClient& r, XayaWalletRpcClient& w)
+    : rpc(r), wallet(w)
+  {}
+
+  uint256 SendRawMove (const std::string& name,
+                       const std::string& value) override;
+  bool IsPending (const uint256& txid) const override;
+
+};
+
+} // namespace xaya
+
+#endif // GAMECHANNEL_RPCWALLET_HPP

--- a/gamechannel/signatures.cpp
+++ b/gamechannel/signatures.cpp
@@ -4,57 +4,13 @@
 
 #include "signatures.hpp"
 
-#include <xayagame/signatures.hpp>
 #include <xayautil/base64.hpp>
 #include <xayautil/hash.hpp>
 
-#include <jsonrpccpp/common/exception.h>
-
 #include <glog/logging.h>
-
-#include <string>
 
 namespace xaya
 {
-
-/* ************************************************************************** */
-
-std::string
-RpcSignatureVerifier::RecoverSigner (const std::string& msg,
-                                     const std::string& sgn) const
-{
-  return VerifyMessage (rpc, msg, EncodeBase64 (sgn));
-}
-
-RpcSignatureSigner::RpcSignatureSigner (XayaWalletRpcClient& w,
-                                        const std::string& addr)
-  : wallet(w), address(addr)
-{
-  const auto info = wallet.getaddressinfo (address);
-  CHECK (info.isObject ());
-  const auto& mineVal = info["ismine"];
-  CHECK (mineVal.isBool ());
-  CHECK (mineVal.asBool ())
-      << "Address " << address
-      << " for signing is not owned by wallet RPC client";
-}
-
-std::string
-RpcSignatureSigner::GetAddress () const
-{
-  return address;
-}
-
-std::string
-RpcSignatureSigner::SignMessage (const std::string& msg)
-{
-  const std::string sgn = wallet.signmessage (address, msg);
-  std::string decoded;
-  CHECK (DecodeBase64 (sgn, decoded));
-  return decoded;
-}
-
-/* ************************************************************************** */
 
 std::string
 GetChannelSignatureMessage (const uint256& channelId,

--- a/gamechannel/signatures.hpp
+++ b/gamechannel/signatures.hpp
@@ -8,8 +8,6 @@
 #include "proto/metadata.pb.h"
 #include "proto/signatures.pb.h"
 
-#include <xayagame/rpc-stubs/xayarpcclient.h>
-#include <xayagame/rpc-stubs/xayawalletrpcclient.h>
 #include <xayautil/uint256.hpp>
 
 #include <set>
@@ -66,55 +64,6 @@ public:
    * Signs a message with the underlying address.
    */
   virtual std::string SignMessage (const std::string& msg) = 0;
-
-};
-
-/**
- * An implementation of the verifier based on a Xaya RPC connection.
- *
- * This uses Xaya Core's signmessage/verifymessage scheme, but signatures
- * returned and passed in for verification are assumed to be already base64
- * decoded to raw bytes.
- */
-class RpcSignatureVerifier : public SignatureVerifier
-{
-
-private:
-
-  /** The underlying RPC client for verification.  */
-  XayaRpcClient& rpc;
-
-public:
-
-  explicit RpcSignatureVerifier (XayaRpcClient& r)
-    : rpc(r)
-  {}
-
-  std::string RecoverSigner (const std::string& msg,
-                             const std::string& sgn) const override;
-
-};
-
-/**
- * An implementation of the signer based on a Xaya RPC connection.
- */
-class RpcSignatureSigner : public SignatureSigner
-{
-
-private:
-
-  /** The underlying RPC wallet for signing.  */
-  XayaWalletRpcClient& wallet;
-
-  /** The address used for signing (must be in the wallet).  */
-  const std::string address;
-
-public:
-
-  explicit RpcSignatureSigner (XayaWalletRpcClient& w, const std::string& addr);
-
-  std::string GetAddress () const override;
-  std::string SignMessage (const std::string& msg) override;
 
 };
 

--- a/gamechannel/signatures_tests.cpp
+++ b/gamechannel/signatures_tests.cpp
@@ -9,8 +9,6 @@
 #include <xayautil/base64.hpp>
 #include <xayautil/hash.hpp>
 
-#include <jsonrpccpp/common/exception.h>
-
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 

--- a/gamechannel/stateproof_tests.cpp
+++ b/gamechannel/stateproof_tests.cpp
@@ -9,8 +9,6 @@
 #include <xayautil/base64.hpp>
 #include <xayautil/hash.hpp>
 
-#include <jsonrpccpp/common/exception.h>
-
 #include <google/protobuf/text_format.h>
 
 #include <gmock/gmock.h>

--- a/gamechannel/syncmanager.cpp
+++ b/gamechannel/syncmanager.cpp
@@ -1,0 +1,112 @@
+// Copyright (C) 2019-2022 The Xaya developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "syncmanager.hpp"
+
+#include <chrono>
+#include <thread>
+
+namespace xaya
+{
+
+namespace
+{
+
+/**
+ * Timeout for WaitForChange (i.e. return after this time even if there
+ * has not been any change).  Having a timeout in the first place avoids
+ * collecting more and more blocked threads in the worst case.
+ */
+constexpr auto WAITFORCHANGE_TIMEOUT = std::chrono::seconds (5);
+
+} // anonymous namespace
+
+SynchronisedChannelManager::SynchronisedChannelManager (ChannelManager& c)
+  : cm(c)
+{
+  cm.RegisterCallback (*this);
+}
+
+SynchronisedChannelManager::~SynchronisedChannelManager ()
+{
+  StopUpdates ();
+
+  std::unique_lock<std::mutex> lock(mut);
+  cm.UnregisterCallback (*this);
+
+  /* Wait for all active waiter threads to finish before we let the instance
+     be destructed.  This is just an extra sanity measure and usually updates
+     should have been stopped (and event loops calling into waitforchange
+     explicitly joined) already before the instance is destructed anyway.
+
+     Using a condition variable here just for signalling possible changes to
+     the waiting counter seems overkill in this situation, so we just sleep
+     as needed (which in practice won't be at all).  */
+  while (waiting > 0)
+    {
+      LOG_FIRST_N (WARNING, 1)
+          << "There are still " << waiting << " waiters active, sleeping";
+      lock.unlock ();
+      std::this_thread::sleep_for (std::chrono::milliseconds (1));
+      lock.lock ();
+    }
+}
+
+void
+SynchronisedChannelManager::StateChanged ()
+{
+  cvStateChanged.notify_all ();
+}
+
+SynchronisedChannelManager::Locked<ChannelManager>
+SynchronisedChannelManager::Access ()
+{
+  return Locked<ChannelManager> (*this);
+}
+
+SynchronisedChannelManager::Locked<const ChannelManager>
+SynchronisedChannelManager::Read () const
+{
+  return Locked<const ChannelManager> (*this);
+}
+
+void
+SynchronisedChannelManager::StopUpdates ()
+{
+  std::lock_guard<std::mutex> lock(mut);
+  stopped = true;
+  cvStateChanged.notify_all ();
+}
+
+Json::Value
+SynchronisedChannelManager::WaitForChange (const int knownVersion) const
+{
+  std::unique_lock<std::mutex> lock(mut);
+
+  if (knownVersion != WAITFORCHANGE_ALWAYS_BLOCK
+          && knownVersion != cm.GetStateVersion ())
+    {
+      VLOG (1)
+          << "Known version " << knownVersion
+          << " differs from current one (" << cm.GetStateVersion ()
+          << "), returning immediately from WaitForChange";
+      return cm.ToJson ();
+    }
+
+  if (stopped)
+    VLOG (1) << "ChannelManager is stopped, not waiting for changes";
+  else
+    {
+      VLOG (1) << "Waiting for state change on condition variable...";
+      ++waiting;
+      cvStateChanged.wait_for (lock, WAITFORCHANGE_TIMEOUT);
+      CHECK_GT (waiting, 0);
+      --waiting;
+      VLOG (1) << "Potential state change detected in WaitForChange";
+    }
+
+  return cm.ToJson ();
+}
+
+} // namespace xaya

--- a/gamechannel/syncmanager.hpp
+++ b/gamechannel/syncmanager.hpp
@@ -1,0 +1,178 @@
+// Copyright (C) 2019-2022 The Xaya developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef GAMECHANNEL_SYNCMANAGER_HPP
+#define GAMECHANNEL_SYNCMANAGER_HPP
+
+#include "channelmanager.hpp"
+
+#include <json/json.h>
+
+#include <condition_variable>
+#include <mutex>
+
+namespace xaya
+{
+
+/**
+ * A ChannelManager reference together with a mutex, so that it can be accessed
+ * from multiple threads (e.g. update event loops and an RPC server).
+ * This class also supports a waitforchange-like interface for handling
+ * state changes.
+ */
+class SynchronisedChannelManager : private ChannelManager::Callbacks
+{
+
+private:
+
+  template <typename T>
+    class Locked;
+
+  /** The actual ChannelManager instance used.  */
+  ChannelManager& cm;
+
+  /**
+   * Mutex for synchronising the internal channel manager.  Also used as
+   * lock for the waitforchange condition variable.
+   */
+  mutable std::mutex mut;
+
+  /**
+   * Condition variable that gets signalled when the state is changed due
+   * to on-chain updates, off-chain updates or local moves.  This is used
+   * for waitforchange.
+   */
+  mutable std::condition_variable cvStateChanged;
+
+  /**
+   * If set to true, then future waitforchange calls will not block anymore.
+   * We use this to ensure we can properly wake all waiters up when shutting
+   * down, without them re-calling.
+   */
+  bool stopped = false;
+
+  /**
+   * Number of currently blocked waiter calls.
+   */
+  mutable unsigned waiting = 0;
+
+  void StateChanged () override;
+
+public:
+
+  /**
+   * Special value for the known version in WaitForChange that tells the
+   * function to always block.
+   */
+  static constexpr int WAITFORCHANGE_ALWAYS_BLOCK = 0;
+
+  explicit SynchronisedChannelManager (ChannelManager& c);
+  ~SynchronisedChannelManager ();
+
+  SynchronisedChannelManager () = delete;
+  SynchronisedChannelManager (const SynchronisedChannelManager&) = delete;
+  void operator= (const SynchronisedChannelManager&) = delete;
+
+  /**
+   * Returns a "locked instance" of the underlying ChannelManager.  This is
+   * a movable instance that holds the underlying mutex while it exists
+   * (like a std::unique_lock) and can be dereferenced to yield the
+   * ChannelManager.
+   *
+   * This method returns a mutable instance of the ChannelManager.
+   */
+  Locked<ChannelManager> Access ();
+
+  /**
+   * Returns a read-only locked ChannelManager (similar to Access).
+   */
+  Locked<const ChannelManager> Read () const;
+
+  /**
+   * Disables processing of updates in the future.  This should be called
+   * when shutting down the channel daemon.  It makes sure that all waiting
+   * callers to WaitForChange are woken up, and no more callers will block
+   * in the future.  Thus, this mechanism ensures that we can properly
+   * shut down WaitForChange.
+   *
+   * This function must be called before a ChannelManager instance is
+   * destructed.  Otherwise the destructor will CHECK-fail.
+   */
+  void StopUpdates ();
+
+  /**
+   * Blocks the calling thread until the state of the channel has (probably)
+   * been changed.  This can be used by frontends to implement long-polling
+   * RPC methods like waitforchange.  Note that the function may return
+   * spuriously even if there is no new state.
+   *
+   * If the passed-in version is different from the current state version
+   * already when starting the call, the function returns immediately.  Ideally,
+   * clients should pass in the version they currently know (as returned
+   * in the JSON state in "version"), so that we can avoid race conditions
+   * when a change happens between two calls to WaitForChange.
+   *
+   * When WAITFORCHANGE_ALWAYS_BLOCK is passed as the known version, then the
+   * function will always block until the next update.
+   *
+   * On return, the current (i.e. likely new) state is returned in the same
+   * format as ToJson() would return.
+   */
+  Json::Value WaitForChange (int knownVersion) const;
+
+};
+
+/**
+ * A "locked" ChannelManager instance.  While an object exists, it will
+ * hold the mutex of an underlying SynchronisedChannelManager, and give
+ * access to its ChannelManager.
+ *
+ * The type T is either "ChannelManager" or "const ChannelManager".
+ */
+template <typename T>
+  class SynchronisedChannelManager::Locked
+{
+
+private:
+
+  /** The underlying instance that can be accessed.  */
+  T& instance;
+
+  /** The lock on the mutex held by this instance.  */
+  std::unique_lock<std::mutex> lock;
+
+public:
+
+  /**
+   * Constructs a new instance, based on the underlying
+   * SynchronisedChannelManager instance.
+   */
+  template <typename CM>
+    explicit Locked (CM& underlying)
+    : instance(underlying.cm), lock(underlying.mut)
+  {}
+
+  Locked (Locked&&) = default;
+  Locked& operator= (Locked&&) = default;
+
+  Locked (const Locked&) = delete;
+  void operator= (const Locked&) = delete;
+
+  T*
+  operator-> ()
+  {
+    return &instance;
+  }
+
+  T&
+  operator* ()
+  {
+    return instance;
+  }
+
+};
+
+} // namespace xaya
+
+#endif // GAMECHANNEL_SYNCMANAGER_HPP

--- a/gamechannel/syncmanager_tests.cpp
+++ b/gamechannel/syncmanager_tests.cpp
@@ -1,0 +1,199 @@
+// Copyright (C) 2019-2022 The Xaya developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "syncmanager.hpp"
+
+#include "channelmanager_tests.hpp"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <glog/logging.h>
+
+#include <thread>
+
+namespace xaya
+{
+namespace
+{
+
+using testing::_;
+
+class WaitForChangeTests : public ChannelManagerTestFixture
+{
+
+private:
+
+  /** The thread that is used to call WaitForChange.  */
+  std::unique_ptr<std::thread> waiter;
+
+  /** Set to true while the thread is actively waiting.  */
+  bool waiting;
+
+  /** Lock for waiting.  */
+  mutable std::mutex mut;
+
+  /** The JSON value returned from WaitForChange.  */
+  Json::Value returnedJson;
+
+protected:
+
+  /** Our synchronised manager for waiting.  */
+  SynchronisedChannelManager scm;
+
+  MockOffChainBroadcast offChain;
+
+  WaitForChangeTests ()
+    : scm(cm), offChain(cm.GetChannelId ())
+  {
+    cm.SetOffChainBroadcast (offChain);
+  }
+
+  /**
+   * Calls WaitForChange on a newly started thread.
+   */
+  void
+  CallWaitForChange (
+      int known = SynchronisedChannelManager::WAITFORCHANGE_ALWAYS_BLOCK)
+  {
+    CHECK (waiter == nullptr);
+    waiter = std::make_unique<std::thread> ([this, known] ()
+      {
+        LOG (INFO) << "Calling WaitForChange...";
+        {
+          std::lock_guard<std::mutex> lock(mut);
+          waiting = true;
+        }
+        returnedJson = scm.WaitForChange (known);
+        {
+          std::lock_guard<std::mutex> lock(mut);
+          waiting = false;
+        }
+        LOG (INFO) << "WaitForChange returned";
+      });
+
+    /* Make sure the thread had time to start and make the call.  */
+    SleepSome ();
+  }
+
+  /**
+   * Waits for the waiter thread to return and checks that the JSON value
+   * from it matches the then-correct ToJson output.  Also expects that the
+   * thread is finished "soon" (rather than timeout later).
+   */
+  void
+  JoinWaiter ()
+  {
+    CHECK (waiter != nullptr);
+
+    SleepSome ();
+    EXPECT_FALSE (IsWaiting ());
+
+    LOG (INFO) << "Joining the waiter thread...";
+    waiter->join ();
+    LOG (INFO) << "Waiter thread finished";
+    waiter.reset ();
+    ASSERT_EQ (returnedJson, cm.ToJson ());
+  }
+
+  /**
+   * Returns true if the thread is currently waiting.
+   */
+  bool
+  IsWaiting () const
+  {
+    CHECK (waiter != nullptr);
+
+    std::lock_guard<std::mutex> lock(mut);
+    return waiting;
+  }
+
+};
+
+TEST_F (WaitForChangeTests, OnChain)
+{
+  CallWaitForChange ();
+  ProcessOnChain ("0 0", ValidProof ("10 5"), 0);
+  JoinWaiter ();
+}
+
+TEST_F (WaitForChangeTests, OnChainNonExistant)
+{
+  CallWaitForChange ();
+  ProcessOnChainNonExistant ();
+  JoinWaiter ();
+}
+
+TEST_F (WaitForChangeTests, OffChain)
+{
+  ProcessOnChain ("0 0", ValidProof ("10 5"), 0);
+
+  CallWaitForChange ();
+  cm.ProcessOffChain ("", ValidProof ("12 6"));
+  JoinWaiter ();
+}
+
+TEST_F (WaitForChangeTests, OffChainNoChange)
+{
+  ProcessOnChain ("0 0", ValidProof ("10 5"), 0);
+
+  CallWaitForChange ();
+  cm.ProcessOffChain ("", ValidProof ("10 5"));
+
+  SleepSome ();
+  EXPECT_TRUE (IsWaiting ());
+
+  scm.StopUpdates ();
+  JoinWaiter ();
+}
+
+TEST_F (WaitForChangeTests, LocalMove)
+{
+  /* We don't care about the broadcast, just specify that one will
+     be triggered.  */
+  EXPECT_CALL (offChain, SendMessage (_)).Times (1);
+
+  ProcessOnChain ("0 0", ValidProof ("10 5"), 0);
+
+  CallWaitForChange ();
+  cm.ProcessLocalMove ("1");
+  JoinWaiter ();
+}
+
+TEST_F (WaitForChangeTests, WhenStopped)
+{
+  scm.StopUpdates ();
+  CallWaitForChange ();
+  JoinWaiter ();
+}
+
+TEST_F (WaitForChangeTests, StopNotifies)
+{
+  CallWaitForChange ();
+  scm.StopUpdates ();
+  JoinWaiter ();
+}
+
+TEST_F (WaitForChangeTests, OutdatedKnownVersion)
+{
+  const int known = cm.ToJson ()["version"].asInt ();
+  ProcessOnChain ("0 0", ValidProof ("10 5"), 0);
+  CallWaitForChange (known);
+  JoinWaiter ();
+}
+
+TEST_F (WaitForChangeTests, UpToDateKnownVersion)
+{
+  const int known = cm.ToJson ()["version"].asInt ();
+  CallWaitForChange (known);
+
+  SleepSome ();
+  EXPECT_TRUE (IsWaiting ());
+
+  ProcessOnChain ("0 0", ValidProof ("10 5"), 0);
+  JoinWaiter ();
+}
+
+} // anonymous namespace
+} // namespace xaya

--- a/gamechannel/testutils.hpp
+++ b/gamechannel/testutils.hpp
@@ -5,6 +5,7 @@
 #ifndef GAMECHANNEL_TESTUTILS_HPP
 #define GAMECHANNEL_TESTUTILS_HPP
 
+#include "broadcast.hpp"
 #include "movesender.hpp"
 #include "signatures.hpp"
 
@@ -135,6 +136,25 @@ public:
   MOCK_METHOD (uint256, SendRawMove,
                (const std::string&, const std::string&), (override));
   bool IsPending (const uint256& txid) const override;
+
+};
+
+/**
+ * Mock instance for a basic off-chain broadcast.
+ */
+class MockOffChainBroadcast : public OffChainBroadcast
+{
+
+public:
+
+  MockOffChainBroadcast (const uint256& i)
+    : OffChainBroadcast(i)
+  {
+    /* Expect no calls by default.  */
+    EXPECT_CALL (*this, SendMessage (testing::_)).Times (0);
+  }
+
+  MOCK_METHOD1 (SendMessage, void (const std::string& msg));
 
 };
 

--- a/ships/Makefile.am
+++ b/ships/Makefile.am
@@ -26,6 +26,7 @@ libships_la_CXXFLAGS = \
 libships_la_LIBADD = \
   $(top_builddir)/xayautil/libxayautil.la \
   $(top_builddir)/xayagame/libxayagame.la \
+  $(top_builddir)/gamechannel/libchannelcore.la \
   $(top_builddir)/gamechannel/libgamechannel.la \
   $(JSONCPP_LIBS) $(SQLITE3_CFLAGS) $(GLOG_LIBS) $(PROTOBUF_LIBS)
 libships_la_SOURCES = \
@@ -55,6 +56,7 @@ shipsd_LDADD = \
   $(builddir)/libships.la \
   $(top_builddir)/xayautil/libxayautil.la \
   $(top_builddir)/xayagame/libxayagame.la \
+  $(top_builddir)/gamechannel/libchannelcore.la \
   $(top_builddir)/gamechannel/libgamechannel.la \
   $(JSONCPP_LIBS) $(GLOG_LIBS) $(GFLAGS_LIBS) $(PROTOBUF_LIBS)
 shipsd_SOURCES = main-gsp.cpp
@@ -67,6 +69,7 @@ ships_channel_LDADD = \
   $(builddir)/libships.la \
   $(top_builddir)/xayautil/libxayautil.la \
   $(top_builddir)/xayagame/libxayagame.la \
+  $(top_builddir)/gamechannel/libchannelcore.la \
   $(top_builddir)/gamechannel/libgamechannel.la \
   $(JSONCPP_LIBS) $(JSONRPCSERVER_LIBS) \
   $(GLOG_LIBS) $(GFLAGS_LIBS) $(PROTOBUF_LIBS)
@@ -90,6 +93,7 @@ tests_LDADD = \
   $(top_builddir)/xayautil/libxayautil.la \
   $(top_builddir)/xayagame/libtestutils.la \
   $(top_builddir)/xayagame/libxayagame.la \
+  $(top_builddir)/gamechannel/libchannelcore.la \
   $(top_builddir)/gamechannel/libgamechannel.la \
   $(top_builddir)/gamechannel/libtestutils.la \
   $(JSONCPP_LIBS) $(GLOG_LIBS) $(GTEST_LIBS) $(PROTOBUF_LIBS)

--- a/ships/main-channel.cpp
+++ b/ships/main-channel.cpp
@@ -9,6 +9,7 @@
 
 #include <gamechannel/daemon.hpp>
 #include <gamechannel/rpcbroadcast.hpp>
+#include <gamechannel/rpcwallet.hpp>
 #include <xayagame/rpc-stubs/xayarpcclient.h>
 #include <xayagame/rpc-stubs/xayawalletrpcclient.h>
 

--- a/websocket/Makefile.am
+++ b/websocket/Makefile.am
@@ -1,1 +1,1 @@
-bin_SCRIPTS = gsp-websocket-server.py
+dist_bin_SCRIPTS = gsp-websocket-server.py


### PR DESCRIPTION
This splits the `gamechannel` library in two parts:  The core logic for managing e.g. state proofs and channel states is moved to a new `channelcore` library, which is particularly light-weight (no threading, networking, RPCs or dependencies on `xayagame` for instance).  This will allow it to be used more easily e.g. in wasm for web-based channel daemons, or for channels not directly linked to a Xaya GSP.