### PR TITLE
SQLite introspection utilities

### DIFF
--- a/xayagame/.gitignore
+++ b/xayagame/.gitignore
@@ -1,0 +1,1 @@
+dumpxayadb

--- a/xayagame/Makefile.am
+++ b/xayagame/Makefile.am
@@ -42,6 +42,7 @@ libxayagame_la_SOURCES = \
   rest.cpp \
   signatures.cpp \
   sqlitegame.cpp \
+  sqliteintro.cpp \
   sqlitestorage.cpp \
   storage.cpp \
   transactionmanager.cpp \
@@ -59,6 +60,7 @@ xayagame_HEADERS = \
   rest.hpp \
   signatures.hpp \
   sqlitegame.hpp \
+  sqliteintro.hpp \
   sqlitestorage.hpp \
   storage.hpp \
   transactionmanager.hpp \
@@ -103,6 +105,7 @@ tests_SOURCES = \
   rest_tests.cpp \
   signatures_tests.cpp \
   sqlitegame_tests.cpp \
+  sqliteintro_tests.cpp \
   sqlitestorage_tests.cpp \
   storage_tests.cpp \
   transactionmanager_tests.cpp \

--- a/xayagame/Makefile.am
+++ b/xayagame/Makefile.am
@@ -60,7 +60,7 @@ xayagame_HEADERS = \
   rest.hpp \
   signatures.hpp \
   sqlitegame.hpp \
-  sqliteintro.hpp \
+  sqliteintro.hpp sqliteintro.tpp \
   sqlitestorage.hpp \
   storage.hpp \
   transactionmanager.hpp \

--- a/xayagame/Makefile.am
+++ b/xayagame/Makefile.am
@@ -1,4 +1,5 @@
 lib_LTLIBRARIES = libxayagame.la
+bin_PROGRAMS = dumpxayadb
 xayagamedir = $(includedir)/xayagame
 rpcstubdir = $(xayagamedir)/rpc-stubs
 
@@ -66,6 +67,15 @@ xayagame_HEADERS = \
   transactionmanager.hpp \
   zmqsubscriber.hpp
 rpcstub_HEADERS = $(RPC_STUBS)
+
+dumpxayadb_CXXFLAGS = \
+  -I$(top_srcdir) \
+  $(GLOG_CFLAGS) $(SQLITE3_CFLAGS) $(GFLAGS_CFLAGS)
+dumpxayadb_LDADD = \
+  $(builddir)/libxayagame.la \
+  $(top_builddir)/xayautil/libxayautil.la \
+  $(GLOG_LIBS) $(SQLITE3_LIBS) $(GFLAGS_LIBS)
+dumpxayadb_SOURCES = main-dumpdb.cpp
 
 check_LTLIBRARIES = libtestutils.la
 check_PROGRAMS = tests

--- a/xayagame/main-dumpdb.cpp
+++ b/xayagame/main-dumpdb.cpp
@@ -1,0 +1,69 @@
+// Copyright (C) 2022 The Xaya developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "config.h"
+
+#include "xayagame/sqliteintro.hpp"
+#include "xayagame/sqlitestorage.hpp"
+
+#include <xayautil/hash.hpp>
+
+#include <gflags/gflags.h>
+#include <glog/logging.h>
+
+#include <cstdlib>
+#include <iostream>
+
+namespace
+{
+
+DEFINE_string (db, "",
+               "File of the SQLite database to open");
+DEFINE_string (table, "",
+               "If set, only the given table is dumped");
+DEFINE_bool (sha256, false, "If true, hash the output with SHA-256");
+
+/**
+ * Runs the main dumping on the given output stream.
+ */
+template <typename Out>
+  void
+  Run (Out& s, const xaya::SQLiteDatabase& db)
+{
+  if (FLAGS_table.empty ())
+    WriteAllTables (s, db);
+  else
+    WriteTableContent (s, db, FLAGS_table);
+}
+
+} // anonymous namespace
+
+int
+main (int argc, char** argv)
+{
+  google::InitGoogleLogging (argv[0]);
+
+  gflags::SetUsageMessage ("Dumps and hashes SQLite databases");
+  gflags::SetVersionString (PACKAGE_VERSION);
+  gflags::ParseCommandLineFlags (&argc, &argv, true);
+
+  if (FLAGS_db.empty ())
+    {
+      std::cerr << "Error: --db must be set" << std::endl;
+      return EXIT_FAILURE;
+    }
+
+  xaya::SQLiteDatabase db(FLAGS_db, SQLITE_OPEN_READONLY);
+
+  if (FLAGS_sha256)
+    {
+      xaya::SHA256 hasher;
+      Run (hasher, db);
+      std::cout << hasher.Finalise ().ToHex () << std::endl;
+    }
+  else
+    Run (std::cout, db);
+
+  return EXIT_SUCCESS;
+}

--- a/xayagame/sqliteintro.cpp
+++ b/xayagame/sqliteintro.cpp
@@ -1,0 +1,87 @@
+// Copyright (C) 2022 The Xaya developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "sqliteintro.hpp"
+
+#include <glog/logging.h>
+
+namespace xaya
+{
+
+namespace
+{
+
+/**
+ * Returns true if the given table name should be considered "internal".
+ */
+bool
+IsInternalTable (const std::string& nm)
+{
+  for (const std::string prefix : {"xayagame_", "sqlite_"})
+    if (nm.substr (0, prefix.size ()) == prefix)
+      return true;
+
+  return false;
+}
+
+} // anonymous namespace
+
+std::set<std::string>
+GetSqliteTables (const SQLiteDatabase& db, const bool internal)
+{
+  auto stmt = db.PrepareRo (R"(
+    SELECT `name`
+      FROM `sqlite_master`
+      WHERE `type` = 'table'
+  )");
+
+  std::set<std::string> res;
+  while (stmt.Step ())
+    {
+      const auto name = stmt.Get<std::string> (0);
+      if (internal || !IsInternalTable (name))
+        res.insert (name);
+    }
+
+  return res;
+}
+
+std::set<std::string>
+GetTableColumns (const SQLiteDatabase& db, const std::string& table)
+{
+  auto stmt = db.PrepareRo ("SELECT * FROM `" + table + "` LIMIT 0");
+  /* No need to step, we just want the metadata of the prepared statement,
+     which is already available.  */
+
+  std::set<std::string> res;
+  const int cnt = sqlite3_column_count (stmt.ro ());
+  for (int i = 0; i < cnt; ++i)
+    res.insert (sqlite3_column_name (stmt.ro (), i));
+
+  return res;
+}
+
+std::set<std::string>
+GetPrimaryKeyColumns (const SQLiteDatabase& db, const std::string& table,
+                      const std::set<std::string>& columns)
+{
+  std::set<std::string> res;
+  db.ReadDatabase ([&] (sqlite3* rawDb)
+    {
+      for (const auto& c : columns)
+        {
+          int isPk;
+          CHECK_EQ (sqlite3_table_column_metadata (
+                        rawDb, nullptr, table.c_str (), c.c_str (),
+                        nullptr, nullptr, nullptr, &isPk, nullptr),
+                    SQLITE_OK);
+          if (isPk)
+            res.insert (c);
+        }
+    });
+
+  return res;
+}
+
+} // namespace xaya

--- a/xayagame/sqliteintro.hpp
+++ b/xayagame/sqliteintro.hpp
@@ -34,6 +34,27 @@ std::set<std::string> GetPrimaryKeyColumns (
     const SQLiteDatabase& db, const std::string& table,
     const std::set<std::string>& columns);
 
+/**
+ * Writes a deterministic "description" of the content of the given
+ * table onto the output stream.  This will contain the table's schema
+ * (from sqlite_master) as well as all content sorted by primary key.
+ *
+ * The stream must support writing of strings, but nothing else is required.
+ */
+template <typename Out>
+  Out& WriteTableContent (Out& s, const SQLiteDatabase& db,
+                          const std::string& table);
+
+/**
+ * Writes a deterministic representation of all tables in the given
+ * database (with the same behaviour as GetSqliteTables including "internal")
+ * to the output stream.
+ */
+template <typename Out>
+  Out& WriteAllTables (Out& s, const SQLiteDatabase& db, bool internal = false);
+
 } // namespace xaya
+
+#include "sqliteintro.tpp"
 
 #endif // XAYAGAME_SQLITEINTRO_HPP

--- a/xayagame/sqliteintro.hpp
+++ b/xayagame/sqliteintro.hpp
@@ -1,0 +1,39 @@
+// Copyright (C) 2022 The Xaya developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef XAYAGAME_SQLITEINTRO_HPP
+#define XAYAGAME_SQLITEINTRO_HPP
+
+#include "sqlitestorage.hpp"
+
+#include <set>
+#include <string>
+
+namespace xaya
+{
+
+/**
+ * Returns a list of all tables in the given SQLite database.  If internal
+ * is false, then xayagame_* and sqlite_* tables are filtered out.
+ */
+std::set<std::string> GetSqliteTables (const SQLiteDatabase& db,
+                                       bool internal = false);
+
+/**
+ * Lists all column names of the given table in the SQLite database.
+ */
+std::set<std::string> GetTableColumns (const SQLiteDatabase& db,
+                                       const std::string& table);
+
+/**
+ * Given the list of columns in a table, returns the subset of columns
+ * that make up the primary key.
+ */
+std::set<std::string> GetPrimaryKeyColumns (
+    const SQLiteDatabase& db, const std::string& table,
+    const std::set<std::string>& columns);
+
+} // namespace xaya
+
+#endif // XAYAGAME_SQLITEINTRO_HPP

--- a/xayagame/sqliteintro.tpp
+++ b/xayagame/sqliteintro.tpp
@@ -1,0 +1,84 @@
+// Copyright (C) 2022 The Xaya developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+/* Template implementation code for sqliteintro.hpp.  */
+
+#include <glog/logging.h>
+
+#include <cstdio>
+
+namespace xaya
+{
+
+namespace internal
+{
+
+/**
+ * Queries for all content of the given database table, sorted by primary key,
+ * and returns the resulting Statement that can be stepped.
+ */
+SQLiteDatabase::Statement QueryAllRows (const SQLiteDatabase& db,
+                                        const std::string& table);
+
+/**
+ * Produces a deterministic representation of the current row's data
+ * for the given database statement.  The result is appended onto
+ * the given string.
+ */
+void TableRowContent (std::string& out, const SQLiteDatabase::Statement& stmt);
+
+} // namespace internal
+
+template <typename Out>
+  Out&
+  WriteTableContent (Out& s, const SQLiteDatabase& db,
+                     const std::string& table)
+{
+  auto stmt = db.PrepareRo (R"(
+    SELECT `sql`
+      FROM `sqlite_master`
+      WHERE `name` = ?1 AND `type` = 'table'
+  )");
+  stmt.Bind (1, table);
+
+  CHECK (stmt.Step ()) << "No table '" << table << "' exists";
+  s << stmt.Get<std::string> (0) << "\n";
+  CHECK (!stmt.Step ());
+
+  char numBuf[64];
+  std::string row;
+
+  stmt = internal::QueryAllRows (db, table);
+  for (unsigned cnt = 0; stmt.Step (); ++cnt)
+    {
+      std::snprintf (numBuf, sizeof (numBuf), "%d", cnt);
+      s << "\nRow " << numBuf << ":\n";
+
+      internal::TableRowContent (row, stmt);
+      s << row;
+      row.clear ();
+    }
+
+  return s;
+}
+
+template <typename Out>
+  Out&
+  WriteAllTables (Out& s, const SQLiteDatabase& db, const bool internal)
+{
+  const auto tables = GetSqliteTables (db, internal);
+
+  bool first = true;
+  for (const auto& t : tables)
+    {
+      if (!first)
+        s << "\n";
+      first = false;
+      WriteTableContent (s, db, t);
+    }
+
+  return s;
+}
+
+} // namespace xaya

--- a/xayagame/sqliteintro_tests.cpp
+++ b/xayagame/sqliteintro_tests.cpp
@@ -4,10 +4,12 @@
 
 #include "sqliteintro.hpp"
 
-#include "sqlitestorage.hpp"
+#include <xayautil/hash.hpp>
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
+
+#include <sstream>
 
 namespace xaya
 {
@@ -17,13 +19,15 @@ namespace
 using testing::ElementsAre;
 
 constexpr const char* TABLE_AUTOINC = R"(
-  `int` INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
-  `text` TEXT NULL
+  `key` INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+  `text` TEXT NULL,
+  `int` INTEGER NULL
 )";
 
 constexpr const char* TABLE_PK = R"(
   `foo` INTEGER NOT NULL,
   `bar` INTEGER NOT NULL,
+  -- Some comment that will be kept in SQL schema.
   `blob` BLOB NULL,
   PRIMARY KEY (`foo`, `bar`)
 )";
@@ -47,11 +51,16 @@ protected:
     db.Execute (std::string ("CREATE TABLE `pk` (") + TABLE_PK + ")");
     db.Execute (std::string ("CREATE TABLE `empty` (") + TABLE_EMPTY + ")");
     db.Execute (R"(
-      INSERT INTO `autoinc` (`text`) VALUES ('foo'), (NULL), ('bar');
+      INSERT INTO `autoinc`
+        (`text`, `int`) VALUES
+        ('foo', 10), (NULL, NULL), ('bar', 42);
       INSERT INTO `pk`
         (`foo`, `bar`, `blob`) VALUES
         (1, 1, 'abc'),
-        (2, 2, 'xyz'),
+        -- Some type conversion checks here.  The '123' will be seen as text
+        -- still (since the column is declared as such), while the '2' will
+        -- be seen as integer 2.
+        (2, '2', '123'),
         (1, 2, NULL),
         (2, 1, '');
 
@@ -83,7 +92,8 @@ TEST_F (SQLiteIntroTests, GetSqliteTables)
 
 TEST_F (SQLiteIntroTests, GetTableColumns)
 {
-  EXPECT_THAT (GetTableColumns (db, "autoinc"), ElementsAre ("int", "text"));
+  EXPECT_THAT (GetTableColumns (db, "autoinc"),
+               ElementsAre ("int", "key", "text"));
   EXPECT_THAT (GetTableColumns (db, "pk"), ElementsAre ("bar", "blob", "foo"));
   EXPECT_THAT (GetTableColumns (db, "empty"), ElementsAre ("id"));
 }
@@ -98,7 +108,7 @@ TEST_F (SQLiteIntroTests, GetPrimaryKeyColumns)
 
   columns = GetTableColumns (db, "autoinc");
   EXPECT_THAT (GetPrimaryKeyColumns (db, "autoinc", columns),
-               ElementsAre ("int"));
+               ElementsAre ("key"));
 
   columns = GetTableColumns (db, "pk");
   EXPECT_THAT (GetPrimaryKeyColumns (db, "pk", columns),
@@ -111,6 +121,107 @@ TEST_F (SQLiteIntroTests, GetPrimaryKeyColumns)
   columns = GetTableColumns (db, "no_pk");
   EXPECT_THAT (GetPrimaryKeyColumns (db, "no_pk", columns),
                ElementsAre ());
+}
+
+class SQLiteWriteAllTablesTests : public SQLiteIntroTests
+{
+
+protected:
+
+  /**
+   * Hashes all DB content with SHA256.
+   */
+  uint256
+  HashDb ()
+  {
+    SHA256 hasher;
+    WriteAllTables (hasher, db);
+    return hasher.Finalise ();
+  }
+
+};
+
+TEST_F (SQLiteWriteAllTablesTests, GoldenData)
+{
+  std::ostringstream out;
+  WriteAllTables (out, db);
+
+  std::ostringstream expected;
+
+  expected << "CREATE TABLE `autoinc` (" << TABLE_AUTOINC << ")\n";
+  expected << "\nRow 0:\n"
+           << "  key: INTEGER 1\n"
+           << "  text: DATA-SHA256 " << SHA256::Hash ("foo").ToHex () << "\n"
+           << "  int: INTEGER 10\n";
+  expected << "\nRow 1:\n"
+           << "  key: INTEGER 2\n"
+           << "  text: NULL\n"
+           << "  int: NULL\n";
+  expected << "\nRow 2:\n"
+           << "  key: INTEGER 3\n"
+           << "  text: DATA-SHA256 " << SHA256::Hash ("bar").ToHex () << "\n"
+           << "  int: INTEGER 42\n";
+
+  expected << "\nCREATE TABLE `empty` (" << TABLE_EMPTY << ")\n";
+
+  expected << "\nCREATE TABLE `pk` (" << TABLE_PK << ")\n";
+  expected << "\nRow 0:\n"
+           << "  foo: INTEGER 0\n"
+           << "  bar: INTEGER 0\n"
+           << "  blob: DATA-SHA256 "
+           << SHA256::Hash (std::string ("x\0y", 3)).ToHex () << "\n";
+  expected << "\nRow 1:\n"
+           << "  foo: INTEGER 1\n"
+           << "  bar: INTEGER 1\n"
+           << "  blob: DATA-SHA256 " << SHA256::Hash ("abc").ToHex () << "\n";
+  expected << "\nRow 2:\n"
+           << "  foo: INTEGER 2\n"
+           << "  bar: INTEGER 1\n"
+           << "  blob: DATA-SHA256 " << SHA256::Hash ("").ToHex () << "\n";
+  expected << "\nRow 3:\n"
+           << "  foo: INTEGER 1\n"
+           << "  bar: INTEGER 2\n"
+           << "  blob: NULL\n";
+  expected << "\nRow 4:\n"
+           << "  foo: INTEGER 2\n"
+           << "  bar: INTEGER 2\n"
+           << "  blob: DATA-SHA256 " << SHA256::Hash ("123").ToHex () << "\n";
+
+  EXPECT_EQ (out.str (), expected.str ());
+}
+
+TEST_F (SQLiteWriteAllTablesTests, ExplicitOrdering)
+{
+  const auto hash1 = HashDb ();
+  db.Execute ("PRAGMA `reverse_unordered_selects` = 1");
+  const auto hash2 = HashDb ();
+  db.Execute ("PRAGMA `reverse_unordered_selects` = 0");
+  const auto hash3 = HashDb ();
+
+  EXPECT_EQ (hash2, hash1);
+  EXPECT_EQ (hash3, hash1);
+}
+
+TEST_F (SQLiteWriteAllTablesTests, DetectsChange)
+{
+  const auto hash1 = HashDb ();
+
+  db.Execute (R"(
+    UPDATE `autoinc`
+      SET `int` = 'x'
+      WHERE `int` = 42
+  )");
+  const auto hash2 = HashDb ();
+
+  db.Execute (R"(
+    UPDATE `autoinc`
+      SET `int` = 42
+      WHERE `int` = 'x'
+  )");
+  const auto hash3 = HashDb ();
+
+  EXPECT_NE (hash2, hash1);
+  EXPECT_EQ (hash3, hash1);
 }
 
 } // anonymous namespace

--- a/xayagame/sqliteintro_tests.cpp
+++ b/xayagame/sqliteintro_tests.cpp
@@ -1,0 +1,117 @@
+// Copyright (C) 2022 The Xaya developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "sqliteintro.hpp"
+
+#include "sqlitestorage.hpp"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+namespace xaya
+{
+namespace
+{
+
+using testing::ElementsAre;
+
+constexpr const char* TABLE_AUTOINC = R"(
+  `int` INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+  `text` TEXT NULL
+)";
+
+constexpr const char* TABLE_PK = R"(
+  `foo` INTEGER NOT NULL,
+  `bar` INTEGER NOT NULL,
+  `blob` BLOB NULL,
+  PRIMARY KEY (`foo`, `bar`)
+)";
+
+constexpr const char* TABLE_EMPTY = R"(
+  `id` INTEGER NOT NULL,
+  PRIMARY KEY (`id`)
+)";
+
+class SQLiteIntroTests : public testing::Test
+{
+
+protected:
+
+  SQLiteDatabase db;
+
+  SQLiteIntroTests ()
+    : db("foo", SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_MEMORY)
+  {
+    db.Execute (std::string ("CREATE TABLE `autoinc` (") + TABLE_AUTOINC + ")");
+    db.Execute (std::string ("CREATE TABLE `pk` (") + TABLE_PK + ")");
+    db.Execute (std::string ("CREATE TABLE `empty` (") + TABLE_EMPTY + ")");
+    db.Execute (R"(
+      INSERT INTO `autoinc` (`text`) VALUES ('foo'), (NULL), ('bar');
+      INSERT INTO `pk`
+        (`foo`, `bar`, `blob`) VALUES
+        (1, 1, 'abc'),
+        (2, 2, 'xyz'),
+        (1, 2, NULL),
+        (2, 1, '');
+
+      -- Just some random index to make sure it is not seen as table.
+      CREATE INDEX `pk_foo` ON `pk` (`blob`, `foo`);
+    )");
+
+    /* Insert a real "blob" with nul character.  */
+    auto stmt = db.Prepare (R"(
+      INSERT INTO `pk` (`foo`, `bar`, `blob`) VALUES (0, 0, ?1)
+    )");
+    stmt.Bind (1, std::string ("x\0y", 3));
+    stmt.Execute ();
+  }
+
+};
+
+TEST_F (SQLiteIntroTests, GetSqliteTables)
+{
+  db.Execute (R"(
+    CREATE TABLE `xayagame_dummy` (`foo` INTEGER NOT NULL PRIMARY KEY);
+  )");
+
+  EXPECT_THAT (GetSqliteTables (db), ElementsAre ("autoinc", "empty", "pk"));
+  EXPECT_THAT (GetSqliteTables (db, true),
+               ElementsAre ("autoinc", "empty", "pk",
+                            "sqlite_sequence", "xayagame_dummy"));
+}
+
+TEST_F (SQLiteIntroTests, GetTableColumns)
+{
+  EXPECT_THAT (GetTableColumns (db, "autoinc"), ElementsAre ("int", "text"));
+  EXPECT_THAT (GetTableColumns (db, "pk"), ElementsAre ("bar", "blob", "foo"));
+  EXPECT_THAT (GetTableColumns (db, "empty"), ElementsAre ("id"));
+}
+
+TEST_F (SQLiteIntroTests, GetPrimaryKeyColumns)
+{
+  db.Execute (R"(
+    CREATE TABLE `no_pk` (`something` TEXT NULL);
+  )");
+
+  std::set<std::string> columns;
+
+  columns = GetTableColumns (db, "autoinc");
+  EXPECT_THAT (GetPrimaryKeyColumns (db, "autoinc", columns),
+               ElementsAre ("int"));
+
+  columns = GetTableColumns (db, "pk");
+  EXPECT_THAT (GetPrimaryKeyColumns (db, "pk", columns),
+               ElementsAre ("bar", "foo"));
+
+  columns = GetTableColumns (db, "empty");
+  EXPECT_THAT (GetPrimaryKeyColumns (db, "empty", columns),
+               ElementsAre ("id"));
+
+  columns = GetTableColumns (db, "no_pk");
+  EXPECT_THAT (GetPrimaryKeyColumns (db, "no_pk", columns),
+               ElementsAre ());
+}
+
+} // anonymous namespace
+} // namespace xaya


### PR DESCRIPTION
This adds a new file `sqliteintro` to the core xayagame library.  The file contains basic introspection utilities for SQLite, and in particular also has the ability to deterministically dump (or hash) the content of a database.  With this, GSPs can implement their own functionality to hash the game state, which can be useful in detecting and debugging forks.

In the future, there may be more libxayagame-level utilities around it, e.g. for automatically saving hashes every X blocks.