### PR TITLE
Fix race condition between on- and off-chain updates

### DIFF
--- a/gamechannel/broadcast.cpp
+++ b/gamechannel/broadcast.cpp
@@ -16,6 +16,18 @@
 namespace xaya
 {
 
+namespace
+{
+
+/**
+ * The maximum size (in bytes) of an off-chain message that gets accepted
+ * and processed.  This is a measure against DoS by a peer; real messages
+ * should in practice always be (much) smaller than this anyway.
+ */
+constexpr size_t MAX_MESSAGE_SIZE = 1'024 * 1'024;
+
+} // anonymous namespace
+
 void
 OffChainBroadcast::SetParticipants (const proto::ChannelMetadata& meta)
 {
@@ -55,6 +67,14 @@ void
 OffChainBroadcast::ProcessIncoming (ChannelManager& m,
                                     const std::string& msg) const
 {
+  if (msg.size () > MAX_MESSAGE_SIZE)
+    {
+      LOG (ERROR)
+          << "Discarding too large off-chain message (size "
+          << msg.size () << " bytes)";
+      return;
+    }
+
   VLOG (1) << "Processing received broadcast message...";
   CHECK (m.GetChannelId () == id) << "Channel ID mismatch";
 

--- a/gamechannel/rollingstate.cpp
+++ b/gamechannel/rollingstate.cpp
@@ -18,6 +18,89 @@ using google::protobuf::util::MessageDifferencer;
 namespace xaya
 {
 
+namespace
+{
+
+/**
+ * Maximum size of the state-update queue for unknown reinits.  This protects
+ * against DoS.  In practice, the queue is needed only in rare edge cases
+ * at all, and then one or two entries in total are most likely more than
+ * enough.
+ */
+constexpr size_t STATE_UPDATE_QUEUE_SIZE = 100;
+
+} // anonymous namespace
+
+/* ************************************************************************** */
+
+void
+StateUpdateQueue::Insert (const std::string& reinit,
+                          const proto::StateProof& upd)
+{
+  /* If we are at capacity, drop all reinits apart from the current one
+     as a first step.  */
+  if (size == maxSize)
+    {
+      LOG_FIRST_N (WARNING, 10)
+          << "StateUpdateQueue has reached maximum size,"
+          << " we will drop some elements";
+
+      auto mit = updates.begin ();
+      while (mit != updates.end ())
+        {
+          if (mit->first == reinit)
+            ++mit;
+          else
+            {
+              CHECK_GE (size, mit->second.size ());
+              size -= mit->second.size ();
+              mit = updates.erase (mit);
+            }
+        }
+    }
+
+  /* If we are still at capacity, we only have the current reinit left,
+     and start dropping the oldest elements for it.  */
+  if (size == maxSize)
+    {
+      CHECK_EQ (updates.size (), 1);
+      const auto mit = updates.begin ();
+      CHECK_EQ (mit->first, reinit);
+      CHECK_EQ (mit->second.size (), size);
+      --size;
+      mit->second.pop_front ();
+    }
+
+  CHECK_LT (size, maxSize);
+  ++size;
+  updates[reinit].push_back (upd);
+}
+
+std::deque<proto::StateProof>
+StateUpdateQueue::ExtractQueue (const std::string& reinit)
+{
+  auto mit = updates.find (reinit);
+  if (mit == updates.end ())
+    return {};
+
+  auto res = std::move (mit->second);
+
+  CHECK_GE (size, res.size ());
+  size -= res.size ();
+
+  updates.erase (mit);
+
+  return res;
+}
+
+/* ************************************************************************** */
+
+RollingState::RollingState (const BoardRules& r, const SignatureVerifier& v,
+                            const std::string& gId, const uint256& id)
+  : rules(r), verifier(v), gameId(gId), channelId(id),
+    unknownReinitMoves(STATE_UPDATE_QUEUE_SIZE)
+{}
+
 const ParsedBoardState&
 RollingState::GetLatestState () const
 {
@@ -113,16 +196,14 @@ RollingState::UpdateOnChain (const proto::ChannelMetadata& meta,
 
       /* If we have any queued up off-chain updates for this reinit,
          process them now.  */
-      const auto mit2 = unknownReinitMoves.find (reinitId);
-      if (mit2 != unknownReinitMoves.end ())
+      const auto updateQueue = unknownReinitMoves.ExtractQueue (reinitId);
+      if (!updateQueue.empty ())
         {
-          const auto& updateQueue = mit2->second;
           LOG (INFO)
               << "Processing " << updateQueue.size ()
               << " queued off-chain updates for the new reinit";
           for (const auto& sp : updateQueue)
             UpdateWithMove (reinitId, sp);
-          unknownReinitMoves.erase (reinitId);
         }
 
       return true;
@@ -183,7 +264,7 @@ RollingState::UpdateWithMove (const std::string& updReinit,
       LOG (WARNING)
           << "Off-chain update for channel " << channelId.ToHex ()
           << " has unknown reinitialisation ID: " << EncodeBase64 (updReinit);
-      unknownReinitMoves[updReinit].push_back (proof);
+      unknownReinitMoves.Insert (updReinit, proof);
       return false;
     }
   ReinitData& entry = mit->second;
@@ -238,5 +319,7 @@ RollingState::UpdateWithMove (const std::string& updReinit,
      when switching to that reinit ID).  */
   return (updReinit == reinitId);
 }
+
+/* ************************************************************************** */
 
 } // namespace xaya

--- a/gamechannel/rollingstate.hpp
+++ b/gamechannel/rollingstate.hpp
@@ -15,6 +15,7 @@
 
 #include <map>
 #include <memory>
+#include <vector>
 
 namespace xaya
 {
@@ -89,6 +90,19 @@ private:
    * this is done, GetLatestState and GetStateProof must not be called.
    */
   std::map<std::string, ReinitData> reinits;
+
+  /**
+   * For still unknown reinitialisations, we keep track of a list of
+   * received off-chain updates.  We can't process them when we receive them
+   * (as the reinit state is unknown), but we will process the full list once
+   * the corresponding reinit gets created on chain.
+   *
+   * FIXME: This is a potential DoS vector.  We should enforce a maximum
+   * number of entries stored in there, and discard old ones when we hit
+   * the limit.  After all, this is supposed to be just a fix for very short
+   * term delays in receiving on-chain updates from our GSP.
+   */
+  std::map<std::string, std::vector<proto::StateProof>> unknownReinitMoves;
 
   /** The reinit ID of the current reinitialisation.  */
   std::string reinitId;

--- a/gamechannel/rollingstate_tests.cpp
+++ b/gamechannel/rollingstate_tests.cpp
@@ -143,23 +143,31 @@ TEST_F (RollingStateTests, OnChainUpdate)
 
 TEST_F (RollingStateTests, UpdateWithMoveUnknownReinit)
 {
-  state.UpdateWithMove ("reinit 1", ParseStateProof (R"(
-    initial_state: { data: "13 5" }
-    transitions:
-      {
-        move: "50"
-        new_state:
-          {
-            data: "63 6"
-            signatures: "sgn 1"
-          }
-      }
-  )"));
-
   state.UpdateOnChain (meta1, "13 5", ParseStateProof (R"(
     initial_state: { data: "13 5" }
   )"));
   ExpectState ("13 5", "reinit 1");
+
+  /* This update gets queued initially, and then applied once
+     the on-chain update is there.  */
+  state.UpdateWithMove ("reinit 2", ParseStateProof (R"(
+    initial_state: { data: "25 4" }
+    transitions:
+      {
+        move: "40"
+        new_state:
+          {
+            data: "65 5"
+            signatures: "sgn 2"
+          }
+      }
+  )"));
+  ExpectState ("13 5", "reinit 1");
+
+  state.UpdateOnChain (meta2, "25 4", ParseStateProof (R"(
+    initial_state: { data: "25 4" }
+  )"));
+  ExpectState ("65 5", "reinit 2");
 }
 
 TEST_F (RollingStateTests, UpdateWithMoveInvalidProof)

--- a/ships/gametest/shipstest.py
+++ b/ships/gametest/shipstest.py
@@ -110,6 +110,8 @@ class ShipsTest (channeltest.TestCase):
     actualTypes = []
     for p in pending:
       val = json.loads (p["value"])
+      if ("g" not in val) or ("xs" not in val["g"]):
+        continue
       mvKeys = list (val["g"]["xs"].keys ())
       self.assertEqual (len (mvKeys), 1)
       actualTypes.append (mvKeys[0])


### PR DESCRIPTION
In a channel game, it may happen that an off-chain message is received from the peer that is for a reinitialisation which is not yet known locally; for instance, if the peer sends an auto move as soon as the channel is created on-chain, and we receive the off-chain message for that before our GSP processes the on-chain update.  In this situation, we used to discard the off-chain message (which would stall the game until a dispute and resolution was done in the worst case).  This issue was also causing the `reorg.py` Xayaships regtest to be flaky.

This set of changes introduces proper handling for this situation (as well as some other fixes, e.g. to `reorg.py` in general).  If we now receive an off-chain message for an unknown reinit, we keep it in memory and try to process it as soon as a matching reinit is created on-chain.  The total size of this cache is limited (to 100, which is more than enough in practice for fixing such an edge case) so that a bad peer cannot DoS us by filling the memory.