### PR TITLE
Probe and fix GSP connection to Xaya Core

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -46,6 +46,7 @@ AX_PKG_CHECK_MODULES([GLOG], [libglog])
 # Private dependencies of the library itself.
 AX_PKG_CHECK_MODULES([OPENSSL], [], [openssl])
 AX_PKG_CHECK_MODULES([MHD], [], [libmicrohttpd])
+AX_PKG_CHECK_MODULES([GFLAGS], [], [gflags])
 # We use deflateGetDictionary from zlib, which was introduced in version
 # 1.2.9.  Since zlib itself recommends using 1.2.11 over .9 and .10, let's
 # make sure we have at least this version.
@@ -56,7 +57,6 @@ AX_PKG_CHECK_MODULES([ZMQ], [], [libzmq >= 4.3.1])
 
 # Private dependencies that are not needed for libxayagame, but only for
 # the unit tests and the example binaries.
-PKG_CHECK_MODULES([GFLAGS], [gflags])
 PKG_CHECK_MODULES([GTEST], [gmock gtest_main])
 
 AC_CONFIG_FILES([

--- a/mover/gametest/stopped_xayad.py
+++ b/mover/gametest/stopped_xayad.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (C) 2018-2021 The Xaya developers
+# Copyright (C) 2018-2022 The Xaya developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -9,14 +9,32 @@ import time
 
 """
 Tests how the moverd reacts if xayad is stopped and restarted intermittantly.
+The connection probe & fix logic should take care of it.
 """
 
 
 class StoppedXayadTest (MoverTest):
 
+  def getState (self):
+    """
+    Returns the 'state' of the GSP.
+    """
+
+    return self.rpc.game.getnullstate ()["state"]
+
   def run (self):
     self.generate (101)
     self.expectGameState ({"players": {}})
+
+    # Turn on the connection check and reduce the staleness threshold
+    # so we can reasonably test with it.
+    self.mainLogger.info ("Turning on connection checker...")
+    self.stopGameDaemon ()
+    args = [
+      "--xaya_connection_check_ms=100",
+      "--xaya_zmq_staleness_ms=1000",
+    ]
+    self.startGameDaemon (extraArgs=args)
 
     self.move ("a", "k", 2)
     self.generate (1)
@@ -24,25 +42,38 @@ class StoppedXayadTest (MoverTest):
       "a": {"x": 0, "y": 1, "dir": "up", "steps": 1},
     }})
 
-    # Stop and restart the Xaya Core daemon.  This should not impact the game
-    # daemon, at least not as long as it does not try to send a JSON-RPC
-    # message while xayad is down.  The ZMQ subscription should be back up
-    # again automatically.
-    self.log.info ("Restarting Xaya daemon")
+    # If we don't stop the Xaya daemon, the connection will remain good,
+    # even if no blocks happen within the staleness period (because the pings
+    # will take care of it).
+    self.mainLogger.info ("Pings keep the connection good...")
+    time.sleep (1.5)
+    self.assertEqual (self.getState (), "up-to-date")
+    self.stopGameDaemon ()
+    assert self.gamenode.logMatches ("seems stale, requesting a block")
+    self.startGameDaemon (extraArgs=args)
+
+    # Stop and restart the Xaya Core daemon.  The GSP will notice it lost the
+    # connection, and automatically reconnect once it is back up.
+    self.mainLogger.info ("Stopping Xaya daemon...")
     self.xayanode.stop ()
+    time.sleep (1.5)
+    self.assertEqual (self.getState (), "disconnected")
+
+    self.mainLogger.info ("Starting Xaya daemon...")
     self.xayanode.start ()
     self.rpc.xaya = self.xayanode.rpc
-
-    # Track the game again and sleep a short time, which ensures that the
-    # ZMQ subscription has indeed had time to catch up again.
-    self.rpc.xaya.trackedgames ("add", "mv")
-    time.sleep (0.1)
+    time.sleep (1.5)
+    self.assertEqual (self.getState (), "up-to-date")
 
     # Mine another block and verify that the game updates.
     self.generate (1)
     self.expectGameState ({"players": {
       "a": {"x": 0, "y": 2},
     }})
+
+    self.stopGameDaemon ()
+    assert self.gamenode.logMatches ("re-establish the Xaya connection")
+    self.startGameDaemon ()
 
 
 if __name__ == "__main__":

--- a/xayagame/game.hpp
+++ b/xayagame/game.hpp
@@ -45,6 +45,8 @@ class Game : private internal::ZmqListener
 
 private:
 
+  class ConnectionCheckerThread;
+
   /**
    * States for the game engine during syncing / operation.  The basic states
    * and transitions between states are as follows:
@@ -191,6 +193,9 @@ private:
   /** The pruning queue if we are pruning.  */
   std::unique_ptr<internal::PruningQueue> pruningQueue;
 
+  /** The background thread running regular connection checks, if any.  */
+  std::unique_ptr<ConnectionCheckerThread> connectionChecker;
+
   void BlockAttach (const std::string& id, const Json::Value& data,
                     bool seqMismatch) override;
   void BlockDetach (const std::string& id, const Json::Value& data,
@@ -320,6 +325,7 @@ public:
     = std::function<Json::Value (const GameStateData& state)>;
 
   explicit Game (const std::string& id);
+  ~Game ();
 
   Game () = delete;
   Game (const Game&) = delete;

--- a/xayagame/game.hpp
+++ b/xayagame/game.hpp
@@ -255,6 +255,14 @@ private:
   void ReinitialiseState ();
 
   /**
+   * Checks if the connection seems fine (e.g. ZMQ staleness), marks the
+   * state as disconnected if not, and tries to reconnect if the state
+   * is disconnected.  This is run periodically by a background thread
+   * while the GSP is supposed to be running.
+   */
+  void ProbeAndFixConnection ();
+
+  /**
    * Notifies potentially-waiting threads that the state has changed.  Callers
    * must hold the mut lock.
    */

--- a/xayagame/game.hpp
+++ b/xayagame/game.hpp
@@ -73,6 +73,11 @@ private:
    * UP_TO_DATE:  As far as is known, we are at the current tip of the daemon.
    * Ordinary ZMQ notifications are processed as they come in for changes
    * to the tip, and we expect them to match the current block hash.
+   *
+   * DISCONNECTED:  The GSP is currently not actively connected to Xaya Core.
+   * This state occurs when the RPC connection to Xaya Core throws, or if
+   * we detect that the ZeroMQ connection seems to have stalled.  In this state,
+   * the GSP tries to reconnect / re-establish the ZMQ sockets and sync back up.
    */
   enum class State
   {
@@ -81,6 +86,7 @@ private:
     OUT_OF_SYNC,
     CATCHING_UP,
     UP_TO_DATE,
+    DISCONNECTED,
   };
 
   /** This game's game ID.  */
@@ -190,6 +196,7 @@ private:
   void BlockDetach (const std::string& id, const Json::Value& data,
                     bool seqMismatch) override;
   void PendingMove (const std::string& id, const Json::Value& data) override;
+  void HasStopped () override;
 
   /**
    * Adds this game's ID to the tracked games of the core daemon.

--- a/xayagame/game_tests.cpp
+++ b/xayagame/game_tests.cpp
@@ -19,6 +19,7 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <gflags/gflags.h>
 #include <glog/logging.h>
 
 #include <atomic>
@@ -28,6 +29,8 @@
 #include <sstream>
 #include <string>
 #include <thread>
+
+DECLARE_int32 (xaya_zmq_staleness_ms);
 
 namespace xaya
 {
@@ -2041,6 +2044,100 @@ TEST_F (GameStorageRetryTests, DetachBlock)
   EXPECT_EQ (GetState (g), State::UP_TO_DATE);
   ExpectGameState (retryStorage, TestGame::GenesisBlockHash (), "");
 
+}
+
+/* ************************************************************************** */
+
+/**
+ * Test fixture for the probe-and-reconnect logic in Game.
+ */
+class GameProbeAndFixConnectionTests : public SyncingTests
+{
+
+protected:
+
+  static constexpr auto MAX_STALENESS = std::chrono::milliseconds (1'000);
+  static constexpr auto PING_STALENESS = MAX_STALENESS / 2;
+
+  GameProbeAndFixConnectionTests ()
+  {
+    FLAGS_xaya_zmq_staleness_ms = MAX_STALENESS.count ();
+
+    AttachBlock (g, BlockHash (11), Moves ("a0b1"));
+    EXPECT_EQ (GetState (g), State::UP_TO_DATE);
+    mockXayaServer->SetBestBlock (11, BlockHash (11));
+
+    /* We need to be able to start the ZMQ subscriber, even if for the test
+       no publisher is connected to it.  */
+    const Json::Value notifications = ParseJson (R"(
+      [
+        {"type": "pubgameblocks", "address": "ipc:///tmp/xayagame_game_tests"}
+      ]
+    )");
+    EXPECT_CALL (*mockXayaServer, getzmqnotifications ())
+        .WillRepeatedly (Return (notifications));
+
+    g.DetectZmqEndpoint ();
+    GameTestFixture::GetZmq (g).Start ();
+  }
+
+  void
+  ProbeAndFix ()
+  {
+    LOG (INFO) << "Probing game connection...";
+    GameTestFixture::ProbeAndFixConnection (g);
+    /* Sleep some time (short compared to staleness) to make sure any
+       potential stop request for ZMQ would be processed by now.  */
+    std::this_thread::sleep_for (MAX_STALENESS / 5);
+  }
+
+  /**
+   * Sets mock expectations for n "ping" calls to game_sendupdates.
+   */
+  void
+  ExpectPings (const unsigned n)
+  {
+    auto& call =
+      EXPECT_CALL (*mockXayaServer,
+                   game_sendupdates (TestGame::GenesisBlockHash ().ToHex (),
+                                     GAME_ID))
+          .Times (n);
+    if (n > 0)
+      call.WillRepeatedly (Return (Json::Value (Json::objectValue)));
+  }
+
+};
+
+TEST_F (GameProbeAndFixConnectionTests, TooEarlyForPing)
+{
+  ExpectPings (0);
+  ProbeAndFix ();
+  EXPECT_EQ (GetState (g), State::UP_TO_DATE);
+  EXPECT_TRUE (GameTestFixture::GetZmq (g).IsRunning ());
+}
+
+TEST_F (GameProbeAndFixConnectionTests, SendsPing)
+{
+  ExpectPings (1);
+  std::this_thread::sleep_for (3 * MAX_STALENESS / 4);
+  ProbeAndFix ();
+  EXPECT_EQ (GetState (g), State::UP_TO_DATE);
+  EXPECT_TRUE (GameTestFixture::GetZmq (g).IsRunning ());
+}
+
+TEST_F (GameProbeAndFixConnectionTests, DisconnectAndReconnect)
+{
+  ExpectPings (0);
+  EXPECT_CALL (*mockXayaServer, trackedgames ("add", GAME_ID));
+
+  std::this_thread::sleep_for (2 * MAX_STALENESS);
+  ProbeAndFix ();
+  EXPECT_EQ (GetState (g), State::DISCONNECTED);
+  EXPECT_FALSE (GameTestFixture::GetZmq (g).IsRunning ());
+
+  ProbeAndFix ();
+  EXPECT_EQ (GetState (g), State::UP_TO_DATE);
+  EXPECT_TRUE (GameTestFixture::GetZmq (g).IsRunning ());
 }
 
 /* ************************************************************************** */

--- a/xayagame/game_tests.cpp
+++ b/xayagame/game_tests.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2021 The Xaya developers
+// Copyright (C) 2018-2022 The Xaya developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -51,7 +51,7 @@ constexpr bool NO_SEQ_MISMATCH = false;
 /**
  * Mock RPC server that takes the place of the Xaya Core daemon in unit tests.
  * Some methods are mocked using GMock, while others (in particular,
- * getblockchaininfo) have an explicit fake implemlentation.
+ * getblockchaininfo) have an explicit fake implementation.
  */
 class MockXayaRpcServerWithState : public MockXayaRpcServer
 {
@@ -708,7 +708,7 @@ TEST_F (GetCurrentJsonStateTests, NoStateYet)
   const Json::Value state = g.GetCurrentJsonState ();
   EXPECT_EQ (state["gameid"], GAME_ID);
   EXPECT_EQ (state["chain"], "main");
-  EXPECT_EQ (state["state"], "unknown");
+  EXPECT_EQ (state["state"], "disconnected");
   EXPECT_FALSE (state.isMember ("blockhash"));
   EXPECT_FALSE (state.isMember ("height"));
   EXPECT_FALSE (state.isMember ("gamestate"));

--- a/xayagame/testutils.hpp
+++ b/xayagame/testutils.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2021 The Xaya developers
+// Copyright (C) 2018-2022 The Xaya developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -307,6 +307,18 @@ protected:
   {
     std::lock_guard<std::mutex> lock(g.mut);
     g.state = s;
+  }
+
+  static void
+  ProbeAndFixConnection (Game& g)
+  {
+    g.ProbeAndFixConnection ();
+  }
+
+  static internal::ZmqSubscriber&
+  GetZmq (Game& g)
+  {
+    return g.zmq;
   }
 
   /**

--- a/xayagame/zmqsubscriber.cpp
+++ b/xayagame/zmqsubscriber.cpp
@@ -227,21 +227,31 @@ ZmqSubscriber::Listen (ZmqSubscriber* self)
           << "Error parsing notification JSON: " << parseErrs
           << "\n" << payload;
 
-      for (auto i = range.first; i != range.second; ++i)
-        switch (type)
-          {
-          case TopicType::ATTACH:
-            i->second->BlockAttach (gameId, data, seqMismatch);
-            break;
-          case TopicType::DETACH:
-            i->second->BlockDetach (gameId, data, seqMismatch);
-            break;
-          case TopicType::PENDING:
-            i->second->PendingMove (gameId, data);
-            break;
-          default:
-            LOG (FATAL) << "Invalid topic type: " << static_cast<int> (type);
-          }
+      try
+        {
+          for (auto i = range.first; i != range.second; ++i)
+            switch (type)
+              {
+              case TopicType::ATTACH:
+                i->second->BlockAttach (gameId, data, seqMismatch);
+                break;
+              case TopicType::DETACH:
+                i->second->BlockDetach (gameId, data, seqMismatch);
+                break;
+              case TopicType::PENDING:
+                i->second->PendingMove (gameId, data);
+                break;
+              default:
+                LOG (FATAL)
+                    << "Invalid topic type: " << static_cast<int> (type);
+              }
+        }
+      catch (const std::exception& exc)
+        {
+          LOG (ERROR)
+              << "Exception while processing ZMQ update: " << exc.what ();
+          break;
+        }
     }
 
   self->running = false;

--- a/xayagame/zmqsubscriber.cpp
+++ b/xayagame/zmqsubscriber.cpp
@@ -6,7 +6,6 @@
 
 #include <glog/logging.h>
 
-#include <chrono>
 #include <sstream>
 
 namespace xaya
@@ -216,6 +215,16 @@ ZmqSubscriber::Listen (ZmqSubscriber* self)
           mit->second = seq;
         }
 
+      switch (type)
+        {
+        case TopicType::ATTACH:
+        case TopicType::DETACH:
+          self->lastBlockUpdate = Clock::now ();
+          break;
+        default:
+          break;
+        }
+
       const auto range = self->listeners.equal_range (gameId);
       if (range.first == self->listeners.end ())
         continue;
@@ -313,6 +322,7 @@ ZmqSubscriber::Start ()
 
   shouldStop = false;
   running = true;
+  lastBlockUpdate = Clock::now ();
   worker = std::make_unique<std::thread> (&ZmqSubscriber::Listen, this);
 }
 

--- a/xayagame/zmqsubscriber.hpp
+++ b/xayagame/zmqsubscriber.hpp
@@ -29,6 +29,8 @@ namespace internal
 
 /**
  * Interface that is used to receive updates from the ZmqSubscriber class.
+ * The processing callbacks are allowed to throw exceptions; in that case,
+ * the ZMQ subscriber assumes something is wrong and stops.
  */
 class ZmqListener
 {

--- a/xayagame/zmqsubscriber_tests.cpp
+++ b/xayagame/zmqsubscriber_tests.cpp
@@ -23,6 +23,7 @@ namespace
 {
 
 using testing::_;
+using testing::AnyNumber;
 using testing::InSequence;
 using testing::Throw;
 
@@ -535,6 +536,31 @@ TEST_F (ZmqSubscriberTests, ExceptionInHandler)
 
   while (mockListener.stopCalls < 1)
     SleepSome ();
+}
+
+TEST_F (ZmqSubscriberTests, StalenessTimer)
+{
+  Json::Value payload;
+  payload["test"] = 42;
+
+  EXPECT_CALL (mockListener, BlockAttach (GAME_ID, payload, _))
+      .Times (AnyNumber ());
+  EXPECT_CALL (mockListener, BlockDetach (GAME_ID, payload, _))
+      .Times (AnyNumber ());
+
+  SendAttach (GAME_ID, payload, 1);
+  SleepSome ();
+  EXPECT_LT (zmq.GetBlockStaleness<std::chrono::milliseconds> (),
+             std::chrono::milliseconds (100));
+
+  std::this_thread::sleep_for (std::chrono::milliseconds (200));
+  EXPECT_GT (zmq.GetBlockStaleness<std::chrono::milliseconds> (),
+             std::chrono::milliseconds (200));
+
+  SendDetach (GAME_ID, payload, 2);
+  SleepSome ();
+  EXPECT_LT (zmq.GetBlockStaleness<std::chrono::milliseconds> (),
+             std::chrono::milliseconds (100));
 }
 
 /* ************************************************************************** */

--- a/xayagame/zmqsubscriber_tests.cpp
+++ b/xayagame/zmqsubscriber_tests.cpp
@@ -24,6 +24,7 @@ namespace
 
 using testing::_;
 using testing::InSequence;
+using testing::Throw;
 
 constexpr const char IPC_ENDPOINT[] = "ipc:///tmp/xayagame_zmqsubscriber_tests";
 constexpr const char IPC_ENDPOINT_PENDING[]
@@ -520,6 +521,20 @@ TEST_F (ZmqSubscriberTests, InvalidJson)
       SendMultipart ({topic, "{} // Junk", "1234"});
       SleepSome ();
     }, "Error parsing");
+}
+
+TEST_F (ZmqSubscriberTests, ExceptionInHandler)
+{
+  Json::Value payload;
+  payload["test"] = 42;
+
+  EXPECT_CALL (mockListener, BlockAttach (GAME_ID, _, _))
+      .WillOnce (Throw (std::runtime_error ("test")));
+
+  SendAttach (GAME_ID, payload, 1);
+
+  while (mockListener.stopCalls < 1)
+    SleepSome ();
 }
 
 /* ************************************************************************** */


### PR DESCRIPTION
This set of changes tries to make the connection a GSP has to Xaya Core (or Xaya X) more robust.  If an exception is thrown while processing a block (for instance) - e.g. because Xaya Core's JSON-RPC interface has issues -, then the state is temporarily changed to `disconnected`.  The same happens if no ZMQ updates for blocks are received for a long time.  Later on, the GSP attempts to reconnect to Xaya Core and re-establish the ZMQ connection, so it can carry on when Xaya Core works again.

The new functionality comes with two command-line flags to toggle and configure it:
- `--xaya_zmq_staleness_ms` specifies the time (in milliseconds) between ZMQ block updates until the connection is considered stale.  The GSP tries to "force" a notification with `game_sendupdates` before that happens, so even if that is set to lower than the block frequency or a block takes some time, it should "work".
- `--xaya_connection_check_ms` can be set to some non-zero value, which enables a periodic background check probing the staleness and trying to reconnect.  By default this is off, but it can be set to some desired interval to turn on the new feature completely.