### PR TITLE
Unblock state reads from block updates

### DIFF
--- a/mover/gametest/pending.py
+++ b/mover/gametest/pending.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2019 The Xaya developers
+# Copyright (C) 2019-2024 The Xaya developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -24,6 +24,9 @@ class PendingMovesTest (MoverTest):
     self.log.info ("Testing ZMQ pending mode '%s'..." % self.zmqPending)
 
     self.generate (101)
+    # Make sure all notifications and updates have been processed for now.
+    self.syncGame ()
+
     self.move ("a", "k", 5)
     self.move ("b", "j", 5)
     self.generate (1)

--- a/mover/gametest/waitforchange.py
+++ b/mover/gametest/waitforchange.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (C) 2018-2020 The Xaya developers
+# Copyright (C) 2018-2024 The Xaya developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -67,6 +67,10 @@ class WaitForChangeTest (MoverTest):
 
   def run (self):
     self.generate (101)
+
+    # Make sure that all notifications up to now and all other
+    # updates have been done before proceeding with the test.
+    self.syncGame ()
 
     self.test_attach ()
     self.test_detach ()

--- a/ships/gametest/pending.py
+++ b/ships/gametest/pending.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (C) 2019-2022 The Xaya developers
+# Copyright (C) 2019-2024 The Xaya developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -41,6 +41,11 @@ class PendingTest (ShipsTest):
 
   def run (self):
     self.generate (110)
+
+    # Ensures that all notifications have been sent and all updates done
+    # until now before we proceed with the test (that may otherwise be
+    # sensible to race conditions).
+    self.syncGame ()
 
     # Pre-register all names we need later for pending.  This ensures that
     # pending tracking also works on EVM chains.

--- a/xayagame/game.hpp
+++ b/xayagame/game.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2023 The Xaya developers
+// Copyright (C) 2018-2024 The Xaya developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -300,6 +300,28 @@ private:
    * Notifies potentially-waiting threads that the pending state has changed.
    */
   void NotifyPendingStateChange ();
+
+  /**
+   * Constructs a JSON object representing the basic instance state (with
+   * gameid, chain and state) as returned by GetCustomStateData and used
+   * in other places.  Expects the caller to hold the mut lock.
+   *
+   * Returns also the current block hash and height if it can be retrieved.
+   * Might return the hash as null if it cannot be retrieved (e.g. due to
+   * an RPC exception from the blockchain node).
+   */
+  Json::Value UnlockedGetInstanceStateJson (uint256& hash,
+                                            unsigned& height) const;
+
+  /**
+   * Calls the InstanceStateChanged method on rules based on the current
+   * instance state.  Expects the caller to hold the mut lock.
+   *
+   * As an implementation detail / rule, this method gets called from the
+   * place that actually holds the mut lock, and not methods further down
+   * the call stack (which might do the actual changes to "state" for instance).
+   */
+  void NotifyInstanceStateChanged () const;
 
   /**
    * Returns the current pending state as JSON, but assuming that the caller

--- a/xayagame/gamelogic.hpp
+++ b/xayagame/gamelogic.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2023 The Xaya developers
+// Copyright (C) 2018-2024 The Xaya developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -323,6 +323,20 @@ public:
    */
   virtual void
   GameStateUpdated (const GameStateData& state, const Json::Value& blockData)
+  {}
+
+  /**
+   * A notification method that gets called whenever the instance
+   * state (not necessarily the game state) changes.  This could be changes
+   * to the game state, but also things like losing connection to the
+   * blockchain node, reaching the target block and things like that.
+   *
+   * The argument passed is a basic representation of the instance
+   * state as returned also from GetCustomStateData, in particular with the
+   * gameid, chain and state fields.
+   */
+  virtual void
+  InstanceStateChanged (const Json::Value& newState)
   {}
 
   /**

--- a/xayagame/sqlitegame.hpp
+++ b/xayagame/sqlitegame.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2020 The Xaya developers
+// Copyright (C) 2018-2024 The Xaya developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -64,6 +64,11 @@ private:
      holds a set of currently activate AutoId values.  */
   class ActiveAutoIds;
 
+  /* Internal helper class (defined and implemented in sqlitegame.cpp) that
+     holds a state snapshot to be used for retrieving (read-only) state
+     data without needing the main lock.  */
+  class StateSnapshot;
+
   /**
    * The storage instance that is used.  std::unique_ptr is used so that we
    * can use the forward-declared type and do not need to define Storage right
@@ -77,6 +82,16 @@ private:
    * to UpdateState).  It is set to null when no set is active.
    */
   ActiveAutoIds* activeIds = nullptr;
+
+  /**
+   * This helper class may (or may not if we were not able to create a database
+   * snapshot) hold a full "state snapshot" that can be used to retrieve
+   * read-only state information, such as for answering RPC calls.  It has
+   * a lock that protects the instance, such as when the state is updated to
+   * a new one, but otherwise the snapshot (if present) can be used without
+   * requiring the main Game lock.
+   */
+  std::unique_ptr<StateSnapshot> stateSnapshot;
 
   /**
    * Any processors attached, that will be called for state updates.  They
@@ -183,10 +198,9 @@ protected:
 
   /**
    * Extracts custom state data from the database (as done by a callback
-   * that queries the data).  This calls GetCustomStateData on the Game
-   * instance and provides a callback that handles the "game state" string
-   * in the same way as GameStateToJson does, before calling the user function
-   * to actually retrieve the data.
+   * that queries the data).  This uses the instance state provided by
+   * Game and retrieves a snapshot of the game state database, which is
+   * then passed on to the user function to retrieve the custom data.
    */
   Json::Value GetCustomStateData (
       const Game& game, const std::string& jsonField,
@@ -270,6 +284,7 @@ public:
 
   void GameStateUpdated (const GameStateData& state,
                          const Json::Value& blockData) override;
+  void InstanceStateChanged (const Json::Value& state) override;
   Json::Value GameStateToJson (const GameStateData& state) override;
 
 };

--- a/xayagame/sqlitestorage.hpp
+++ b/xayagame/sqlitestorage.hpp
@@ -383,11 +383,6 @@ private:
   void OpenDatabase ();
 
   /**
-   * Blocks until no read snapshots are open.
-   */
-  void WaitForSnapshots ();
-
-  /**
    * Decrements the count of outstanding snapshots.
    */
   void UnrefSnapshot () const;
@@ -412,6 +407,13 @@ protected:
    * implementation.
    */
   virtual void SetupSchema ();
+
+  /**
+   * Blocks until no read snapshots are open.  This method is overwritten
+   * in the SQLiteGame::Storage class, to add logic for explicitly closing
+   * snapshots retained by the class itself.
+   */
+  virtual void WaitForSnapshots ();
 
   /**
    * Returns the underlying SQLiteDatabase instance.

--- a/xayagame/sqlitestorage_tests.cpp
+++ b/xayagame/sqlitestorage_tests.cpp
@@ -1,9 +1,10 @@
-// Copyright (C) 2018-2023 The Xaya developers
+// Copyright (C) 2018-2024 The Xaya developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include "sqlitestorage.hpp"
 
+#include "perftimer.hpp"
 #include "storage_tests.hpp"
 #include "testutils.hpp"
 
@@ -500,6 +501,56 @@ TEST_F (SQLiteStorageSnapshotTests, StatementsMustAllBeDestructed)
      should CHECK fail.  At the end of the test scope, the statement
      will be destructed before the snapshot, which is fine.  */
   EXPECT_DEATH (s.reset (), "statement is still in use");
+}
+
+TEST_F (SQLiteStorageSnapshotTests, OneSnapshotMultipleThreads)
+{
+  /* It is possible to use one snapshot from multiple threads, and this should
+     not cause any specific congestion.  Just when a statement is prepared
+     should there be a lock, but then processing a statement should not block
+     other threads from also doing something on the snapshot.  */
+
+  Storage storage(file.GetName ());
+  storage.Initialise ();
+  storage.GetDatabase ().Execute (R"(
+    CREATE TABLE `foo` (`id` INTEGER NOT NULL PRIMARY KEY);
+    INSERT INTO `foo` (`id`) VALUES (1), (2), (3);
+  )");
+
+  auto snapshot = storage.GetSnapshot ();
+  storage.GetDatabase ().Execute (R"(
+    DELETE FROM `foo`
+  )");
+
+  constexpr auto sleep = std::chrono::milliseconds (100);
+
+  PerformanceTimer timer;
+  std::vector<std::thread> threads;
+  for (unsigned i = 0; i < 10; ++i)
+    threads.emplace_back ([&] ()
+      {
+        auto stmt = snapshot->PrepareRo (R"(
+          SELECT `id`
+            FROM `foo`
+            ORDER BY `id`
+        )");
+
+        for (unsigned j = 1; j <= 3; ++j)
+          {
+            std::this_thread::sleep_for (sleep);
+            ASSERT_TRUE (stmt.Step ());
+            ASSERT_EQ (stmt.Get<int64_t> (0), j);
+          }
+
+        ASSERT_FALSE (stmt.Step ());
+      });
+  for (auto& t : threads)
+    t.join ();
+  timer.Stop ();
+
+  const auto dur = timer.Get<std::chrono::milliseconds> ();
+  EXPECT_GT (dur, 2 * sleep);
+  EXPECT_LT (dur, 4 * sleep);
 }
 
 /* ************************************************************************** */


### PR DESCRIPTION
In this set of changes, we refactor how `SQLiteGame` handes the `GetCustomStateData` method, i.e. how it exposes state reads (e.g. to RPC calls in GSPs).  Whenever the instance state changes (game state or things like connected/disconnected/catching up), we update a "current state snapshot".  This contains both the instance state and a database snapshot of the full game state.  With this, we can then use this to service state reads without requiring a lock on `Game::mut`.  This allows us to continue supporting state reads even when a block update takes a long time.

This implements #136.