### PR TITLE
Run SQLiteProcessor's asynchronously

### DIFF
--- a/xayagame/defaultmain.cpp
+++ b/xayagame/defaultmain.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2021 The Xaya developers
+// Copyright (C) 2018-2023 The Xaya developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -329,6 +329,11 @@ SQLiteMain (const GameDaemonConfiguration& config, const std::string& gameId,
          may still cause some batched transactions to be flushed, and this
          needs the storage intact.  */
       game.reset ();
+
+      /* Also explicitly close the database here to make this explicit and
+         make sure all is run properly.  This also ensures for instance
+         that all still running processors are waited for.  */
+      rules.GetStorage ().CloseDatabase ();
     }
   catch (const std::exception& exc)
     {

--- a/xayagame/game.cpp
+++ b/xayagame/game.cpp
@@ -44,7 +44,7 @@ namespace
 {
 
 /** Clock used for timing the callbacks.  */
-using PerformanceTimer = std::chrono::high_resolution_clock;
+using PerformanceTimer = std::chrono::steady_clock;
 
 /** Duration type used for reporting callback timings.  */
 using CallbackDuration = std::chrono::microseconds;

--- a/xayagame/sqlitegame.cpp
+++ b/xayagame/sqlitegame.cpp
@@ -367,7 +367,7 @@ SQLiteGame::SetupSchema (SQLiteDatabase& db)
      is done in Storage::SetupSchema already before calling here.  */
 }
 
-StorageInterface&
+SQLiteStorage&
 SQLiteGame::GetStorage ()
 {
   CHECK (database != nullptr) << "SQLiteGame has not been initialised";

--- a/xayagame/sqlitegame.hpp
+++ b/xayagame/sqlitegame.hpp
@@ -250,7 +250,7 @@ public:
    * Returns the storage implementation used internally, which should be set
    * as main storage in Game.
    */
-  StorageInterface& GetStorage ();
+  SQLiteStorage& GetStorage ();
 
   /**
    * Attaches a processor.

--- a/xayagame/sqliteproc.cpp
+++ b/xayagame/sqliteproc.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 The Xaya developers
+// Copyright (C) 2022-2023 The Xaya developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -34,13 +34,15 @@ SQLiteProcessor::SetupSchema (SQLiteDatabase& db)
 {}
 
 void
-SQLiteProcessor::Finish ()
+SQLiteProcessor::Finish (SQLiteDatabase& db)
 {
   /* Nothing needs to be done for now while processing runs synchronously.  */
 }
 
 void
-SQLiteProcessor::Process (const Json::Value& blockData, SQLiteDatabase& db)
+SQLiteProcessor::Process (const Json::Value& blockData,
+                          SQLiteDatabase& db,
+                          std::shared_ptr<SQLiteDatabase> snapshot)
 {
   if (!ShouldRun (blockData))
     return;

--- a/xayagame/sqliteproc.hpp
+++ b/xayagame/sqliteproc.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 The Xaya developers
+// Copyright (C) 2022-2023 The Xaya developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -9,6 +9,7 @@
 
 #include <json/json.h>
 
+#include <memory>
 #include <set>
 #include <string>
 
@@ -97,14 +98,24 @@ public:
    * stays valid, so a new call to Process can be made afterwards as desired
    * (if the database is opened again), and then Finish called again.
    */
-  void Finish ();
+  void Finish (SQLiteDatabase& db);
 
   /**
    * Checks if the processor should be executed for the given block,
    * and if so, triggers it by calling the subclass-specific Compute and
    * Store methods accordingly.
+   *
+   * baseDb is always a reference to the "real" database instance, owned
+   * by the calling SQLiteGame.  If it was possible to get a read-only snapshot
+   * that can be used for async processing, then snapshot will be non-null,
+   * and the underlying logic may run async using this snapshot.
+   *
+   * The snapshot may be shared between multiple processors running in
+   * parallel.
    */
-  void Process (const Json::Value& blockData, SQLiteDatabase& db);
+  void Process (const Json::Value& blockData,
+                SQLiteDatabase& db,
+                std::shared_ptr<SQLiteDatabase> snapshot);
 
   /**
    * Enables the processor to run every X blocks (with modulo value M).

--- a/xayagame/sqliteproc.hpp
+++ b/xayagame/sqliteproc.hpp
@@ -46,6 +46,9 @@ class SQLiteProcessor
 
 private:
 
+  /** The name of the processor, used in logs.  */
+  const std::string name;
+
   /**
    * If the default rule of "every X blocks" is used to determine when
    * processing is done, this is set to the block interval (X).  If zero,
@@ -74,6 +77,12 @@ private:
    */
   void StoreResult (SQLiteDatabase& db);
 
+  /**
+   * Runs Compute internally, but with a timer running for logging
+   * the result.
+   */
+  void TimedCompute (const Json::Value& blockData, const SQLiteDatabase& db);
+
 protected:
 
   /**
@@ -100,7 +109,10 @@ protected:
 
 public:
 
-  SQLiteProcessor () = default;
+  SQLiteProcessor (const std::string& nm)
+    : name(nm)
+  {}
+
   virtual ~SQLiteProcessor ();
 
   /**
@@ -170,6 +182,10 @@ protected:
   virtual std::set<std::string> GetTables (const SQLiteDatabase& db);
 
 public:
+
+  SQLiteHasher ()
+    : SQLiteProcessor ("game-state hash")
+  {}
 
   void SetupSchema (SQLiteDatabase& db) override;
 

--- a/xayagame/sqliteproc.hpp
+++ b/xayagame/sqliteproc.hpp
@@ -9,9 +9,11 @@
 
 #include <json/json.h>
 
+#include <atomic>
 #include <memory>
 #include <set>
 #include <string>
+#include <thread>
 
 namespace xaya
 {
@@ -56,6 +58,22 @@ private:
    */
   uint64_t blockModulo;
 
+  /**
+   * Set to true while the processing is still running.  When the thread
+   * finishes (even if it is not yet joined), this flag will be turned
+   * to false.
+   */
+  std::atomic<bool> processing;
+
+  /** The active processing thread, if any.  */
+  std::unique_ptr<std::thread> runner;
+
+  /**
+   * Helper function to store the current result, with a savepoint
+   * wrapped around the operation to make it atomic in the DB.
+   */
+  void StoreResult (SQLiteDatabase& db);
+
 protected:
 
   /**
@@ -83,7 +101,7 @@ protected:
 public:
 
   SQLiteProcessor () = default;
-  virtual ~SQLiteProcessor () = default;
+  virtual ~SQLiteProcessor ();
 
   /**
    * This is called when setting up the processor and database, and gives

--- a/xayagame/sqliteproc_tests.cpp
+++ b/xayagame/sqliteproc_tests.cpp
@@ -5,14 +5,17 @@
 #include "sqliteproc.hpp"
 
 #include "sqliteintro.hpp"
+#include "testutils.hpp"
 
 #include <xayautil/hash.hpp>
 
 #include <glog/logging.h>
 #include <gtest/gtest.h>
 
+#include <chrono>
 #include <map>
 #include <sstream>
+#include <thread>
 
 namespace xaya
 {
@@ -59,11 +62,15 @@ private:
   uint256 block;
   std::string value;
 
+  /** Sleep this long in Compute() before running the actual logic.  */
+  std::chrono::milliseconds delay{0};
+
 protected:
 
   void
   Compute (const Json::Value& blockData, const SQLiteDatabase& db) override
   {
+    std::this_thread::sleep_for (delay);
     CHECK (block.FromHex (blockData["hash"].asString ()));
     auto stmt = db.PrepareRo (R"(
       SELECT `text` FROM `onerow`
@@ -98,19 +105,56 @@ public:
     )");
   }
 
+  /**
+   * Configures the processor to delay Compute() by a given duration
+   * before actually processing the query.
+   */
+  void
+  SetDelay (const std::chrono::milliseconds d)
+  {
+    delay = d;
+  }
+
+};
+
+/**
+ * Helper SQLiteStorage, which exposes the raw database used.
+ */
+class TestSQLiteStorage : public SQLiteStorage
+{
+
+public:
+
+  TestSQLiteStorage (const std::string& file)
+    : SQLiteStorage(file)
+  {
+    Initialise ();
+  }
+
+  using SQLiteStorage::GetDatabase;
+  using SQLiteStorage::GetSnapshot;
+
 };
 
 class SQLiteProcTests : public testing::Test
 {
 
+private:
+
+  TempFileName file;
+  TestSQLiteStorage storage;
+
 protected:
 
-  SQLiteDatabase db;
+  SQLiteDatabase& db;
   TestProcessor proc;
 
   SQLiteProcTests ()
-    : db("foo", SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_MEMORY)
+    : storage(file.GetName ()),
+      db(storage.GetDatabase ())
   {
+    LOG (INFO) << "Using temporary file as database: " << file.GetName ();
+
     /* We use a single table with a single row and just some value
        as the underlying "game state" database, so that it is easy to
        create / modify / restore for testing.  */
@@ -140,8 +184,24 @@ protected:
   void
   ExpectValues (const std::map<std::string, std::string>& expected)
   {
-    proc.Finish (db);
     ExpectRecords (db, "xayagame_procvalues", "value", expected);
+  }
+
+  /**
+   * Runs the processor with the given block data on the test database.
+   * Optionally a snapshot can be passed (for testing async processing).
+   */
+  void
+  Process (const Json::Value& blockData, const bool useSnapshot)
+  {
+    std::shared_ptr<SQLiteDatabase> snapshot;
+    if (useSnapshot)
+      {
+        auto uniqueSnapshot = storage.GetSnapshot ();
+        CHECK (uniqueSnapshot != nullptr);
+        snapshot.reset (uniqueSnapshot.release ());
+      }
+    proc.Process (blockData, db, snapshot);
   }
 
   /**
@@ -163,14 +223,50 @@ TEST_F (SQLiteProcTests, RunsAtDefinedInterval)
 {
   proc.SetInterval (3, 1);
 
-  proc.Process (BlockData (0, "zero"), db, nullptr);
-  proc.Process (BlockData (1, "one"), db, nullptr);
-  proc.Process (BlockData (2, "two"), db, nullptr);
+  Process (BlockData (0, "zero"), false);
+  Process (BlockData (1, "one"), false);
+  Process (BlockData (2, "two"), false);
   SetValue ("changed");
-  proc.Process (BlockData (3, "three"), db, nullptr);
-  proc.Process (BlockData (4, "four"), db, nullptr);
+  Process (BlockData (3, "three"), false);
+  Process (BlockData (4, "four"), false);
 
+  proc.Finish (db);
   ExpectValues ({{"one", "initial"}, {"four", "changed"}});
+}
+
+TEST_F (SQLiteProcTests, WorksAsyncOnSnapshot)
+{
+  constexpr auto DELAY = std::chrono::milliseconds (100);
+
+  proc.SetInterval (2);
+  proc.SetDelay (DELAY);
+
+  Process (BlockData (0, "zero"), false);
+  SetValue ("foo");
+  Process (BlockData (2, "two"), true);
+  SetValue ("bar");
+  Process (BlockData (4, "four"), true);
+
+  /* The second snapshot processing will have waited for the first one,
+     and then started its own processing async, so it is not finished yet.  */
+  Process (BlockData (5, "five"), true);
+  ExpectValues ({{"zero", "initial"}, {"two", "foo"}});
+
+  /* After waiting and triggering another run (even if not actually processing
+     the block), it will be done.  */
+  std::this_thread::sleep_for (2 * DELAY);
+  Process (BlockData (7, "seven"), true);
+  ExpectValues ({{"zero", "initial"}, {"two", "foo"}, {"four", "bar"}});
+
+  /* Also Finish() will wait for the pending processor.  */
+  Process (BlockData (8, "eight"), true);
+  proc.Finish (db);
+  ExpectValues ({
+    {"zero", "initial"},
+    {"two", "foo"},
+    {"four", "bar"},
+    {"eight", "bar"},
+  });
 }
 
 /* ************************************************************************** */

--- a/xayagame/sqliteproc_tests.cpp
+++ b/xayagame/sqliteproc_tests.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 The Xaya developers
+// Copyright (C) 2022-2023 The Xaya developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -140,7 +140,7 @@ protected:
   void
   ExpectValues (const std::map<std::string, std::string>& expected)
   {
-    proc.Finish ();
+    proc.Finish (db);
     ExpectRecords (db, "xayagame_procvalues", "value", expected);
   }
 
@@ -163,12 +163,12 @@ TEST_F (SQLiteProcTests, RunsAtDefinedInterval)
 {
   proc.SetInterval (3, 1);
 
-  proc.Process (BlockData (0, "zero"), db);
-  proc.Process (BlockData (1, "one"), db);
-  proc.Process (BlockData (2, "two"), db);
+  proc.Process (BlockData (0, "zero"), db, nullptr);
+  proc.Process (BlockData (1, "one"), db, nullptr);
+  proc.Process (BlockData (2, "two"), db, nullptr);
   SetValue ("changed");
-  proc.Process (BlockData (3, "three"), db);
-  proc.Process (BlockData (4, "four"), db);
+  proc.Process (BlockData (3, "three"), db, nullptr);
+  proc.Process (BlockData (4, "four"), db, nullptr);
 
   ExpectValues ({{"one", "initial"}, {"four", "changed"}});
 }
@@ -206,15 +206,15 @@ TEST_F (SQLiteHasherTests, Works)
   WriteAllTables (hasher1, db);
   const uint256 hash1 = hasher1.Finalise ();
 
-  hasher.Process (BlockData (0, "zero"), db);
-  hasher.Process (BlockData (1, "one"), db);
+  hasher.Process (BlockData (0, "zero"), db, nullptr);
+  hasher.Process (BlockData (1, "one"), db, nullptr);
 
   SetValue ("bar");
   SHA256 hasher2;
   WriteAllTables (hasher2, db);
   const uint256 hash2 = hasher2.Finalise ();
 
-  hasher.Process (BlockData (2, "two"), db);
+  hasher.Process (BlockData (2, "two"), db, nullptr);
 
   ExpectHashes ({{"zero", hash1}, {"one", hash1}, {"two", hash2}});
 
@@ -229,15 +229,15 @@ TEST_F (SQLiteHasherTests, Works)
 TEST_F (SQLiteHasherTests, SameBlock)
 {
   SetValue ("foo");
-  hasher.Process (BlockData (0, "zero"), db);
+  hasher.Process (BlockData (0, "zero"), db, nullptr);
 
   SetValue ("bar");
-  EXPECT_DEATH (hasher.Process (BlockData (0, "zero"), db),
+  EXPECT_DEATH (hasher.Process (BlockData (0, "zero"), db, nullptr),
                 "differs from computed");
-  hasher.Process (BlockData (0, "other zero"), db);
+  hasher.Process (BlockData (0, "other zero"), db, nullptr);
 
   SetValue ("foo");
-  hasher.Process (BlockData (0, "zero"), db);
+  hasher.Process (BlockData (0, "zero"), db, nullptr);
 }
 
 /* ************************************************************************** */

--- a/xayagame/sqliteproc_tests.cpp
+++ b/xayagame/sqliteproc_tests.cpp
@@ -94,6 +94,10 @@ protected:
 
 public:
 
+  TestProcessor ()
+    : SQLiteProcessor ("test")
+  {}
+
   void
   SetupSchema (SQLiteDatabase& db) override
   {

--- a/xayagame/sqlitestorage.hpp
+++ b/xayagame/sqlitestorage.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2022 The Xaya developers
+// Copyright (C) 2018-2023 The Xaya developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -394,12 +394,6 @@ private:
 protected:
 
   /**
-   * Closes the database, making sure to wait for all outstanding snapshots.
-   * The method is overridden (extended) in the SQLiteGame::Storage subclass.
-   */
-  virtual void CloseDatabase ();
-
-  /**
    * Sets up the database schema if it does not already exist.  This function is
    * called after opening the database, including when it was first created (but
    * not only then).  It creates the required tables if they do not yet exist.
@@ -449,6 +443,12 @@ public:
   void operator= (const SQLiteStorage&) = delete;
 
   void Initialise () override;
+
+  /**
+   * Closes the database, making sure to wait for all outstanding snapshots.
+   * The method is overridden (extended) in the SQLiteGame::Storage subclass.
+   */
+  virtual void CloseDatabase ();
 
   /**
    * Clears the storage.  This deletes and re-creates the full database,


### PR DESCRIPTION
This implements #128:  If it is possible to obtain a read-only snapshot of the database (i.e. when not batching updates from catching up), then `SQLiteProcessor`s are run asynchronously on that snapshot.  This allows them to run in the background without blocking the GSP, so it can continue attaching blocks.

Note that there can still be at most one instance of each processor running at any one time.  If the previous run is not yet finished before the next would be started, it will be awaited synchronously.  But this is still useful if the processor's runtime is potentially larger than the block time, but the processor is only run at an interval longer than its runtime.  For instance, with this it is possible to run state hashing every `N`th block in production GSPs (assuming `N` is large enough).