### PR TITLE
Explicitly truncate SQLite WAL file

### DIFF
--- a/nonfungible/gametest/Makefile.am
+++ b/nonfungible/gametest/Makefile.am
@@ -8,6 +8,7 @@ REGTESTS = \
   burn.py \
   minting.py \
   reorg.py \
+  sqlite_wal.py \
   transfers.py
 
 EXTRA_DIST = $(REGTESTS) $(TEST_LIBRARY)

--- a/nonfungible/gametest/sqlite_wal.py
+++ b/nonfungible/gametest/sqlite_wal.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2022 The Xaya developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+"""
+Tests the automatic WAL truncation for the SQLite database.
+"""
+
+from nftest import NonFungibleTest
+
+import threading
+import time
+
+# Regexp for the log when truncation happens.
+TRUNCATION_SUCCESS = "Checkpointed and truncated WAL file"
+
+
+class ReaderThread (threading.Thread):
+  """
+  A thread that spams read RPCs to the GSP under test.
+  """
+
+  def __init__ (self, test):
+    super ().__init__ ()
+
+    self.test = test
+    self.gsp = test.gamenode.createRpc ()
+
+    self.lock = threading.Lock ()
+    self.calls = 0
+    self.shouldStop = False
+    self.start ()
+
+  def stop (self):
+    with self.lock:
+      self.shouldStop = True
+    self.join ()
+
+  def run (self):
+    while True:
+      with self.lock:
+        if self.shouldStop:
+          break
+        self.calls += 1
+
+    self.test.assertEqual (
+      self.gsp.getassetdetails ({"m": "domob", "a": "foo"})["data"], {
+      "asset": {"m": "domob", "a": "foo"},
+      "supply": 10,
+      "data": None,
+      "balances": {"domob": 10},
+    })
+
+
+class SQLiteWalTest (NonFungibleTest):
+
+  def run (self):
+    self.collectPremine ()
+    self.sendMove ("domob", [{"m": {"a": "foo", "n": 10}}])
+    self.generate (1)
+
+    self.log.info ("Turning on periodic WAL truncation...")
+    self.stopGameDaemon ()
+    assert not self.gamenode.logMatches (TRUNCATION_SUCCESS)
+    self.startGameDaemon (extraArgs=["--xaya_sqlite_wal_truncate_ms=1"])
+
+    # We spam RPC requests (that create read snapshots and interfere with
+    # WAL truncation) to stress-test the system, and also mine some blocks
+    # which will trigger snapshots.
+    self.log.info ("Starting reader threads...")
+    readers = [ReaderThread (self) for _ in range (10)]
+
+    self.log.info ("Mining blocks...")
+    for _ in range (10):
+      time.sleep (0.01)
+      self.generate (1)
+
+    self.log.info ("Stopping reader threads...")
+    totalCalls = 0
+    for r in readers:
+      r.stop ()
+      totalCalls += r.calls
+    self.mainLogger.info ("Processed %d read calls" % totalCalls)
+
+    self.stopGameDaemon ()
+    assert self.gamenode.logMatches (TRUNCATION_SUCCESS)
+
+
+if __name__ == "__main__":
+  SQLiteWalTest ().main ()

--- a/xayagame/sqlitegame_tests.cpp
+++ b/xayagame/sqlitegame_tests.cpp
@@ -16,6 +16,7 @@
 
 #include <sqlite3.h>
 
+#include <gflags/gflags.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
@@ -28,6 +29,8 @@
 #include <string>
 #include <utility>
 #include <vector>
+
+DECLARE_int32 (xaya_sqlite_wal_truncate_ms);
 
 namespace xaya
 {
@@ -906,6 +909,11 @@ protected:
 
 TEST_F (UnblockedStateExtractionTests, UnblockedCallbackOnSnapshot)
 {
+  /* We need to disable WAL checkpointing for this test.  Otherwise the
+     AttachBlock might do a checkpoint, waiting for the snapshot, which
+     defeates the test's purpose.  */
+  FLAGS_xaya_sqlite_wal_truncate_ms = 0;
+
   std::atomic<bool> firstStarted;
   std::atomic<bool> firstDone;
   firstStarted = false;

--- a/xayagame/sqlitestorage_tests.cpp
+++ b/xayagame/sqlitestorage_tests.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2020 The Xaya developers
+// Copyright (C) 2018-2022 The Xaya developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -9,6 +9,7 @@
 
 #include "xayautil/hash.hpp"
 
+#include <gflags/gflags.h>
 #include <gtest/gtest.h>
 
 #include <atomic>
@@ -17,6 +18,8 @@
 #include <limits>
 #include <memory>
 #include <thread>
+
+DECLARE_int32 (xaya_sqlite_wal_truncate_ms);
 
 namespace xaya
 {
@@ -428,6 +431,12 @@ TEST_F (SQLiteStorageSnapshotTests, SnapshotsAreReadonly)
 
 TEST_F (SQLiteStorageSnapshotTests, MultipleSnapshots)
 {
+  /* For this test, we need to disable WAL checkpointing.  Unlike real
+     usage, this test has snapshots and transaction-commits (triggering
+     checkpoints) mixed up into a single thread, so it might deadlock if
+     the checkpointing attempted to wait for all outstanding snapshots.  */
+  FLAGS_xaya_sqlite_wal_truncate_ms = 0;
+
   Storage storage(filename);
   storage.Initialise ();
 


### PR DESCRIPTION
Especially when syncing or running a long time, the WAL file for an SQLite-based GSP might grow very large with database updates, even if in theory old state is already pruned (but still kept in the WAL).

This introduces a new optional flag, `--xaya_sqlite_wal_truncate_ms`, which can be used to force a full checkpointing and WAL-truncation in regular intervals.

Whenever a write is committed and the last checkpointing is longer ago than the chosen interval, the database will wait (still holding the `Game` lock) for any read snapshots to be finished and then request a full WAL checkpoint and truncating of the WAL file.