### PR TITLE
Framework for game-state processors and state hashing

### DIFF
--- a/nonfungible/gametest/Makefile.am
+++ b/nonfungible/gametest/Makefile.am
@@ -9,6 +9,7 @@ REGTESTS = \
   minting.py \
   reorg.py \
   sqlite_wal.py \
+  statehash.py \
   transfers.py
 
 EXTRA_DIST = $(REGTESTS) $(TEST_LIBRARY)

--- a/nonfungible/gametest/burn.py
+++ b/nonfungible/gametest/burn.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (C) 2020 The Xaya developers
+# Copyright (C) 2020-2023 The Xaya developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -14,8 +14,6 @@ from nftest import NonFungibleTest
 class BurnTest (NonFungibleTest):
 
   def run (self):
-    self.collectPremine ()
-
     self.sendMove ("domob", [
       {"m": {"a": "foo", "n": 10}},
       {"b": {"a": {"m": "domob", "a": "foo"}, "n": 11}},

--- a/nonfungible/gametest/minting.py
+++ b/nonfungible/gametest/minting.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # coding=utf8
 
-# Copyright (C) 2020 The Xaya developers
+# Copyright (C) 2020-2023 The Xaya developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -15,7 +15,6 @@ from nftest import NonFungibleTest
 class MintingTest (NonFungibleTest):
 
   def run (self):
-    self.collectPremine ()
     self.assertEqual (self.getRpc ("listassets"), [])
 
     self.sendMove ("domob", [

--- a/nonfungible/gametest/nftest.py
+++ b/nonfungible/gametest/nftest.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 The Xaya developers
+# Copyright (C) 2020-2023 The Xaya developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -19,6 +19,16 @@ class NonFungibleTest (XayaGameTest):
       top_builddir = "../.."
     nfd = os.path.join (top_builddir, "nonfungible", "nonfungibled")
     super ().__init__ ("nf", nfd)
+
+  def setup (self):
+    super ().setup ()
+
+    self.collectPremine ()
+    sendTo = {}
+    for _ in range (10):
+      sendTo[self.rpc.xaya.getnewaddress ()] = 10
+    self.rpc.xaya.sendmany ("", sendTo)
+    self.generate (1)
 
   def getRpc (self, method, *args, **kwargs):
     """

--- a/nonfungible/gametest/reorg.py
+++ b/nonfungible/gametest/reorg.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (C) 2020 The Xaya developers
+# Copyright (C) 2020-2023 The Xaya developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -14,13 +14,6 @@ from nftest import NonFungibleTest
 class ReorgTest (NonFungibleTest):
 
   def run (self):
-    self.collectPremine ()
-    sendTo = {}
-    for _ in range (10):
-      sendTo[self.rpc.xaya.getnewaddress ()] = 10
-    self.rpc.xaya.sendmany ("", sendTo)
-    self.generate (1)
-
     self.sendMove ("domob", [
       {"m": {"a": "foo", "n": 10}},
     ])

--- a/nonfungible/gametest/sqlite_wal.py
+++ b/nonfungible/gametest/sqlite_wal.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (C) 2022 The Xaya developers
+# Copyright (C) 2022-2023 The Xaya developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -57,7 +57,6 @@ class ReaderThread (threading.Thread):
 class SQLiteWalTest (NonFungibleTest):
 
   def run (self):
-    self.collectPremine ()
     self.sendMove ("domob", [{"m": {"a": "foo", "n": 10}}])
     self.generate (1)
 

--- a/nonfungible/gametest/statehash.py
+++ b/nonfungible/gametest/statehash.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2023 The Xaya developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+"""
+Tests game-state hashing in the GSP.
+"""
+
+from nftest import NonFungibleTest
+
+
+class StatehashTest (NonFungibleTest):
+
+  def hashState (self):
+    return self.getRpc ("hashcurrentstate")
+
+  def run (self):
+    # Mint some assets and get to an even block height (so we know for sure
+    # which blocks will be hashed and which not) before the reorg point.
+    self.sendMove ("domob", [
+      {"m": {"a": "foo", "n": 10}},
+    ])
+    self.generate (10)
+    if self.env.getChainTip ()[1] % 2 == 1:
+      self.generate (1)
+    hash0 = self.hashState ()
+    baseBlk, _ = self.env.getChainTip ()
+    self.assertEqual (
+        hash0,
+        "62b033bfc82496a027dde72de4d81e0341de012eaa921194656c119ac88f6761")
+    self.generate (1)
+    reorgBlk, height = self.env.getChainTip ()
+    assert height % 2 == 1
+
+    # This is the chain structure we will build:
+    # baseBlk
+    #   |-- reorgBlk -- blk0p -- x -- blk1
+    #   \--- oddBlk --- blk2
+
+    # Without automatic hashing turned on, build up a chain and manually
+    # hash the state at some points.
+    self.assertEqual (self.hashState (), hash0)
+    blkOdd, _ = self.env.getChainTip ()
+    self.generate (1)
+    self.assertEqual (self.hashState (), hash0)
+    blk0p, _ = self.env.getChainTip ()
+    self.sendMove ("domob", [
+      {"t": {"a": {"m": "domob", "a": "foo"}, "n": 7, "r": "andy"}},
+    ])
+    self.generate (2)
+    self.expectGameState ([
+      {
+        "asset": {"m": "domob", "a": "foo"},
+        "supply": 10,
+        "data": None,
+        "balances": {"domob": 3, "andy": 7},
+      },
+    ])
+    hash1 = self.hashState ()
+    blk1, _ = self.env.getChainTip ()
+    assert hash1 != hash0
+
+    # Hashing is not turned on yet, so getstatehash should fail.
+    self.expectError (-32601, ".*state hashing is not enabled.*",
+                      self.getRpc, "getstatehash", reorgBlk)
+
+    # Turn on hashing of every second block.
+    self.log.info ("Turning on hashing...")
+    self.stopGameDaemon ()
+    self.startGameDaemon (extraArgs=["--statehash_interval=2"])
+
+    # The blocks are still not hashed for now.
+    self.assertEqual (self.getRpc ("getstatehash", baseBlk), None)
+    self.assertEqual (self.getRpc ("getstatehash", blk0p), None)
+    self.assertEqual (self.getRpc ("getstatehash", blk1), None)
+
+    # Reorg and build up the second (shorter chain).  Hashing
+    # is now turned on, so along the way all even blocks will be
+    # hashed (including on the detach).
+    self.rpc.xaya.invalidateblock (reorgBlk)
+    self.sendMove ("domob", [
+      {"t": {"a": {"m": "domob", "a": "foo"}, "n": 7, "r": "daniel"}},
+    ])
+    self.generate (1)
+    self.expectGameState ([
+      {
+        "asset": {"m": "domob", "a": "foo"},
+        "supply": 10,
+        "data": None,
+        "balances": {"domob": 3, "daniel": 7},
+      },
+    ])
+    oddBlk, _ = self.env.getChainTip ()
+    self.generate (1)
+    hash2 = self.hashState ()
+    blk2, _ = self.env.getChainTip ()
+    assert hash2 not in [hash0, hash1]
+
+    # Check the stored hashes.
+    self.assertEqual (self.getRpc ("getstatehash", baseBlk), hash0)
+    self.assertEqual (self.getRpc ("getstatehash", blk0p), hash0)
+    # blk1 is still not hashed for now, since we only turned on hashing
+    # when it was already active, and it has not "become" the tip state
+    # since yet.
+    self.assertEqual (self.getRpc ("getstatehash", blk1), None)
+    self.assertEqual (self.getRpc ("getstatehash", oddBlk), None)
+    self.assertEqual (self.getRpc ("getstatehash", blk2), hash2)
+
+    # Reorg back to the original chain.
+    self.rpc.xaya.reconsiderblock (reorgBlk)
+    self.syncGame ()
+    self.assertEqual (self.env.getChainTip ()[0], blk1)
+
+    # Check stored hashes again.  Now all should be there.
+    self.assertEqual (self.getRpc ("getstatehash", baseBlk), hash0)
+    self.assertEqual (self.getRpc ("getstatehash", blk0p), hash0)
+    self.assertEqual (self.getRpc ("getstatehash", blk1), hash1)
+    self.assertEqual (self.getRpc ("getstatehash", blk2), hash2)
+
+
+if __name__ == "__main__":
+  StatehashTest ().main ()

--- a/nonfungible/gametest/transfers.py
+++ b/nonfungible/gametest/transfers.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (C) 2020 The Xaya developers
+# Copyright (C) 2020-2023 The Xaya developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -14,8 +14,6 @@ from nftest import NonFungibleTest
 class TransfersTest (NonFungibleTest):
 
   def run (self):
-    self.collectPremine ()
-
     self.sendMove ("domob", [
       {"m": {"a": "foo", "n": 10}},
       {"m": {"a": "bar", "n": 10}},

--- a/nonfungible/logic.hpp
+++ b/nonfungible/logic.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 The Xaya developers
+// Copyright (C) 2020-2022 The Xaya developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -57,6 +57,10 @@ public:
    * StateJsonExtractor instance.
    */
   Json::Value GetCustomStateData (xaya::Game& game, const StateCallback& cb);
+
+  /* Expose the super-class variant as well, which is used for
+     state hashing.  */
+  using SQLiteGame::GetCustomStateData;
 
 };
 

--- a/nonfungible/rpc-stubs/nf.json
+++ b/nonfungible/rpc-stubs/nf.json
@@ -3,6 +3,7 @@
     "name": "stop",
     "params": {}
   },
+
   {
     "name": "getcurrentstate",
     "params": {},
@@ -18,6 +19,18 @@
     "params": {},
     "returns": {}
   },
+
+  {
+    "name": "hashcurrentstate",
+    "params": [],
+    "returns": {}
+  },
+  {
+    "name": "getstatehash",
+    "params": ["blockhash"],
+    "returns": {}
+  },
+
   {
     "name": "waitforchange",
     "params": ["known block"],

--- a/nonfungible/rpcserver.hpp
+++ b/nonfungible/rpcserver.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 The Xaya developers
+// Copyright (C) 2020-2022 The Xaya developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -9,6 +9,7 @@
 #include "rpc-stubs/nfrpcserverstub.h"
 
 #include "xayagame/game.hpp"
+#include "xayagame/sqliteproc.hpp"
 
 #include <json/json.h>
 #include <jsonrpccpp/server.h>
@@ -32,11 +33,14 @@ private:
   /** The NF logic instance for the SQLite database.  */
   NonFungibleLogic& logic;
 
+  /** The state hasher, if any.  */
+  xaya::SQLiteHasher* hasher;
+
 public:
 
-  explicit RpcServer (xaya::Game& g, NonFungibleLogic& l,
+  explicit RpcServer (xaya::Game& g, NonFungibleLogic& l, xaya::SQLiteHasher* h,
                       jsonrpc::AbstractServerConnector& conn)
-    : NFRpcServerStub(conn), game(g), logic(l)
+    : NFRpcServerStub(conn), game(g), logic(l), hasher(h)
   {}
 
   void stop () override;
@@ -44,6 +48,10 @@ public:
   Json::Value getcurrentstate () override;
   Json::Value getnullstate () override;
   Json::Value getpendingstate () override;
+
+  Json::Value hashcurrentstate () override;
+  Json::Value getstatehash (const std::string& block) override;
+
   std::string waitforchange (const std::string& knownBlock) override;
   Json::Value waitforpendingchange (int knownVersion) override;
 

--- a/xayagame/Makefile.am
+++ b/xayagame/Makefile.am
@@ -44,6 +44,7 @@ libxayagame_la_SOURCES = \
   signatures.cpp \
   sqlitegame.cpp \
   sqliteintro.cpp \
+  sqliteproc.cpp \
   sqlitestorage.cpp \
   storage.cpp \
   transactionmanager.cpp \
@@ -62,6 +63,7 @@ xayagame_HEADERS = \
   signatures.hpp \
   sqlitegame.hpp \
   sqliteintro.hpp sqliteintro.tpp \
+  sqliteproc.hpp \
   sqlitestorage.hpp \
   storage.hpp \
   transactionmanager.hpp \
@@ -116,6 +118,7 @@ tests_SOURCES = \
   signatures_tests.cpp \
   sqlitegame_tests.cpp \
   sqliteintro_tests.cpp \
+  sqliteproc_tests.cpp \
   sqlitestorage_tests.cpp \
   storage_tests.cpp \
   transactionmanager_tests.cpp \

--- a/xayagame/gamelogic.hpp
+++ b/xayagame/gamelogic.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2021 The Xaya developers
+// Copyright (C) 2018-2022 The Xaya developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -288,6 +288,16 @@ public:
   GameStateData ProcessBackwards (const GameStateData& newState,
                                   const Json::Value& blockData,
                                   const UndoData& undoData);
+
+  /**
+   * A notification method that gets called whenever the Game instance
+   * updated the game state, when the new state has been committed to storage.
+   * The blockData will contain the main block information to which the
+   * new state corresponds, like "height" and "hash".
+   */
+  virtual void
+  GameStateUpdated (const GameStateData& state, const Json::Value& blockData)
+  {}
 
   /**
    * Converts an encoded game state to JSON format, which can be returned as

--- a/xayagame/sqlitegame.hpp
+++ b/xayagame/sqlitegame.hpp
@@ -8,6 +8,7 @@
 #include "game.hpp"
 #include "gamelogic.hpp"
 #include "pendingmoves.hpp"
+#include "sqliteproc.hpp"
 #include "sqlitestorage.hpp"
 
 #include <json/json.h>
@@ -15,6 +16,7 @@
 #include <cstdint>
 #include <functional>
 #include <memory>
+#include <set>
 #include <string>
 
 namespace xaya
@@ -75,6 +77,12 @@ private:
    * to UpdateState).  It is set to null when no set is active.
    */
   ActiveAutoIds* activeIds = nullptr;
+
+  /**
+   * Any processors attached, that will be called for state updates.  They
+   * are not owned by this instance.
+   */
+  std::set<SQLiteProcessor*> processors;
 
   /**
    * If set to true, then we enable 'PRAGMA reverse_unordered_selects' in the
@@ -245,6 +253,11 @@ public:
   StorageInterface& GetStorage ();
 
   /**
+   * Attaches a processor.
+   */
+  void AddProcessor (SQLiteProcessor& proc);
+
+  /**
    * Sets a flag (off by default) that determines whether to set
    * 'PRAGMA reverse_unordered_selects' in SQLite (and potentially
    * other related features).  Changing this flag "should" not affect
@@ -255,6 +268,8 @@ public:
    */
   void SetMessForDebug (bool val);
 
+  void GameStateUpdated (const GameStateData& state,
+                         const Json::Value& blockData) override;
   Json::Value GameStateToJson (const GameStateData& state) override;
 
 };

--- a/xayagame/sqliteintro.hpp
+++ b/xayagame/sqliteintro.hpp
@@ -46,6 +46,13 @@ template <typename Out>
                           const std::string& table);
 
 /**
+ * Writes a deterministic representation of the given tables to the stream.
+ */
+template <typename Out>
+  Out& WriteTables (Out& s, const SQLiteDatabase& db,
+                    const std::set<std::string>& tables);
+
+/**
  * Writes a deterministic representation of all tables in the given
  * database (with the same behaviour as GetSqliteTables including "internal")
  * to the output stream.

--- a/xayagame/sqliteintro.tpp
+++ b/xayagame/sqliteintro.tpp
@@ -65,10 +65,9 @@ template <typename Out>
 
 template <typename Out>
   Out&
-  WriteAllTables (Out& s, const SQLiteDatabase& db, const bool internal)
+  WriteTables (Out& s, const SQLiteDatabase& db,
+               const std::set<std::string>& tables)
 {
-  const auto tables = GetSqliteTables (db, internal);
-
   bool first = true;
   for (const auto& t : tables)
     {
@@ -79,6 +78,13 @@ template <typename Out>
     }
 
   return s;
+}
+
+template <typename Out>
+  Out&
+  WriteAllTables (Out& s, const SQLiteDatabase& db, const bool internal)
+{
+  return WriteTables (s, db, GetSqliteTables (db, internal));
 }
 
 } // namespace xaya

--- a/xayagame/sqliteproc.cpp
+++ b/xayagame/sqliteproc.cpp
@@ -1,0 +1,141 @@
+// Copyright (C) 2022 The Xaya developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "sqliteproc.hpp"
+
+#include "sqliteintro.hpp"
+
+#include <xayautil/hash.hpp>
+
+#include <glog/logging.h>
+
+namespace xaya
+{
+
+/* ************************************************************************** */
+
+bool
+SQLiteProcessor::ShouldRun (const Json::Value& blockData) const
+{
+  if (blockInterval == 0)
+    return false;
+
+  CHECK (blockData.isObject ());
+  const auto& heightVal = blockData["height"];
+  CHECK (heightVal.isUInt64 ());
+  const uint64_t height = heightVal.asUInt64 ();
+
+  return (height % blockInterval) == blockModulo;
+}
+
+void
+SQLiteProcessor::SetupSchema (SQLiteDatabase& db)
+{}
+
+void
+SQLiteProcessor::Finish ()
+{
+  /* Nothing needs to be done for now while processing runs synchronously.  */
+}
+
+void
+SQLiteProcessor::Process (const Json::Value& blockData, SQLiteDatabase& db)
+{
+  if (!ShouldRun (blockData))
+    return;
+
+  /* TODO:  Actually make Compute() run on a snapshot asynchronously,
+     rather than blocking the entire GSP process for a long-running computation
+     (like hashing of a large game state).
+
+     For now we just run it synchronously here for simplicity.  */
+
+  Compute (blockData, db);
+
+  db.Prepare ("SAVEPOINT `xayagame-processor`").Execute ();
+  Store (db);
+  db.Prepare ("RELEASE `xayagame-processor`").Execute ();
+}
+
+void
+SQLiteProcessor::SetInterval (const uint64_t intv, const uint64_t modulo)
+{
+  blockInterval = intv;
+  blockModulo = modulo;
+}
+
+/* ************************************************************************** */
+
+void
+SQLiteHasher::SetupSchema (SQLiteDatabase& db)
+{
+  SQLiteProcessor::SetupSchema (db);
+  db.Execute (R"(
+    CREATE TABLE IF NOT EXISTS `xayagame_statehashes`
+        (`block` BLOB PRIMARY KEY,
+         `hash` BLOB NOT NULL);
+  )");
+} 
+
+std::set<std::string>
+SQLiteHasher::GetTables (const SQLiteDatabase& db)
+{
+  return GetSqliteTables (db);
+}
+
+void
+SQLiteHasher::Compute (const Json::Value& blockData, const SQLiteDatabase& db)
+{
+  const auto hashVal = blockData["hash"];
+  CHECK (hashVal.isString ());
+  CHECK (block.FromHex (hashVal.asString ()));
+
+  VLOG (1) << "Computing game-state hash for block " << block.ToHex ();
+  SHA256 hasher;
+  WriteTables (hasher, db, GetTables (db));
+  hash = hasher.Finalise ();
+}
+
+void
+SQLiteHasher::Store (SQLiteDatabase& db)
+{
+  /* First check that if a hash exists already, it matches what we computed.
+     Otherwise there is some kind of serious bug.  */
+  uint256 existing;
+  if (GetHash (db, block, existing))
+    CHECK (existing == hash)
+        << "Already stored game-state differs from computed for block "
+        << block.ToHex ();
+
+  auto stmt = db.Prepare (R"(
+    INSERT OR IGNORE INTO `xayagame_statehashes`
+      (`block`, `hash`) VALUES (?1, ?2)
+  )");
+  stmt.Bind (1, block);
+  stmt.Bind (2, hash);
+  stmt.Execute ();
+}
+
+bool
+SQLiteHasher::GetHash (const SQLiteDatabase& db, const uint256& block,
+                       uint256& hash) const
+{
+  auto stmt = db.PrepareRo (R"(
+    SELECT `hash`
+      FROM `xayagame_statehashes`
+      WHERE `block` = ?1
+  )");
+  stmt.Bind (1, block);
+
+  if (!stmt.Step ())
+    return false;
+
+  hash = stmt.Get<uint256> (0);
+  CHECK (!stmt.Step ());
+  return true;
+}
+
+/* ************************************************************************** */
+
+} // namespace xaya

--- a/xayagame/sqliteproc.hpp
+++ b/xayagame/sqliteproc.hpp
@@ -1,0 +1,159 @@
+// Copyright (C) 2022 The Xaya developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef XAYAGAME_SQLITEPROC_HPP
+#define XAYAGAME_SQLITEPROC_HPP
+
+#include "sqlitestorage.hpp"
+
+#include <json/json.h>
+
+#include <set>
+#include <string>
+
+namespace xaya
+{
+
+/**
+ * A processor is a component that computes some stuff and updates to the
+ * game SQLite database after the main game-state updates have been done.
+ * This could just be hashing the game state for debugging purposes, or it
+ * could be computing some caches useful to the frontend.
+ *
+ * The processing is done in two steps:  First, a read-only snapshot at a
+ * well-defined block / game state is given, on which the computations can be
+ * performed, and they can take relatively long on a separate processing
+ * thread (without holding up the main GSP's block processing).  Second, once
+ * the computation is done, the main database is acquired and the result can
+ * be written back.  Ideally the processor should use its own database
+ * table (that can be set up specifically with SetupSchema) for that.
+ *
+ * Results of the computation can be accumulated and stored in the processor
+ * instance.  The two methods (Compute and Store) will always be called
+ * alternatingly, i.e. when Compute is called, it can store the results
+ * into member variables, and no second call to Compute will be done until
+ * Store has been called (that can access those member variables).
+ *
+ * Note that processors should be treated as "optional" and "best effort".
+ * Their results must not influence the actual consensus game state.
+ */
+class SQLiteProcessor
+{
+
+private:
+
+  /**
+   * If the default rule of "every X blocks" is used to determine when
+   * processing is done, this is set to the block interval (X).  If zero,
+   * then it has not yet been enabled / set up.
+   */
+  uint64_t blockInterval = 0;
+  /**
+   * If blockInterval is used, then this is the modulo at which it runs
+   * (i.e. at all blocks N where (N % X) == M).
+   */
+  uint64_t blockModulo;
+
+protected:
+
+  /**
+   * Checks whether or not the processor should run at the given block.
+   * By default, it uses a fixed block interval and modulo to determine
+   * this, but subclasses may overwrite the check.
+   */
+  virtual bool ShouldRun (const Json::Value& blockData) const;
+
+  /**
+   * Runs the internal computation on a read-only database snapshot for
+   * the given block data.  Results should be stored somewhere in the instance,
+   * and can be written back to the database later in Store.
+   */
+  virtual void Compute (const Json::Value& blockData,
+                        const SQLiteDatabase& db) = 0;
+
+  /**
+   * After Compute() finishes, this method is called with a writable database
+   * so that the internally-stored result can be saved.  The call is wrapped
+   * with an SQLite SAVEPOINT for atomicity.
+   */
+  virtual void Store (SQLiteDatabase& db) = 0;
+
+public:
+
+  SQLiteProcessor () = default;
+  virtual ~SQLiteProcessor () = default;
+
+  /**
+   * This is called when setting up the processor and database, and gives
+   * it the chance to set up any specific database tables or schema it needs
+   * for writing the results.
+   */
+  virtual void SetupSchema (SQLiteDatabase& db);
+
+  /**
+   * Waits for all potentially still running operations to finish.  This is
+   * invoked before the attached database is closed.  Note that the object
+   * stays valid, so a new call to Process can be made afterwards as desired
+   * (if the database is opened again), and then Finish called again.
+   */
+  void Finish ();
+
+  /**
+   * Checks if the processor should be executed for the given block,
+   * and if so, triggers it by calling the subclass-specific Compute and
+   * Store methods accordingly.
+   */
+  void Process (const Json::Value& blockData, SQLiteDatabase& db);
+
+  /**
+   * Enables the processor to run every X blocks (with modulo value M).
+   */
+  void SetInterval (uint64_t intv, uint64_t modulo = 0);
+
+};
+
+/**
+ * A processor that hases the database (excluding internal tables)
+ * with SHA256 and records (block hash, game-state hash) into a new table.
+ */
+class SQLiteHasher : public SQLiteProcessor
+{
+
+private:
+
+  /** The block hash being processed currently.  */
+  uint256 block;
+  /** The computed game-state hash of the currently processed block.  */
+  uint256 hash;
+
+protected:
+
+  void Compute (const Json::Value& blockData,
+                const SQLiteDatabase& db) override;
+  void Store (SQLiteDatabase& db) override;
+
+  /**
+   * Computes the list of tables to hash.  By default, it is what
+   * GetSqliteTables returns as non-internal tables.  Subclasses may override
+   * it to use a different list.
+   */
+  virtual std::set<std::string> GetTables (const SQLiteDatabase& db);
+
+public:
+
+  void SetupSchema (SQLiteDatabase& db) override;
+
+  /**
+   * Retrieves the game-state hash stored in the database for the given
+   * block hash, if any.  Returns true if a hash was found, and false
+   * if none is stored.
+   */
+  bool GetHash (const SQLiteDatabase& db, const uint256& block,
+                uint256& hash) const;
+
+};
+
+} // namespace xaya
+
+#endif // XAYAGAME_SQLITEPROC_HPP

--- a/xayagame/sqliteproc_tests.cpp
+++ b/xayagame/sqliteproc_tests.cpp
@@ -1,0 +1,246 @@
+// Copyright (C) 2022 The Xaya developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "sqliteproc.hpp"
+
+#include "sqliteintro.hpp"
+
+#include <xayautil/hash.hpp>
+
+#include <glog/logging.h>
+#include <gtest/gtest.h>
+
+#include <map>
+#include <sstream>
+
+namespace xaya
+{
+namespace
+{
+
+/* ************************************************************************** */
+
+/**
+ * Expects that the values recorded in a key/value table match the given set.
+ * The block hashes are constructed by hashing the key strings.
+ */
+template <typename T>
+  void
+  ExpectRecords (const SQLiteDatabase& db,
+                 const std::string& table, const std::string& valueCol,
+                 const std::map<std::string, T>& expected)
+  {
+    std::map<uint256, T> expectedHashed;
+    for (const auto& entry : expected)
+      expectedHashed.emplace (SHA256::Hash (entry.first), entry.second);
+
+    std::ostringstream sql;
+    sql << "SELECT `block`, `" << valueCol << "` FROM `" << table << "`";
+
+    std::map<uint256, T> actual;
+    auto stmt = db.PrepareRo (sql.str ());
+    while (stmt.Step ())
+      actual.emplace (stmt.Get<uint256> (0), stmt.Get<T> (1));
+
+    EXPECT_EQ (actual, expectedHashed);
+  }
+
+/**
+ * A simple processor class, which just records the value from the test database
+ * "onerow" table with block hashes (without hashing the state otherwise,
+ * so it can be easily compared to known expected values).
+ */
+class TestProcessor : public SQLiteProcessor
+{
+
+private:
+
+  uint256 block;
+  std::string value;
+
+protected:
+
+  void
+  Compute (const Json::Value& blockData, const SQLiteDatabase& db) override
+  {
+    CHECK (block.FromHex (blockData["hash"].asString ()));
+    auto stmt = db.PrepareRo (R"(
+      SELECT `text` FROM `onerow`
+    )");
+    CHECK (stmt.Step ());
+    value = stmt.Get<std::string> (0);
+    CHECK (!stmt.Step ());
+  }
+
+  void
+  Store (SQLiteDatabase& db) override
+  {
+    auto stmt = db.Prepare (R"(
+      INSERT OR IGNORE INTO `xayagame_procvalues`
+        (`block`, `value`) VALUES (?1, ?2)
+    )");
+    stmt.Bind (1, block);
+    stmt.Bind (2, value);
+    stmt.Execute ();
+  }
+
+public:
+
+  void
+  SetupSchema (SQLiteDatabase& db) override
+  {
+    SQLiteProcessor::SetupSchema (db);
+    db.Execute (R"(
+      CREATE TABLE IF NOT EXISTS `xayagame_procvalues`
+          (`block` BLOB PRIMARY KEY,
+           `value` TEXT NOT NULL);
+    )");
+  }
+
+};
+
+class SQLiteProcTests : public testing::Test
+{
+
+protected:
+
+  SQLiteDatabase db;
+  TestProcessor proc;
+
+  SQLiteProcTests ()
+    : db("foo", SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_MEMORY)
+  {
+    /* We use a single table with a single row and just some value
+       as the underlying "game state" database, so that it is easy to
+       create / modify / restore for testing.  */
+    db.Execute (R"(
+      CREATE TABLE `onerow` (`text` TEXT PRIMARY KEY);
+      INSERT INTO `onerow` (`text`) VALUES ('initial');
+    )");
+    proc.SetupSchema (db);
+  }
+
+  /**
+   * Sets the value in the database.
+   */
+  void
+  SetValue (const std::string& val)
+  {
+    auto stmt = db.Prepare (R"(
+      UPDATE `onerow` SET `text` = ?1
+    )");
+    stmt.Bind (1, val);
+    stmt.Execute ();
+  }
+
+  /**
+   * Expects that the processor has recorded the given values.
+   */
+  void
+  ExpectValues (const std::map<std::string, std::string>& expected)
+  {
+    proc.Finish ();
+    ExpectRecords (db, "xayagame_procvalues", "value", expected);
+  }
+
+  /**
+   * Builds fake JSON block data for the given block height.  The block
+   * hash will be the SHA256 of the block string.
+   */
+  static Json::Value
+  BlockData (const unsigned height, const std::string& blk)
+  {
+    Json::Value blockData(Json::objectValue);
+    blockData["height"] = static_cast<Json::Int64> (height);
+    blockData["hash"] = SHA256::Hash (blk).ToHex ();
+    return blockData;
+  }
+
+};
+
+TEST_F (SQLiteProcTests, RunsAtDefinedInterval)
+{
+  proc.SetInterval (3, 1);
+
+  proc.Process (BlockData (0, "zero"), db);
+  proc.Process (BlockData (1, "one"), db);
+  proc.Process (BlockData (2, "two"), db);
+  SetValue ("changed");
+  proc.Process (BlockData (3, "three"), db);
+  proc.Process (BlockData (4, "four"), db);
+
+  ExpectValues ({{"one", "initial"}, {"four", "changed"}});
+}
+
+/* ************************************************************************** */
+
+class SQLiteHasherTests : public SQLiteProcTests
+{
+
+protected:
+
+  SQLiteHasher hasher;
+
+  SQLiteHasherTests ()
+  {
+    hasher.SetupSchema (db);
+
+    /* We run at every block for simplicity.  The interval filtering
+       is tested already at the general level.  */
+    hasher.SetInterval (1);
+  }
+
+  void
+  ExpectHashes (const std::map<std::string, uint256>& expected)
+  {
+    ExpectRecords (db, "xayagame_statehashes", "hash", expected);
+  }
+
+};
+
+TEST_F (SQLiteHasherTests, Works)
+{
+  SetValue ("foo");
+  SHA256 hasher1;
+  WriteAllTables (hasher1, db);
+  const uint256 hash1 = hasher1.Finalise ();
+
+  hasher.Process (BlockData (0, "zero"), db);
+  hasher.Process (BlockData (1, "one"), db);
+
+  SetValue ("bar");
+  SHA256 hasher2;
+  WriteAllTables (hasher2, db);
+  const uint256 hash2 = hasher2.Finalise ();
+
+  hasher.Process (BlockData (2, "two"), db);
+
+  ExpectHashes ({{"zero", hash1}, {"one", hash1}, {"two", hash2}});
+
+  uint256 value;
+  ASSERT_TRUE (hasher.GetHash (db, SHA256::Hash ("zero"), value));
+  EXPECT_EQ (value, hash1);
+  ASSERT_TRUE (hasher.GetHash (db, SHA256::Hash ("two"), value));
+  EXPECT_EQ (value, hash2);
+  ASSERT_FALSE (hasher.GetHash (db, SHA256::Hash ("foo"), value));
+}
+
+TEST_F (SQLiteHasherTests, SameBlock)
+{
+  SetValue ("foo");
+  hasher.Process (BlockData (0, "zero"), db);
+
+  SetValue ("bar");
+  EXPECT_DEATH (hasher.Process (BlockData (0, "zero"), db),
+                "differs from computed");
+  hasher.Process (BlockData (0, "other zero"), db);
+
+  SetValue ("foo");
+  hasher.Process (BlockData (0, "zero"), db);
+}
+
+/* ************************************************************************** */
+
+} // anonymous namespace
+} // namespace xaya

--- a/xayagame/sqlitestorage.hpp
+++ b/xayagame/sqlitestorage.hpp
@@ -375,11 +375,6 @@ private:
   void OpenDatabase ();
 
   /**
-   * Closes the database, making sure to wait for all outstanding snapshots.
-   */
-  void CloseDatabase ();
-
-  /**
    * Blocks until no read snapshots are open.
    */
   void WaitForSnapshots ();
@@ -397,6 +392,12 @@ private:
   friend class SQLiteDatabase;
 
 protected:
+
+  /**
+   * Closes the database, making sure to wait for all outstanding snapshots.
+   * The method is overridden (extended) in the SQLiteGame::Storage subclass.
+   */
+  virtual void CloseDatabase ();
 
   /**
    * Sets up the database schema if it does not already exist.  This function is


### PR DESCRIPTION
This introduces a framework for "game-state processors":  They can be added to the `Game` and will then be notified about state updates.  For SQLite specifically, they can be used to compute specific "extra data" (that is not directly consensus relevant), e.g. some caches for frontends.

In particular, with this we also implement a feature for hashing the SQLite game database every X blocks, which can be useful to detect and debug forks.