### PR TITLE
Request updates to explicit target block

### DIFF
--- a/nonfungible/gametest/targetblock.py
+++ b/nonfungible/gametest/targetblock.py
@@ -102,11 +102,7 @@ class TargetBlockTest (NonFungibleTest):
     ])
 
     # Test a target state in the past.
-    # FIXME:  For now, the GSP does not explicitly trigger ZMQ notifications
-    # to the target state.  So this only works if we trigger detaches
-    # externally.
     self.rpc.game._notify.settargetblock (blk2)
-    self.rpc.xaya.invalidateblock (blk1)
     self.assertEqual (self.getStateAtTarget (blk2), [
       {
         "asset": {"m": "domob", "a": "foo"},

--- a/xayagame/game_tests.cpp
+++ b/xayagame/game_tests.cpp
@@ -1607,7 +1607,7 @@ using TargetBlockTests = SyncingTests;
 
 TEST_F (TargetBlockTests, StopsWhileAttaching)
 {
-  g.SetTargetBlock (BlockHash (12));
+  SetTargetBlock (g, BlockHash (12));
 
   AttachBlock (g, BlockHash (11), Moves ("a0b1"));
   AttachBlock (g, BlockHash (12), Moves ("a2"));
@@ -1627,7 +1627,7 @@ TEST_F (TargetBlockTests, StopsWhileDetaching)
   ExpectGameState (BlockHash (13), "a2b1c3");
 
   mockXayaServer->SetBestBlock (13, BlockHash (13));
-  g.SetTargetBlock (BlockHash (12));
+  SetTargetBlock (g, BlockHash (12));
 
   DetachBlock (g);
   DetachBlock (g);

--- a/xayagame/testutils.hpp
+++ b/xayagame/testutils.hpp
@@ -345,6 +345,13 @@ protected:
     return g.zmq;
   }
 
+  static void
+  SetTargetBlock (Game& g, const uint256& blk)
+  {
+    std::lock_guard<std::mutex> lock(g.mut);
+    g.targetBlock = blk;
+  }
+
   /**
    * Calls BlockAttach on the given Game instance.  The function takes care
    * of setting up the blockData JSON object correctly based on the building


### PR DESCRIPTION
When an explicit target block is set, request `game_sendupdates` notifications from `Game` with that target set as `toblock` argument.  This ensures that we can properly sync to the target block, even if it is e.g. in the past.

This fixes #130.