### PR TITLE
Clear-text message signing for channels

### DIFF
--- a/gamechannel/channelgame.cpp
+++ b/gamechannel/channelgame.cpp
@@ -42,8 +42,8 @@ ChannelGame::ProcessDispute (ChannelData& ch, const unsigned height,
     return false;
 
   BoardState provenState;
-  if (!VerifyStateProof (GetSignatureVerifier (), rules, id, meta,
-                         ch.GetReinitState (), proof, provenState))
+  if (!VerifyStateProof (GetSignatureVerifier (), rules, GetGameId (), id,
+                         meta, ch.GetReinitState (), proof, provenState))
     {
       LOG (WARNING) << "Dispute has invalid state proof";
       return false;
@@ -116,8 +116,8 @@ ChannelGame::ProcessResolution (ChannelData& ch, const proto::StateProof& proof)
     return false;
 
   BoardState provenState;
-  if (!VerifyStateProof (GetSignatureVerifier (), rules, id, meta,
-                         ch.GetReinitState (), proof, provenState))
+  if (!VerifyStateProof (GetSignatureVerifier (), rules, GetGameId (), id,
+                         meta, ch.GetReinitState (), proof, provenState))
     {
       LOG (WARNING) << "Resolution has invalid state proof";
       return false;
@@ -176,8 +176,8 @@ ChannelGame::PendingMoves::AddPendingStateProof (ChannelData& ch,
     return;
 
   BoardState provenState;
-  if (!VerifyStateProof (game.GetSignatureVerifier (), rules, id, meta,
-                         ch.GetReinitState (), proof, provenState))
+  if (!VerifyStateProof (game.GetSignatureVerifier (), rules, GetGameId (), id,
+                         meta, ch.GetReinitState (), proof, provenState))
     {
       LOG (WARNING) << "StateProof of pending move is invalid";
       return;

--- a/gamechannel/channelmanager.cpp
+++ b/gamechannel/channelmanager.cpp
@@ -17,9 +17,11 @@ ChannelManager::DisputeData::DisputeData ()
 
 ChannelManager::ChannelManager (const BoardRules& r, OpenChannel& oc,
                                 const SignatureVerifier& v, SignatureSigner& s,
-                                const uint256& id, const std::string& name)
-  : rules(r), game(oc), verifier(v), signer(s), channelId(id), playerName(name),
-    boardStates(rules, verifier, channelId)
+                                const std::string& gId, const uint256& id,
+                                const std::string& name)
+  : rules(r), game(oc), verifier(v), signer(s),
+    gameId(gId), channelId(id), playerName(name),
+    boardStates(rules, verifier, gameId, channelId)
 {
   blockHash.SetNull ();
   pendingPutStateOnChain.SetNull ();
@@ -270,7 +272,7 @@ ChannelManager::ApplyLocalMove (const BoardMove& mv)
   CHECK (exists);
 
   proto::StateProof newProof;
-  if (!ExtendStateProof (verifier, signer, rules, channelId,
+  if (!ExtendStateProof (verifier, signer, rules, gameId, channelId,
                          boardStates.GetMetadata (),
                          boardStates.GetStateProof (), mv, newProof))
     {

--- a/gamechannel/channelmanager.hpp
+++ b/gamechannel/channelmanager.hpp
@@ -87,6 +87,8 @@ private:
   /** Message signer for this user.  */
   SignatureSigner& signer;
 
+  /** The ID for this channel application (used to salt signatures).  */
+  const std::string gameId;
   /** The ID of the managed channel.  */
   const uint256 channelId;
 
@@ -194,7 +196,8 @@ public:
   explicit ChannelManager (const BoardRules& r, OpenChannel& oc,
                            const SignatureVerifier& v,
                            SignatureSigner& s,
-                           const uint256& id, const std::string& name);
+                           const std::string& gId, const uint256& id,
+                           const std::string& name);
 
   ChannelManager () = delete;
   ChannelManager (const ChannelManager&) = delete;

--- a/gamechannel/channelmanager_tests.cpp
+++ b/gamechannel/channelmanager_tests.cpp
@@ -43,7 +43,7 @@ ValidProof (const std::string& state)
 ChannelManagerTestFixture::ChannelManagerTestFixture ()
   : cm(game.rules, game.channel,
        verifier, signer,
-       channelId, "player"),
+       "game id", channelId, "player"),
     onChain("game id", cm.GetChannelId (), "player", txSender, game.channel)
 {
   CHECK (TextFormat::ParseFromString (R"(

--- a/gamechannel/daemon.cpp
+++ b/gamechannel/daemon.cpp
@@ -30,7 +30,8 @@ ChannelDaemon::WalletBasedInstances::WalletBasedInstances (
     const SignatureVerifier& verifier, SignatureSigner& signer,
     TransactionSender& txSender)
   : sender(d.gameId, d.channelId, d.playerName, txSender, d.channel),
-    realCm(d.rules, d.channel, verifier, signer, d.channelId, d.playerName),
+    realCm(d.rules, d.channel, verifier, signer,
+           d.gameId, d.channelId, d.playerName),
     cm(realCm)
 {
   realCm.SetMoveSender (sender);

--- a/gamechannel/rollingstate.cpp
+++ b/gamechannel/rollingstate.cpp
@@ -78,7 +78,7 @@ RollingState::UpdateOnChain (const proto::ChannelMetadata& meta,
   CHECK (CheckVersionedProto (rules, meta, proof));
 
   BoardState provenState;
-  CHECK (VerifyStateProof (verifier, rules, channelId, meta,
+  CHECK (VerifyStateProof (verifier, rules, gameId, channelId, meta,
                            reinitState, proof, provenState))
       << "State proof provided on-chain is not valid";
 
@@ -179,7 +179,7 @@ RollingState::UpdateWithMove (const std::string& updReinit,
      on-chain updates (which are filtered through the GSP), the data we get
      here comes straight from the other players and may be complete garbage.  */
   BoardState provenState;
-  if (!VerifyStateProof (verifier, rules, channelId, *entry.meta,
+  if (!VerifyStateProof (verifier, rules, gameId, channelId, *entry.meta,
                          entry.reinitState, proof, provenState))
     {
       LOG (WARNING)

--- a/gamechannel/rollingstate.hpp
+++ b/gamechannel/rollingstate.hpp
@@ -78,6 +78,8 @@ private:
   /** Signature verifier for state proofs.  */
   const SignatureVerifier& verifier;
 
+  /** The game ID of this application.  */
+  const std::string& gameId;
   /** The ID of the channel this is for.  */
   const uint256& channelId;
 
@@ -94,8 +96,8 @@ private:
 public:
 
   explicit RollingState (const BoardRules& r, const SignatureVerifier& v,
-                         const uint256& id)
-    : rules(r), verifier(v), channelId(id)
+                         const std::string& gId, const uint256& id)
+    : rules(r), verifier(v), gameId(gId), channelId(id)
   {}
 
   RollingState () = delete;

--- a/gamechannel/rollingstate_tests.cpp
+++ b/gamechannel/rollingstate_tests.cpp
@@ -39,6 +39,7 @@ class RollingStateTests : public TestGameFixture
 
 protected:
 
+  const std::string gameId = "game id";
   const uint256 channelId = SHA256::Hash ("channel id");
   proto::ChannelMetadata meta1;
   proto::ChannelMetadata meta2;
@@ -46,7 +47,7 @@ protected:
   RollingState state;
 
   RollingStateTests ()
-    : state(game.rules, verifier, channelId)
+    : state(game.rules, verifier, gameId, channelId)
   {
     meta1.set_reinit ("reinit 1");
     meta1.add_participants ()->set_address ("addr 0");

--- a/gamechannel/signatures.cpp
+++ b/gamechannel/signatures.cpp
@@ -13,7 +13,8 @@ namespace xaya
 {
 
 std::string
-GetChannelSignatureMessage (const uint256& channelId,
+GetChannelSignatureMessage (const std::string& gameId,
+                            const uint256& channelId,
                             const proto::ChannelMetadata& meta,
                             const std::string& topic,
                             const std::string& data)
@@ -33,13 +34,15 @@ GetChannelSignatureMessage (const uint256& channelId,
 
 std::set<int>
 VerifyParticipantSignatures (const SignatureVerifier& verifier,
+                             const std::string& gameId,
                              const uint256& channelId,
                              const proto::ChannelMetadata& meta,
                              const std::string& topic,
                              const proto::SignedData& data)
 {
-  const std::string msg = GetChannelSignatureMessage (channelId, meta, topic,
-                                                      data.data ());
+  const auto msg
+      = GetChannelSignatureMessage (gameId, channelId, meta,
+                                    topic, data.data ());
 
   std::set<std::string> addresses;
   for (const auto& sgn : data.signatures ())
@@ -55,6 +58,7 @@ VerifyParticipantSignatures (const SignatureVerifier& verifier,
 
 bool
 SignDataForParticipant (SignatureSigner& signer,
+                        const std::string& gameId,
                         const uint256& channelId,
                         const proto::ChannelMetadata& meta,
                         const std::string& topic,
@@ -73,7 +77,8 @@ SignDataForParticipant (SignatureSigner& signer,
     }
 
   const auto msg
-      = GetChannelSignatureMessage (channelId, meta, topic, data.data ());
+      = GetChannelSignatureMessage (gameId, channelId, meta,
+                                    topic, data.data ());
   data.add_signatures (signer.SignMessage (msg));
   return true;
 }

--- a/gamechannel/signatures.hpp
+++ b/gamechannel/signatures.hpp
@@ -79,7 +79,8 @@ public:
  * with a game-specific BoardState and BoardMove value, respectively.  Other
  * values can be used for game-specific needs.
  */
-std::string GetChannelSignatureMessage (const uint256& channelId,
+std::string GetChannelSignatureMessage (const std::string& gameId,
+                                        const uint256& channelId,
                                         const proto::ChannelMetadata& meta,
                                         const std::string& topic,
                                         const std::string& data);
@@ -97,6 +98,7 @@ std::string GetChannelSignatureMessage (const uint256& channelId,
  * values can be used for game-specific needs.
  */
 std::set<int> VerifyParticipantSignatures (const SignatureVerifier& verifier,
+                                           const std::string& gameId,
                                            const uint256& channelId,
                                            const proto::ChannelMetadata& meta,
                                            const std::string& topic,
@@ -107,6 +109,7 @@ std::set<int> VerifyParticipantSignatures (const SignatureVerifier& verifier,
  * the provided signer.  Returns true if a signature could be made.
  */
 bool SignDataForParticipant (SignatureSigner& signer,
+                             const std::string& gameId,
                              const uint256& channelId,
                              const proto::ChannelMetadata& meta,
                              const std::string& topic,

--- a/gamechannel/signatures.hpp
+++ b/gamechannel/signatures.hpp
@@ -75,9 +75,9 @@ public:
  *
  * The topic string describes what the data is, so that e.g. a signed state
  * cannot be mistaken as a signed message stating the winner.  This string
- * must not contain any nul bytes.  "state" and "move" are reserved for use
- * with a game-specific BoardState and BoardMove value, respectively.  Other
- * values can be used for game-specific needs.
+ * must only contain alpha-numeric characters (0-9, a-z, A-Z).  "state" and
+ * "move" are reserved for use with a game-specific BoardState and BoardMove
+ * value, respectively.  Other values can be used for game-specific needs.
  */
 std::string GetChannelSignatureMessage (const std::string& gameId,
                                         const uint256& channelId,

--- a/gamechannel/signatures.py
+++ b/gamechannel/signatures.py
@@ -23,16 +23,15 @@ def getChannelMessage (gameId, channelId, meta, topic, data):
   """
 
   assert len (channelId) == 32
-  hasher = hashlib.sha256 ()
 
-  hasher.update (channelId)
-  hasher.update (base64.b64encode (meta.reinit))
-  hasher.update (b"\0")
-  hasher.update (codecs.encode (topic, "ascii"))
-  hasher.update (b"\0")
-  hasher.update (data)
+  reinit = codecs.decode (base64.b64encode (meta.reinit), "ascii")
 
-  return hasher.hexdigest ()
+  return "Game-Channel Signature\n" \
+          + ("Game ID: %s\n" % gameId) \
+          + ("Channel: %s\n" % channelId.hex ()) \
+          + ("Reinit: %s\n" % reinit) \
+          + ("Topic: %s\n" % topic) \
+          + ("Data Hash: %s" % hashlib.sha256 (data).hexdigest ())
 
 
 def createForChannel (rpc, gameId, channel, topic, data):

--- a/gamechannel/signatures.py
+++ b/gamechannel/signatures.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2019-2020 The Xaya developers
+# Copyright (C) 2019-2022 The Xaya developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -13,7 +13,7 @@ import codecs
 import hashlib
 
 
-def getChannelMessage (channelId, meta, topic, data):
+def getChannelMessage (gameId, channelId, meta, topic, data):
   """
   Returns the raw message that is signed (as string, using signmessage)
   for signing the given data in a channel with the given ID and topic.
@@ -35,7 +35,7 @@ def getChannelMessage (channelId, meta, topic, data):
   return hasher.hexdigest ()
 
 
-def createForChannel (rpc, channel, topic, data):
+def createForChannel (rpc, gameId, channel, topic, data):
   """
   Constructs a SignedData protocol buffer instance that contains the given
   data and signatures for all participants of the channel for which the private
@@ -53,7 +53,7 @@ def createForChannel (rpc, channel, topic, data):
   channelId = codecs.decode (channel["id"], "hex")
   meta = metadata_pb2.ChannelMetadata ()
   meta.ParseFromString (base64.b64decode (channel["meta"]["proto"]))
-  msg = getChannelMessage (channelId, meta, topic, data)
+  msg = getChannelMessage (gameId, channelId, meta, topic, data)
 
   for p in meta.participants:
     valid = rpc.validateaddress (p.address)

--- a/gamechannel/signatures_tests.py
+++ b/gamechannel/signatures_tests.py
@@ -26,7 +26,12 @@ class SignaturesTest (unittest.TestCase):
     meta.reinit = b"re\0init"
 
     # This is logged by the C++ signatures test.
-    msg = "917ad3494da16c7728ef5f8f44f2285d7d7fd3ed7b78278be440fa644927d5cc"
+    msg = """Game-Channel Signature
+Game ID: game id
+Channel: 537e2fa2e3e5eafcb04ff353ff2a1984b7c1500419d322dcbec8b3613c224d57
+Reinit: cmUAaW5pdA==
+Topic: topic
+Data Hash: d6b681bfce7155d44721afb79c296ef4f0fa80a9dd6b43c5cf74dd0f64c85512"""
     actual = signatures.getChannelMessage ("game id", channelId, meta,
                                            "topic", b"foo\0bar")
     self.assertEqual (actual, msg)

--- a/gamechannel/signatures_tests.py
+++ b/gamechannel/signatures_tests.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (C) 2019-2020 The Xaya developers
+# Copyright (C) 2019-2022 The Xaya developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -27,7 +27,7 @@ class SignaturesTest (unittest.TestCase):
 
     # This is logged by the C++ signatures test.
     msg = "917ad3494da16c7728ef5f8f44f2285d7d7fd3ed7b78278be440fa644927d5cc"
-    actual = signatures.getChannelMessage (channelId, meta,
+    actual = signatures.getChannelMessage ("game id", channelId, meta,
                                            "topic", b"foo\0bar")
     self.assertEqual (actual, msg)
 
@@ -72,7 +72,8 @@ class SignaturesTest (unittest.TestCase):
       signatures: "sgn 1"
     """, expected)
 
-    actual = signatures.createForChannel (rpc, channel, "topic", b"foobar")
+    actual = signatures.createForChannel (rpc, "game id", channel,
+                                          "topic", b"foobar")
     self.assertEqual (actual, expected)
 
 

--- a/gamechannel/stateproof.hpp
+++ b/gamechannel/stateproof.hpp
@@ -25,6 +25,7 @@ namespace xaya
  */
 bool VerifyStateTransition (const SignatureVerifier& verifier,
                             const BoardRules& rules,
+                            const std::string& gameId,
                             const uint256& channelId,
                             const proto::ChannelMetadata& meta,
                             const BoardState& oldState,
@@ -37,6 +38,7 @@ bool VerifyStateTransition (const SignatureVerifier& verifier,
  */
 bool VerifyStateProof (const SignatureVerifier& verifier,
                        const BoardRules& rules,
+                       const std::string& gameId,
                        const uint256& channelId,
                        const proto::ChannelMetadata& meta,
                        const BoardState& reinitState,
@@ -65,6 +67,7 @@ const BoardState& UnverifiedProofEndState (const proto::StateProof& proof);
 bool ExtendStateProof (const SignatureVerifier& verifier,
                        SignatureSigner& signer,
                        const BoardRules& rules,
+                       const std::string& gameId,
                        const uint256& channelId,
                        const proto::ChannelMetadata& meta,
                        const proto::StateProof& oldProof,

--- a/gamechannel/testutils.cpp
+++ b/gamechannel/testutils.cpp
@@ -95,7 +95,8 @@ MockSignatureVerifier::SetValid (const std::string& sgn,
 }
 
 void
-MockSignatureVerifier::ExpectOne (const uint256& channelId,
+MockSignatureVerifier::ExpectOne (const std::string& gameId,
+                                  const uint256& channelId,
                                   const proto::ChannelMetadata& meta,
                                   const std::string& topic,
                                   const std::string& msg,
@@ -103,7 +104,7 @@ MockSignatureVerifier::ExpectOne (const uint256& channelId,
                                   const std::string& addr)
 {
   const std::string hashed
-      = GetChannelSignatureMessage (channelId, meta, topic, msg);
+      = GetChannelSignatureMessage (gameId, channelId, meta, topic, msg);
   EXPECT_CALL (*this, RecoverSigner (hashed, sgn)).WillOnce (Return (addr));
 }
 

--- a/gamechannel/testutils.hpp
+++ b/gamechannel/testutils.hpp
@@ -44,7 +44,7 @@ public:
    * and signature (both as binary).  Returns a valid response for the
    * given address.
    */
-  void ExpectOne (const uint256& channelId,
+  void ExpectOne (const std::string& gameId, const uint256& channelId,
                   const proto::ChannelMetadata& meta,
                   const std::string& topic,
                   const std::string& msg, const std::string& sgn,

--- a/ships/gametest/shipstest.py
+++ b/ships/gametest/shipstest.py
@@ -18,6 +18,9 @@ from google.protobuf import text_format
 import base64
 
 
+GAME_ID = "xs"
+
+
 class ShipsTest (channeltest.TestCase):
   """
   An integration test for the ships on-chain GSP and (potentially)
@@ -30,7 +33,7 @@ class ShipsTest (channeltest.TestCase):
       top_builddir = "../.."
     shipsd = os.path.join (top_builddir, "ships", "shipsd")
     channeld = os.path.join (top_builddir, "ships", "ships-channel")
-    super (ShipsTest, self).__init__ ("xs", shipsd, channeld)
+    super (ShipsTest, self).__init__ (GAME_ID, shipsd, channeld)
 
   def openChannel (self, names, addresses=None):
     """
@@ -69,7 +72,7 @@ class ShipsTest (channeltest.TestCase):
     stateBytes = state.SerializeToString ()
 
     res = stateproof_pb2.StateProof ()
-    signedData = signatures.createForChannel (self.rpc.xaya, channel,
+    signedData = signatures.createForChannel (self.rpc.xaya, GAME_ID, channel,
                                               "state", stateBytes)
     res.initial_state.CopyFrom (signedData)
 


### PR DESCRIPTION
This updates the way channel signatures are done.  Instead of hashing all the data together and signing just a (hex-encoded) hash, the message is now constructed as a human-readable / clear-text string.
    
This string contains the game ID, channel ID, reinit and topic in a way that a human can check them inside before signing, and only the actual data (e.g. state proto) is hashed beforehand.  This makes signatures potentially more secure and trusted (even though they should be made by a temporary key anyway).
    
With this change, we also include the game ID now, which was previously not included, as an extra protection against relay attacks.
    
Note that this forks existing game-channel applications, in particular the Xayaships tech demo.