### PR TITLE
Docker with full WASM setup

### DIFF
--- a/wasm/README.md
+++ b/wasm/README.md
@@ -64,10 +64,75 @@ internal logging which uses token pasting (`LOGLEVEL_##LEVEL`).
 The shim headers are installed into the prefix alongside the libraries so
 that game projects do not need a copy of the libxayagame source tree.
 
-## Prerequisites
+## Docker Image (Recommended)
+
+The `wasm/docker/` directory contains a `Dockerfile` that builds a
+self-contained image with Emscripten and all required dependencies
+already cross-compiled and installed into the Emscripten sysroot.  This
+is the easiest way to get a reproducible build environment without
+installing or cross-compiling anything on the host.
+
+### What is in the image
+
+The image is based on `emscripten/emsdk` (Debian-based) and adds:
+
+| Component | Version ARG | How built |
+|-----------|-------------|-----------|
+| Emscripten SDK | (from base image) | Pre-installed |
+| OpenSSL | `OPENSSL_VERSION` | Cross-compiled for WASM |
+| Protobuf (`protoc` + `libprotobuf`) | `PROTOBUF_VERSION` | `protoc` built natively; `libprotobuf` cross-compiled for WASM |
+| jsoncpp | `JSONCPP_VERSION` | Cross-compiled for WASM |
+| secp256k1 | `SECP256K1_VERSION` | Cross-compiled for WASM |
+| eth-utils | `ETHUTILS_VERSION` | Cross-compiled for WASM |
+
+`protoc` and `libprotobuf` are built from **the same source checkout**,
+guaranteeing that the code-generator binary and the runtime library are
+always the exact same version.
+
+All WASM artefacts are installed into the Emscripten sysroot
+(`/emsdk/upstream/emscripten/cache/sysroot`), which Emscripten searches
+automatically, so no extra `-I` or `-L` flags are needed.
+
+### Building the image
+
+```bash
+# From the root of the libxayagame repository:
+docker build -f wasm/docker/Dockerfile -t libxayagame-wasm .
+```
+
+Parallel builds can be enabled with the `N` build argument to speed up
+the cross-compilation steps:
+
+```bash
+docker build -f wasm/docker/Dockerfile -t libxayagame-wasm \
+  --build-arg N=$(nproc) .
+```
+
+### Using the image
+
+Mount your game project into the container and run the build inside it:
+
+```bash
+docker run --rm -v $(pwd):/game libxayagame-wasm \
+  bash -c "
+    emcmake cmake -B /game/build /game \
+      -DCMAKE_PREFIX_PATH=\${WASM_PREFIX} && \
+    cmake --build /game/build
+  "
+```
+
+The `WASM_PREFIX` environment variable is set inside the image to the
+Emscripten sysroot path, so game projects can reference it without
+hardcoding the path.
+
+## Prerequisites (manual setup)
+
+If you prefer not to use Docker, you will need to set up the following
+manually:
 
 1. **Emscripten SDK** — Install and activate (`source emsdk_env.sh`)
-2. **Protobuf for WASM** — Full protobuf compiled as a static WASM library
+2. **Protobuf for WASM** — Full protobuf compiled as a static WASM library,
+   plus a matching native `protoc` binary on `$PATH`
 3. **OpenSSL for WASM** — OpenSSL compiled as a static WASM library
 4. **jsoncpp for WASM** — jsoncpp compiled as a static WASM library
 5. **eth-utils for WASM** — eth-utils (with secp256k1) compiled as a static WASM library

--- a/wasm/XayaGameWasmConfig.cmake.in
+++ b/wasm/XayaGameWasmConfig.cmake.in
@@ -29,7 +29,7 @@ foreach (_lib IN ITEMS
     openssl:ssl:libssl.a
     openssl:crypto:libcrypto.a
     jsoncpp:jsoncpp:libjsoncpp.a
-    ethutils:eth-utils:libeth-utils.a)
+    ethutils:eth-utils:libethutils.a)
   # Each entry is  namespace:target-suffix:filename
   string (REPLACE ":" ";" _parts "${_lib}")
   list (GET _parts 0 _ns)

--- a/wasm/docker/Dockerfile
+++ b/wasm/docker/Dockerfile
@@ -1,0 +1,152 @@
+# This Dockerfile builds an image that has the game-channel libraries
+# and all required dependencies cross-compiled to WASM for use by
+# game projects.
+
+FROM emscripten/emsdk
+
+RUN apt-get update && apt-get install -y \
+  autoconf \
+  autoconf-archive \
+  cmake \
+  g++ \
+  libtool \
+  perl \
+  pkg-config
+
+# Number of cores to use for parallel builds.
+ARG N=1
+
+# Prefix used by emsdk for compiled artefacts.  We use the sysroot root
+# directly (not the /usr sub-prefix) so that pkg-config files are installed
+# into sysroot/lib/pkgconfig, which is the path emscripten's pkg-config
+# wrapper searches by default.
+ENV WASM_PREFIX="/emsdk/upstream/emscripten/cache/sysroot"
+
+# Install the glog shim into the sysroot so all subsequent builds that
+# do #include <glog/logging.h> get the stub without needing extra flags.
+# NOTE: COPY does not expand ENV variables, so the sysroot path is hardcoded.
+COPY wasm/shims/glog/logging.h /emsdk/upstream/emscripten/cache/sysroot/include/glog/logging.h
+COPY wasm/docker/libglog.pc /emsdk/upstream/emscripten/cache/sysroot/lib/pkgconfig/libglog.pc
+
+# Build and install OpenSSL.
+# OpenSSL uses its own custom Perl-based Configure (not autoconf), so the
+# build procedure differs from other autotools libraries:
+#
+#  1. We call emconfigure ./Configure with an explicit arch of linux-x32
+#     (32-bit pointer model, matching WASM32).  emconfigure injects CC=emcc
+#     etc. into the environment which OpenSSL's Configure script picks up.
+#
+#  2. After Configure runs it writes CROSS_COMPILE=<emscripten-path> into the
+#     generated Makefile, which would cause path-doubling bugs when make
+#     expands $(CROSS_COMPILE)ar etc.  The sed clears that variable.
+#
+#  3. We build only the library targets explicitly; the default 'all' target
+#     would attempt to link executables that cannot run on WASM.
+#
+#  4. 'make install_sw' installs headers, static libs, and .pc files without
+#     any documentation or command-line tools.
+ARG OPENSSL_VERSION="openssl-3.6.1"
+WORKDIR /src/openssl
+RUN git clone https://github.com/openssl/openssl . \
+    && git checkout "${OPENSSL_VERSION}" \
+    && emconfigure ./Configure linux-x32 \
+          --prefix="${WASM_PREFIX}" \
+          --libdir=lib \
+          --cross-compile-prefix= \
+          no-asm \
+          no-shared \
+          no-dso \
+          no-engine \
+          no-module \
+          no-sse2 \
+          no-threads \
+          no-apps \
+          no-tests \
+    && sed -i 's|^CROSS_COMPILE.*$|CROSS_COMPILE=|' Makefile \
+    && emmake make -j${N} build_generated libssl.a libcrypto.a \
+    && emmake make install_sw \
+    && make distclean
+
+# Build protoc (native) and libprotobuf (WASM) from the same source checkout.
+# The native build provides the protoc code-generator binary that runs at
+# cmake build time; the WASM build provides the headers and static library
+# for linking.  Building both from the same checkout guarantees that the
+# protoc version and the library version are identical.
+ARG PROTOBUF_VERSION="v3.21.12"
+WORKDIR /src/protobuf
+RUN git clone https://github.com/protocolbuffers/protobuf . \
+    && git checkout "${PROTOBUF_VERSION}" \
+    \
+    && cmake -B build-native \
+          -DCMAKE_BUILD_TYPE=Release \
+          -DCMAKE_INSTALL_PREFIX=/usr/local \
+          -Dprotobuf_BUILD_TESTS=OFF \
+          -Dprotobuf_BUILD_SHARED_LIBS=OFF \
+    && cmake --build build-native -j${N} --target protoc \
+    && cp build-native/protoc /usr/local/bin/protoc \
+    \
+    && emcmake cmake -B build-wasm \
+          -DCMAKE_BUILD_TYPE=Release \
+          -DCMAKE_INSTALL_PREFIX="${WASM_PREFIX}" \
+          -Dprotobuf_BUILD_TESTS=OFF \
+          -Dprotobuf_BUILD_PROTOC_BINARIES=OFF \
+          -Dprotobuf_BUILD_SHARED_LIBS=OFF \
+    && cmake --build build-wasm -j${N} \
+    && cmake --install build-wasm \
+    && rm -rf build-native build-wasm
+
+# Build and install jsoncpp.
+ARG JSONCPP_VERSION="1.9.6"
+WORKDIR /src/jsoncpp
+RUN git clone https://github.com/open-source-parsers/jsoncpp . \
+    && git checkout "${JSONCPP_VERSION}" \
+    && emcmake cmake -B build . \
+          -DCMAKE_BUILD_TYPE=Release \
+          -DCMAKE_INSTALL_PREFIX="${WASM_PREFIX}" \
+          -DBUILD_SHARED_LIBS=OFF -DBUILD_STATIC_LIBS=ON \
+          -DJSONCPP_WITH_TESTS=OFF \
+    && cmake --build build -j${N} \
+    && cmake --install build \
+    && rm -rf build
+
+# Build and install secp256k1.
+ARG SECP256K1_VERSION="v0.7.1"
+WORKDIR /src/secp256k1
+RUN git clone https://github.com/bitcoin-core/secp256k1 . \
+    && git checkout "${SECP256K1_VERSION}" \
+    && ./autogen.sh \
+    && emconfigure ./configure \
+          --prefix="${WASM_PREFIX}" \
+          --host=wasm32-unknown-emscripten \
+          --disable-shared --enable-static \
+          --enable-module-recovery \
+          --disable-benchmark --disable-exhaustive-tests --disable-tests \
+    && emmake make -j${N} \
+    && emmake make install \
+    && emmake make distclean
+
+# Build and install eth-utils.
+ARG ETHUTILS_VERSION="31c8936812878b4a717feefb2ffc8429ced8d9c6"
+WORKDIR /src/eth-utils
+RUN git clone https://github.com/xaya/eth-utils . \
+    && git checkout "${ETHUTILS_VERSION}" \
+    && ./autogen.sh \
+    && emconfigure ./configure \
+          --prefix="${WASM_PREFIX}" \
+          --host=wasm32-unknown-emscripten \
+          --disable-shared --enable-static \
+          --disable-tests \
+    && emmake make -j${N} \
+    && emmake make install \
+    && emmake make distclean
+
+# Build and install libxayagame itself (WASM parts).
+COPY . /src/libxayagame/
+WORKDIR /src/libxayagame
+RUN emcmake cmake -B build wasm \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_INSTALL_PREFIX="${WASM_PREFIX}" \
+        -DWASM_DIR="${WASM_PREFIX}" \
+    && cmake --build build -j${N} \
+    && cmake --install build \
+    && rm -rf build

--- a/wasm/docker/libglog.pc
+++ b/wasm/docker/libglog.pc
@@ -1,0 +1,8 @@
+prefix=/emsdk/upstream/emscripten/cache/sysroot
+includedir=${prefix}/include
+
+Name: libglog
+Description: glog shim for WASM builds
+Version: 0.0
+Cflags: -I${includedir}
+Libs:


### PR DESCRIPTION
This adds a Docker script (`wasm/docker/Dockerfile`) which builds an image that has the game-channel bits pre-built and installed as WASM library together with all the dependencies.