### PR TITLE
Coprocessors

### DIFF
--- a/mover/logic_tests.cpp
+++ b/mover/logic_tests.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2019 The Xaya developers
+// Copyright (C) 2018-2023 The Xaya developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -39,7 +39,8 @@ TEST (InitialStateTests, IsEmpty)
 
       unsigned height;
       std::string hashHex;
-      const GameStateData state = rules.GetInitialState (height, hashHex);
+      const GameStateData state
+          = rules.GetInitialState (height, hashHex, nullptr);
 
       proto::GameState actualState;
       ASSERT_TRUE (actualState.ParseFromString (state));
@@ -101,7 +102,7 @@ protected:
 
     unsigned height;
     std::string hashHex;
-    initialState = rules.GetInitialState (height, hashHex);
+    initialState = rules.GetInitialState (height, hashHex, nullptr);
     currentState = initialState;
   }
 
@@ -113,7 +114,8 @@ protected:
       {
         const auto& d = blocks.top ();
         VerifyStatesEqual (currentState, d.newState);
-        currentState = rules.ProcessBackwards (d.newState, d.blockData, d.undo);
+        currentState = rules.ProcessBackwards (d.newState, d.blockData,
+                                               d.undo, nullptr);
         blocks.pop ();
       }
     VerifyStatesEqual (currentState, initialState);
@@ -162,7 +164,8 @@ protected:
     GameStateData expectedState;
     ASSERT_TRUE (expectedStatePb.SerializeToString (&expectedState));
 
-    d.newState = rules.ProcessForward (currentState, d.blockData, d.undo);
+    d.newState = rules.ProcessForward (currentState, d.blockData,
+                                       d.undo, nullptr);
     VerifyStatesEqual (d.newState, expectedState);
 
     currentState = d.newState;

--- a/xayagame/Makefile.am
+++ b/xayagame/Makefile.am
@@ -33,6 +33,7 @@ libxayagame_la_LIBADD = \
   $(SQLITE3_LIBS) $(LMDB_LIBS) $(ZMQ_LIBS) \
   -lstdc++fs
 libxayagame_la_SOURCES = \
+  coprocessor.cpp \
   defaultmain.cpp \
   game.cpp \
   gamelogic.cpp \
@@ -52,6 +53,7 @@ libxayagame_la_SOURCES = \
   transactionmanager.cpp \
   zmqsubscriber.cpp
 xayagame_HEADERS = \
+  coprocessor.hpp \
   defaultmain.hpp \
   game.hpp \
   gamelogic.hpp \
@@ -112,6 +114,7 @@ tests_LDADD = \
   $(GLOG_LIBS) $(GTEST_LIBS) $(GFLAGS_LIBS) \
   $(SQLITE3_LIBS) $(LMDB_LIBS) $(ZMQ_LIBS)
 tests_SOURCES = \
+  coprocessor_tests.cpp \
   game_tests.cpp \
   gamelogic_tests.cpp \
   heightcache_tests.cpp \

--- a/xayagame/coprocessor.cpp
+++ b/xayagame/coprocessor.cpp
@@ -1,0 +1,71 @@
+// Copyright (C) 2023 The Xaya developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "coprocessor.hpp"
+
+namespace xaya
+{
+
+void
+CoprocessorBatch::Add (const std::string& name, Coprocessor& p)
+{
+  CHECK (processors.emplace (name, &p).second)
+      << "We already had a processor of name '" << name << "'";
+  LOG (INFO) << "Added coprocessor '" << name << "'";
+}
+
+Coprocessor::Block::Block (const Json::Value& d, const Op o)
+  : blockData(d), op(o)
+{
+  CHECK (blockData.isObject ()) << "Invalid block data:\n" << blockData;
+  CHECK (hash.FromHex (blockData["hash"].asString ()))
+      << "Invalid block data:\n" << blockData;
+
+  const auto& heightVal = blockData["height"];
+  CHECK (heightVal.isUInt64 ()) << "Invalid block data:\n" << blockData;
+  height = heightVal.asUInt64 ();
+}
+
+CoprocessorBatch::Block::Block (CoprocessorBatch& batch,
+                                const Json::Value& blockData,
+                                const Coprocessor::Op op)
+{
+  for (auto& entry : batch.processors)
+    blocks.emplace (entry.first, entry.second->ForBlock (blockData, op));
+  CHECK_EQ (blocks.size (), batch.processors.size ())
+      << "Duplicate coprocessor names while constructing batch";
+}
+
+CoprocessorBatch::Block::~Block ()
+{
+  if (!committed)
+    for (auto& entry : blocks)
+      if (started.count (entry.first) > 0)
+        entry.second->Abort ();
+}
+
+void
+CoprocessorBatch::Block::Begin ()
+{
+  for (auto& entry : blocks)
+    {
+      entry.second->Begin ();
+      started.insert (entry.first);
+    }
+}
+
+void
+CoprocessorBatch::Block::Commit ()
+{
+  CHECK (!committed) << "CoprocessorBatch::Block is already committed";
+  committed = true;
+  for (auto& entry : blocks)
+    {
+      CHECK_EQ (started.count (entry.first), 1)
+          << "Commit() called without Begin()";
+      entry.second->Commit ();
+    }
+}
+
+} // namespace xaya

--- a/xayagame/coprocessor.hpp
+++ b/xayagame/coprocessor.hpp
@@ -1,0 +1,279 @@
+// Copyright (C) 2023 The Xaya developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef XAYAGAME_COPROCESSOR_HPP
+#define XAYAGAME_COPROCESSOR_HPP
+
+#include <xayautil/uint256.hpp>
+
+#include <json/json.h>
+
+#include <glog/logging.h>
+
+#include <map>
+#include <memory>
+#include <set>
+#include <string>
+
+namespace xaya
+{
+
+/**
+ * A coprocessor defines a set of extra logic for processing blocks forward
+ * and backward.  It is called for processing blocks forward and backward
+ * by the Game instance, and while a block is being processed, the GameLogic
+ * implementation can access the active coprocessors from the Context to make
+ * use of them.
+ *
+ * One possible use-case is computing and storing extra data alongside the
+ * game state, such as "archival logs" that are only created for use by a
+ * game frontend but do not otherwise influence the core game state.  In this
+ * case, a coprocessor can be set up that stores those events into an external
+ * storage (such as a database server), and the game logic in its state-update
+ * function can access the coprocessor to tell it about events while doing
+ * the main game-state calculations.
+ */
+class Coprocessor
+{
+
+public:
+
+  /**
+   * A type of "operation" done on a specific block.
+   */
+  enum class Op
+  {
+    /**
+     * This block is the game genesis, and we are doing state
+     * initialisation.
+     */
+    INITIALISATION,
+
+    /** This block is being processed forward.  */
+    FORWARD,
+
+    /** This block is being processed backwards (undone).  */
+    BACKWARD,
+  };
+
+  class Block;
+
+  Coprocessor () = default;
+  virtual ~Coprocessor () = default;
+
+  /**
+   * Constructs a block-processor instance for this coprocessor and the
+   * given block data.
+   */
+  virtual std::unique_ptr<Block> ForBlock (const Json::Value& blockData,
+                                           Op op) = 0;
+
+};
+
+/**
+ * A list of coprocessors, each named by a string as key.
+ */
+class CoprocessorBatch
+{
+
+private:
+
+  /** The included coprocessors, not owned by this instance.  */
+  std::map<std::string, Coprocessor*> processors;
+
+public:
+
+  class Block;
+
+  CoprocessorBatch () = default;
+  CoprocessorBatch (const CoprocessorBatch&) = delete;
+  void operator= (const CoprocessorBatch&) = delete;
+
+  /**
+   * Adds a new coprocessor to the batch.  This instance does not take
+   * over ownership, so the reference must remain valid for as long as the
+   * CoprocessorBatch lives.
+   */
+  void Add (const std::string& name, Coprocessor& p);
+
+};
+
+/**
+ * Processing instance for a single block.  Implementations of this interface
+ * are constructed by a Coprocessor.  The instance will live during processing
+ * of one block, either forward or backward.  It will then be committed or
+ * aborted (if an error occurs while running the GameLogic for that block),
+ * so it can use this for transactional integrity if desired.
+ *
+ * The active block processor instance is what the GameLogic can query for
+ * from the Context while the state update is executing.
+ */
+class Coprocessor::Block
+{
+
+private:
+
+  /** The full block data as JSON.  */
+  const Json::Value& blockData;
+
+  /** The operation being done.  */
+  const Op op;
+
+  /** The block's hash.  */
+  uint256 hash;
+
+  /** The block's height.  */
+  uint64_t height;
+
+  friend class CoprocessorBatch::Block;
+
+protected:
+
+  /**
+   * Signals to the implementation that it should start processing / open
+   * a database transaction if it wants.  This is called after the constructor.
+   *
+   * This is separate from the constructor, as that has some technical
+   * advantages (such as more well-defined behaviour in case of exceptions
+   * or calls to virtual methods).
+   *
+   * In case a Block instance had no call to Begin() yet (for instance because
+   * another coprocessor's Begin() failed), then also no Abort() or Commit()
+   * will be called.
+   */
+  virtual void
+  Begin ()
+  {}
+
+  /**
+   * Signals to the implementation that processing the block is finished and
+   * was successful, so if a transaction of some sort is used in the background,
+   * it can be committed.
+   */
+  virtual void
+  Commit ()
+  {}
+
+  /**
+   * Signals to the implementation that processing the block failed, and
+   * a potential transaction should be aborted.
+   */
+  virtual void
+  Abort ()
+  {}
+
+public:
+
+  Block (const Json::Value& d, Op o);
+  virtual ~Block () = default;
+
+  /**
+   * Returns the block's JSON data as convenience.
+   */
+  const Json::Value&
+  GetBlockData () const
+  {
+    return blockData;
+  }
+
+  /**
+   * Returns the block's hash.
+   */
+  const uint256&
+  GetBlockHash () const
+  {
+    return hash;
+  }
+
+  /**
+   * Returns the block's height.
+   */
+  uint64_t
+  GetBlockHeight () const
+  {
+    return height;
+  }
+
+  /**
+   * Returns the operation being done on the block.
+   */
+  Op
+  GetOperation () const
+  {
+    return op;
+  }
+
+};
+
+/**
+ * An instance representing the processing of a block by all coprocessors
+ * in a CoprocessorBatch.  This class handles by RAII the transaction
+ * of all the Coprocessor::Blocks contained, committing or aborting them
+ * respectively.
+ */
+class CoprocessorBatch::Block
+{
+
+private:
+
+  /** All the individual block processors.  */
+  std::map<std::string, std::unique_ptr<Coprocessor::Block>> blocks;
+
+  /**
+   * All the processors (names of them) that have been successfully started
+   * with a call to Begin().
+   */
+  std::set<std::string> started;
+
+  /**
+   * Set to true if the block has been committed explicitly.  If it is not
+   * committed by the time the destructor runs, all blocks will be aborted
+   * instead.
+   */
+  bool committed = false;
+
+public:
+
+  /**
+   * Constructs the block for the given batch of coprocessors and block data.
+   */
+  Block (CoprocessorBatch& batch, const Json::Value& blockData,
+         Coprocessor::Op op);
+
+  ~Block ();
+
+  /**
+   * Calls Begin() on all of the coprocessors.
+   */
+  void Begin ();
+
+  /**
+   * Mark the block processing as completed with success.
+   */
+  void Commit ();
+
+  /**
+   * Gets the coprocessor block with the given name or null if none exists.
+   * The result is dynamic-casted to the requested type, which must be
+   * the correct runtime type.
+   */
+  template <typename T>
+    T*
+    Get (const std::string& name)
+  {
+    const auto mit = blocks.find (name);
+    if (mit == blocks.end ())
+      return nullptr;
+
+    auto* res = dynamic_cast<T*> (mit->second.get ());
+    CHECK (res != nullptr)
+        << "Wrong dynamic type of coprocessor '" << name << "'";
+    return res;
+  }
+
+};
+
+} // namespace xaya
+
+#endif // XAYAGAME_COPROCESSOR_HPP

--- a/xayagame/coprocessor_tests.cpp
+++ b/xayagame/coprocessor_tests.cpp
@@ -1,0 +1,305 @@
+// Copyright (C) 2023 The Xaya developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "coprocessor.hpp"
+
+#include "testutils.hpp"
+
+#include <gtest/gtest.h>
+
+namespace xaya
+{
+
+/* ************************************************************************** */
+
+namespace
+{
+
+/**
+ * A mock Coprocessor that verifies that exactly the expected of
+ * Commitor Abort is called on each Block subprocessor.
+ */
+class MockCoprocessor : public Coprocessor
+{
+
+private:
+
+  /** Whether constructed block processors should expect success.  */
+  bool shouldBeSuccess = true;
+
+  /** Whether constructed block processors should expect Begin() calls.  */
+  bool shouldBeginBeCalled = true;
+
+  /** Whether constructed block processors should throw in Begin().  */
+  bool throwInBegin = false;
+
+public:
+
+  class MockBlock;
+
+  /**
+   * Specifies that constructed block processors should be failures.
+   */
+  void
+  ExpectFailure ()
+  {
+    shouldBeSuccess = false;
+  }
+
+  /**
+   * Specifies that block processors should not expect Begin() calls.
+   */
+  void
+  BeginShouldNotBeCalled ()
+  {
+    shouldBeginBeCalled = false;
+  }
+
+  /**
+   * Specifies that block processors should throw in Begin().
+   */
+  void
+  ThrowInBegin ()
+  {
+    throwInBegin = true;
+    shouldBeginBeCalled = false;
+  }
+
+  std::unique_ptr<Block> ForBlock (const Json::Value& blockData,
+                                   Op op) override;
+
+};
+
+class MockCoprocessor::MockBlock : public Coprocessor::Block
+{
+
+private:
+
+  /**
+   * Whether the block should be handled as successful, i.e. Commit()
+   * should be called.  If false, then Abort() must be called.
+   */
+  const bool shouldBeSuccess;
+
+  /** Whether or not the block should be started with Begin() at all.  */
+  const bool shouldBeginBeCalled;
+
+  /** If set to true, then fail (throw) from Begin().  */
+  const bool throwInBegin;
+
+  /** Whether or not Begin() has been called.  */
+  bool beginCalled = false;
+  /** Whether or not Commit() has been called.  */
+  bool commitCalled = false;
+  /** Whether or not Abort() has been called.  */
+  bool abortCalled = false;
+
+protected:
+
+  void
+  Begin () override
+  {
+    /* In case of throwInBegin, we actually have shouldBeginBeCalled set
+       to false (even though we expect this call), since then we do not
+       expect a Commit() or Abort() for this instance.  Thus throw
+       here before doing any of the other things.  */
+    if (throwInBegin)
+      throw std::runtime_error ("Begin() error");
+
+    EXPECT_TRUE (shouldBeginBeCalled) << "Unexpected Begin() call";
+    EXPECT_FALSE (beginCalled) << "Begin() called twice";
+    beginCalled = true;
+  }
+
+  void
+  Commit () override
+  {
+    EXPECT_TRUE (beginCalled) << "Resolution without Begin()";
+    EXPECT_FALSE (commitCalled || abortCalled) << "Duplicate resolution call";
+    EXPECT_TRUE (shouldBeSuccess) << "Expected failure, but Commit() called";
+    commitCalled = true;
+  }
+
+  void
+  Abort () override
+  {
+    EXPECT_TRUE (beginCalled) << "Resolution without Begin()";
+    EXPECT_FALSE (commitCalled || abortCalled) << "Duplicate resolution call";
+    EXPECT_FALSE (shouldBeSuccess) << "Expected success, but Abort() called";
+    abortCalled = true;
+  }
+
+public:
+
+  /**
+   * The parent coprocessor.  This is used in tests to verify that the
+   * block requested from a batch by name is the correct one (i.e. matching
+   * the coprocessor of this name).
+   */
+  const MockCoprocessor& parent;
+
+  MockBlock (const Json::Value& blockData, const Coprocessor::Op o,
+             const bool s, const bool b, const bool t,
+             const MockCoprocessor& p)
+    : Block(blockData, o),
+      shouldBeSuccess(s), shouldBeginBeCalled(b), throwInBegin(t),
+      parent(p)
+  {}
+
+  ~MockBlock ()
+  {
+    if (shouldBeginBeCalled)
+      {
+        /* If both have been called, then we already failed the test
+           in the Commit() or Abort() method.  */
+        EXPECT_TRUE (beginCalled) << "Begin() has not been called";
+        EXPECT_TRUE (commitCalled || abortCalled) << "No resolution call";
+      }
+    /* Otherwise, we already fail the test in Begin() being called, or
+       when Commit() or Abort() are called without Begin().  */
+  }
+
+};
+
+std::unique_ptr<Coprocessor::Block>
+MockCoprocessor::ForBlock (const Json::Value& blockData, const Op op)
+{
+  return std::make_unique<MockBlock> (blockData, op,
+                                      shouldBeSuccess, shouldBeginBeCalled,
+                                      throwInBegin, *this);
+}
+
+/* ************************************************************************** */
+
+} // anonymous namespace
+
+class CoprocessorTests : public testing::Test
+{
+
+protected:
+
+  MockCoprocessor coproc;
+  MockCoprocessor proc2;
+  MockCoprocessor proc3;
+
+  CoprocessorBatch batch;
+
+  CoprocessorTests ()
+  {
+    batch.Add ("mock", coproc);
+  }
+
+  /**
+   * Returns the MockBlock of the given coprocessor batch.
+   */
+  MockCoprocessor::MockBlock&
+  GetMockBlock (CoprocessorBatch::Block& blk)
+  {
+    auto* res = blk.Get<MockCoprocessor::MockBlock> ("mock");
+    CHECK (res != nullptr);
+    return *res;
+  }
+
+  /**
+   * Constructs fake block data for the given block height.
+   */
+  static Json::Value
+  FakeBlockData (const unsigned height)
+  {
+    Json::Value res(Json::objectValue);
+    res["hash"] = BlockHash (height).ToHex ();
+    res["height"] = static_cast<Json::Int64> (height);
+
+    return res;
+  }
+
+};
+
+namespace
+{
+
+TEST_F (CoprocessorTests, ParsesBlockData)
+{
+  const auto blockData = FakeBlockData (123);
+
+  {
+    CoprocessorBatch::Block batchBlock(batch, blockData,
+                                       Coprocessor::Op::FORWARD);
+    auto& blk = GetMockBlock (batchBlock);
+    EXPECT_EQ (blk.GetBlockData (), blockData);
+    EXPECT_EQ (blk.GetBlockHash (), BlockHash (123));
+    EXPECT_EQ (blk.GetBlockHeight (), 123);
+    EXPECT_EQ (blk.GetOperation (), Coprocessor::Op::FORWARD);
+    batchBlock.Begin ();
+    batchBlock.Commit ();
+  }
+
+  {
+    CoprocessorBatch::Block batchBlock(batch, blockData,
+                                       Coprocessor::Op::BACKWARD);
+    EXPECT_EQ (GetMockBlock (batchBlock).GetOperation (),
+               Coprocessor::Op::BACKWARD);
+    batchBlock.Begin ();
+    batchBlock.Commit ();
+  }
+}
+
+TEST_F (CoprocessorTests, CommitAndAbort)
+{
+  {
+    CoprocessorBatch::Block batchBlock(batch, FakeBlockData (10),
+                                       Coprocessor::Op::FORWARD);
+    /* By default, the mock block expects success.  */
+    batchBlock.Begin ();
+    batchBlock.Commit ();
+  }
+
+  {
+    coproc.ExpectFailure ();
+    CoprocessorBatch::Block batchBlock(batch, FakeBlockData (11),
+                                       Coprocessor::Op::FORWARD);
+    batchBlock.Begin ();
+    /* We do not commit, which means that it should be aborted instead.  */
+  }
+}
+
+TEST_F (CoprocessorTests, ErrorInBegin)
+{
+  batch.Add ("mock2", proc2);
+  batch.Add ("mock3", proc3);
+
+  coproc.ExpectFailure ();
+  proc2.ThrowInBegin ();
+  proc3.BeginShouldNotBeCalled ();
+
+  EXPECT_THROW (
+    {
+      CoprocessorBatch::Block batchBlock(batch, FakeBlockData (10),
+                                         Coprocessor::Op::FORWARD);
+      batchBlock.Begin ();
+    },
+    std::runtime_error
+  );
+}
+
+TEST_F (CoprocessorTests, ByName)
+{
+  batch.Add ("2", proc2);
+  CoprocessorBatch::Block batchBlock(batch, FakeBlockData (10),
+                                     Coprocessor::Op::FORWARD);
+
+  EXPECT_EQ (batchBlock.Get<MockCoprocessor::MockBlock> ("foo"), nullptr);
+  EXPECT_EQ (&batchBlock.Get<MockCoprocessor::MockBlock> ("mock")->parent,
+             &coproc);
+  EXPECT_EQ (&batchBlock.Get<MockCoprocessor::MockBlock> ("2")->parent,
+             &proc2);
+
+  batchBlock.Begin ();
+  batchBlock.Commit ();
+}
+
+/* ************************************************************************** */
+
+} // anonymous namespace
+} // namespace xaya

--- a/xayagame/game.hpp
+++ b/xayagame/game.hpp
@@ -5,6 +5,7 @@
 #ifndef XAYAGAME_GAME_HPP
 #define XAYAGAME_GAME_HPP
 
+#include "coprocessor.hpp"
 #include "gamelogic.hpp"
 #include "heightcache.hpp"
 #include "mainloop.hpp"
@@ -207,6 +208,9 @@ private:
 
   /** The background thread running regular connection checks, if any.  */
   std::unique_ptr<ConnectionCheckerThread> connectionChecker;
+
+  /** The coprocessor batch we use to handle coprocessors during blocks.  */
+  CoprocessorBatch coproc;
 
   void BlockAttach (const std::string& id, const Json::Value& data,
                     bool seqMismatch) override;
@@ -411,6 +415,11 @@ public:
    * or disables one (i.e. sync to tip) if the value is null.
    */
   void SetTargetBlock (const uint256& blk);
+
+  /**
+   * Adds a coprocessor to the batch that is updated on each block.
+   */
+  void AddCoprocessor (const std::string& name, Coprocessor& p);
 
   /**
    * Detects the ZMQ endpoint(s) by calling getzmqnotifications on the Xaya

--- a/xayagame/gamelogic.hpp
+++ b/xayagame/gamelogic.hpp
@@ -1,10 +1,11 @@
-// Copyright (C) 2018-2022 The Xaya developers
+// Copyright (C) 2018-2023 The Xaya developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #ifndef XAYAGAME_GAMELOGIC_HPP
 #define XAYAGAME_GAMELOGIC_HPP
 
+#include "coprocessor.hpp"
 #include "storage.hpp"
 
 #include "rpc-stubs/xayarpcclient.h"
@@ -142,9 +143,16 @@ private:
   Random rnd;
 
   /**
+   * Coprocessor batch that the implementation can use to access individual
+   * coprocessors by name.
+   */
+  CoprocessorBatch::Block* coprocBlk;
+
+  /**
    * Constructs a context.  This is done by the GameLogic class.
    */
-  Context (const GameLogic& l, const uint256& rndSeed);
+  Context (const GameLogic& l, const uint256& rndSeed,
+           CoprocessorBatch::Block* cb);
 
   friend class GameLogic;
 
@@ -176,6 +184,19 @@ public:
   GetRandom ()
   {
     return rnd;
+  }
+
+  /**
+   * Returns the coprocessor with the given name, casted to the given
+   * type.  Returns null if no such coprocessor is registered.
+   */
+  template <typename T>
+    T*
+    GetCoprocessor (const std::string& name)
+  {
+    if (coprocBlk == nullptr)
+      return nullptr;
+    return coprocBlk->Get<T> (name);
   }
 
 };
@@ -267,9 +288,12 @@ public:
   /**
    * Returns the initial state for the game.  This is the function that is
    * called externally.  It sets up a Context instance and then calls
-   * through to GetInitialStateInternal.
+   * through to GetInitialStateInternal.  The coprocessor batch is optional,
+   * and will not be set when this method is called to determine the
+   * genesis height initially.
    */
-  GameStateData GetInitialState (unsigned& height, std::string& hashHex);
+  GameStateData GetInitialState (unsigned& height, std::string& hashHex,
+                                 CoprocessorBatch::Block* cb);
 
   /**
    * Processes the game state forward in time.  This method should be
@@ -278,7 +302,8 @@ public:
    */
   GameStateData ProcessForward (const GameStateData& oldState,
                                 const Json::Value& blockData,
-                                UndoData& undoData);
+                                UndoData& undoData,
+                                CoprocessorBatch::Block* cb);
 
   /**
    * Processes the game state backwards in time (for reorgs).  This function
@@ -287,7 +312,8 @@ public:
    */
   GameStateData ProcessBackwards (const GameStateData& newState,
                                   const Json::Value& blockData,
-                                  const UndoData& undoData);
+                                  const UndoData& undoData,
+                                  CoprocessorBatch::Block* cb);
 
   /**
    * A notification method that gets called whenever the Game instance

--- a/xayagame/gamelogic_tests.cpp
+++ b/xayagame/gamelogic_tests.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2021 The Xaya developers
+// Copyright (C) 2018-2023 The Xaya developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -71,7 +71,7 @@ protected:
 
     unsigned dummyHeight;
     std::string dummyHashHex;
-    state = game.GetInitialState (dummyHeight, dummyHashHex);
+    state = game.GetInitialState (dummyHeight, dummyHashHex, nullptr);
   }
 
   /**
@@ -90,7 +90,7 @@ protected:
     blockStack.push (blockData);
 
     UndoData undo;
-    state = game.ProcessForward (state, blockData, undo);
+    state = game.ProcessForward (state, blockData, undo, nullptr);
     undoStack.push (undo);
   }
 
@@ -100,7 +100,8 @@ protected:
   void
   DetachBlock ()
   {
-    state = game.ProcessBackwards (state, blockStack.top (), undoStack.top ());
+    state = game.ProcessBackwards (state, blockStack.top (),
+                                   undoStack.top (), nullptr);
 
     undoStack.pop ();
     blockStack.pop ();

--- a/xayagame/sqlitegame_tests.cpp
+++ b/xayagame/sqlitegame_tests.cpp
@@ -361,7 +361,7 @@ InitialiseState (Game& game, SQLiteGame& rules)
 {
   unsigned height;
   std::string hashHex;
-  const GameStateData state = rules.GetInitialState (height, hashHex);
+  const GameStateData state = rules.GetInitialState (height, hashHex, nullptr);
 
   uint256 hash;
   ASSERT_TRUE (hash.FromHex (hashHex));
@@ -461,7 +461,7 @@ TEST_F (StateInitialisationTests, HeightAndHash)
 
   unsigned height;
   std::string hashHex;
-  const GameStateData state = rules.GetInitialState (height, hashHex);
+  const GameStateData state = rules.GetInitialState (height, hashHex, nullptr);
   EXPECT_EQ (height, GENESIS_HEIGHT);
   EXPECT_EQ (hashHex, GenesisHash ().ToHex ());
 }


### PR DESCRIPTION
This introduces the concept of *Coprocessors*:  They are optional modules which run alongside the core game logic inside a GSP.  They get notified about block attaches, detaches and game-state initialisation, and while the core `GameLogic` callbacks are executing, the user-code can access (and work with) the active coprocessors through `Context`.

A specific feature that this will allow is archival data:  Similar to logs in the EVM, GSPs can use a coprocessor to write "append only" data such as logs of game events into some external database or storage, outside the core game state.  For data that is only produced and served to frontends but not otherwise required inside the GSP for state updates, this can help to keep the core game state lean and improve scalability and performance overall.