### PR TITLE
Introduce "target block" feature for syncing a Game

### DIFF
--- a/nonfungible/gametest/Makefile.am
+++ b/nonfungible/gametest/Makefile.am
@@ -10,6 +10,7 @@ REGTESTS = \
   reorg.py \
   sqlite_wal.py \
   statehash.py \
+  targetblock.py \
   transfers.py
 
 EXTRA_DIST = $(REGTESTS) $(TEST_LIBRARY)

--- a/nonfungible/gametest/targetblock.py
+++ b/nonfungible/gametest/targetblock.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2023 The Xaya developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+"""
+Tests the "target block" feature in the GSP.  This is the main integration
+test for the feature in libxayagame itself as well.
+"""
+
+from nftest import NonFungibleTest
+
+import time
+
+
+class TargetBlockTest (NonFungibleTest):
+
+  def getStateAtTarget (self, blk):
+    """
+    Wait for the GSP to be in at-target state and then return
+    the associated game state.
+    """
+
+    while True:
+      state = self.rpc.game.getcurrentstate ()
+      if state["state"] == "at-target":
+        self.assertEqual (state["blockhash"], blk)
+        return state["gamestate"]
+      time.sleep (0.1)
+
+  def run (self):
+    # Stop the game daemon, so we can generate an existing chain against
+    # which we then test the target-block syncing.
+    self.mainLogger.info ("Pre-generating blockchain without GSP attached...")
+    self.stopGameDaemon ()
+
+    self.sendMove ("domob", [
+      {"m": {"a": "foo", "n": 10}},
+    ])
+    self.generate (10)
+    blk1, _ = self.env.getChainTip ()
+
+    self.sendMove ("domob", [
+      {"t": {"a": {"m": "domob", "a": "foo"}, "n": 1, "r": "andy"}},
+    ])
+    self.generate (2)
+    blk2, _ = self.env.getChainTip ()
+
+    self.sendMove ("domob", [
+      {"t": {"a": {"m": "domob", "a": "foo"}, "n": 2, "r": "andy"}},
+    ])
+    self.generate (1)
+
+    # Start with an explicit target hash right away.
+    self.mainLogger.info ("Starting GSP with target hash...")
+    self.startGameDaemon (extraArgs=["--target_block=%s" % blk1])
+    self.assertEqual (self.getStateAtTarget (blk1), [
+      {
+        "asset": {"m": "domob", "a": "foo"},
+        "supply": 10,
+        "data": None,
+        "balances": {"domob": 10},
+      },
+    ])
+
+    # Test setting the target block by RPC.
+    self.mainLogger.info ("Testing target block by RPC...")
+    self.rpc.game._notify.settargetblock (blk2)
+    time.sleep (0.1)
+    self.assertEqual (self.getStateAtTarget (blk2), [
+      {
+        "asset": {"m": "domob", "a": "foo"},
+        "supply": 10,
+        "data": None,
+        "balances": {"domob": 9, "andy": 1},
+      },
+    ])
+    self.rpc.game._notify.settargetblock ("")
+    self.expectGameState ([
+      {
+        "asset": {"m": "domob", "a": "foo"},
+        "supply": 10,
+        "data": None,
+        "balances": {"domob": 7, "andy": 3},
+      },
+    ])
+    self.sendMove ("domob", [
+      {"t": {"a": {"m": "domob", "a": "foo"}, "n": 3, "r": "andy"}},
+    ])
+    self.generate (1)
+    self.expectGameState ([
+      {
+        "asset": {"m": "domob", "a": "foo"},
+        "supply": 10,
+        "data": None,
+        "balances": {"domob": 4, "andy": 6},
+      },
+    ])
+
+    # Test a target state in the past.
+    # FIXME:  For now, the GSP does not explicitly trigger ZMQ notifications
+    # to the target state.  So this only works if we trigger detaches
+    # externally.
+    self.rpc.game._notify.settargetblock (blk2)
+    self.rpc.xaya.invalidateblock (blk1)
+    self.assertEqual (self.getStateAtTarget (blk2), [
+      {
+        "asset": {"m": "domob", "a": "foo"},
+        "supply": 10,
+        "data": None,
+        "balances": {"domob": 9, "andy": 1},
+      },
+    ])
+
+
+if __name__ == "__main__":
+  TargetBlockTest ().main ()

--- a/nonfungible/main.cpp
+++ b/nonfungible/main.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2022 The Xaya developers
+// Copyright (C) 2020-2023 The Xaya developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -40,6 +40,8 @@ DEFINE_int32 (enable_pruning, -1,
 DEFINE_int32 (statehash_interval, 0,
               "if set to a positive number N, hash the game state"
               " every N blocks");
+DEFINE_string (target_block, "",
+               "if set to a block hash, sync to this block and then stop");
 
 DEFINE_string (datadir, "",
                "base data directory for state data"
@@ -84,6 +86,22 @@ public:
     res.reset (new xaya::WrappedRpcServer<nf::RpcServer> (
         game, logic, h, conn));
     return res;
+  }
+
+  std::vector<std::unique_ptr<xaya::GameComponent>>
+  BuildGameComponents (xaya::Game& g)
+  {
+    /* We don't actually use any custom game components, but we can use this
+       method to set up the target block on Game.  */
+    if (!FLAGS_target_block.empty ())
+      {
+        xaya::uint256 hash;
+        CHECK (hash.FromHex (FLAGS_target_block))
+            << "Invalid block hash set as target: " << FLAGS_target_block;
+        g.SetTargetBlock (hash);
+      }
+
+    return xaya::CustomisedInstanceFactory::BuildGameComponents (g);
   }
 
 };

--- a/nonfungible/rpc-stubs/nf.json
+++ b/nonfungible/rpc-stubs/nf.json
@@ -32,6 +32,10 @@
   },
 
   {
+    "name": "settargetblock",
+    "params": ["block"]
+  },
+  {
     "name": "waitforchange",
     "params": ["known block"],
     "returns": ""

--- a/nonfungible/rpcserver.cpp
+++ b/nonfungible/rpcserver.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2022 The Xaya developers
+// Copyright (C) 2020-2023 The Xaya developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -105,6 +105,21 @@ RpcServer::getstatehash (const std::string& block)
             return Json::Value ();
           return value.ToHex ();
         });
+}
+
+void
+RpcServer::settargetblock (const std::string& block)
+{
+  LOG (INFO) << "RPC method called: settargetblock " << block;
+
+  xaya::uint256 hash;
+  if (block.empty ())
+    hash.SetNull ();
+  else if (!hash.FromHex (block))
+    throw jsonrpc::JsonRpcException (
+        jsonrpc::Errors::ERROR_RPC_INVALID_PARAMS, "invalid block hash");
+
+  game.SetTargetBlock (hash);
 }
 
 std::string

--- a/nonfungible/rpcserver.hpp
+++ b/nonfungible/rpcserver.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2022 The Xaya developers
+// Copyright (C) 2020-2023 The Xaya developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -51,6 +51,8 @@ public:
 
   Json::Value hashcurrentstate () override;
   Json::Value getstatehash (const std::string& block) override;
+
+  void settargetblock (const std::string& block) override;
 
   std::string waitforchange (const std::string& knownBlock) override;
   Json::Value waitforpendingchange (int knownVersion) override;

--- a/xayagame/game.cpp
+++ b/xayagame/game.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2022 The Xaya developers
+// Copyright (C) 2018-2023 The Xaya developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -338,7 +338,7 @@ Game::BlockAttach (const std::string& id, const Json::Value& data,
           /* If we are now at the last catching-up's target block hash,
              reinitialise the state as well.  This will check the current best
              tip and set the state to UP_TO_DATE or request more updates.  */
-          if (hash == targetBlockHash)
+          if (hash == catchingUpTarget)
             needReinit = true;
 
           break;
@@ -430,7 +430,7 @@ Game::BlockDetach (const std::string& id, const Json::Value& data,
              at the same time (*or if this was the very first detach
              notification*!), then the client is catching-up while only
              detaching.  */
-          if (parent == targetBlockHash)
+          if (parent == catchingUpTarget)
             needReinit = true;
 
           break;
@@ -1006,7 +1006,7 @@ Game::SyncFromCurrentState (const Json::Value& blockchainInfo,
   state = State::CATCHING_UP;
   transactionManager.SetBatchSize (transactionBatchSize);
 
-  CHECK (targetBlockHash.FromHex (upd["toblock"].asString ()));
+  CHECK (catchingUpTarget.FromHex (upd["toblock"].asString ()));
   reqToken = upd["reqtoken"].asString ();
 }
 

--- a/xayagame/game.hpp
+++ b/xayagame/game.hpp
@@ -72,6 +72,9 @@ private:
    * updates to be sent.  Those are processed based on a particular reqtoken
    * for now to bring us up-to-date.
    *
+   * AT_TARGET:  We are synced to an explicitly specified target block,
+   * and will remain there until it gets changed.
+   *
    * UP_TO_DATE:  As far as is known, we are at the current tip of the daemon.
    * Ordinary ZMQ notifications are processed as they come in for changes
    * to the tip, and we expect them to match the current block hash.
@@ -87,6 +90,7 @@ private:
     PREGENESIS,
     OUT_OF_SYNC,
     CATCHING_UP,
+    AT_TARGET,
     UP_TO_DATE,
     DISCONNECTED,
   };
@@ -117,6 +121,14 @@ private:
 
   /** The chain type to which the game is connected.  */
   Chain chain = Chain::UNKNOWN;
+
+  /**
+   * If this is set to non-null, then it is a block hash that we try to
+   * sync to (exactly).  If we reach it, then the sync will stop, and
+   * the state be frozen as AT_TARGET (at least until the target
+   * is changed again).
+   */
+  uint256 targetBlock;
 
   /**
    * The game's current state.  For any changes and most access in general,
@@ -393,6 +405,12 @@ public:
    * Must be called after the storage is set already.
    */
   void EnablePruning (unsigned nBlocks);
+
+  /**
+   * Sets an explicit block hash to sync to (and then stop as AT_TARGET),
+   * or disables one (i.e. sync to tip) if the value is null.
+   */
+  void SetTargetBlock (const uint256& blk);
 
   /**
    * Detects the ZMQ endpoint(s) by calling getzmqnotifications on the Xaya

--- a/xayagame/game.hpp
+++ b/xayagame/game.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2022 The Xaya developers
+// Copyright (C) 2018-2023 The Xaya developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -148,7 +148,7 @@ private:
    * This is compared against the CHILD hashes of block-attach notifications
    * to know when we've finished catching up to the current target.
    */
-  uint256 targetBlockHash;
+  uint256 catchingUpTarget;
 
   /**
    * The reqtoken value for the currently processed game_sendupdates request


### PR DESCRIPTION
This introduces a new "target block" feature into `Game`'s syncing logic.  If the target block is set, then the `Game` will try to sync to *exactly* that block, stopping when it reaches it (in a new `AT_TARGET` state).  The target can be set dynamically and the `Game` will then try to sync to the new one, or it can be unset and the `Game` will sync to tip.