### PR TITLE
SQLite locking improvements for concurrent RPC

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,6 @@ RUN apt -y update && apt -y install --no-install-recommends \
   libzmq3-dev \
   zlib1g-dev \
   libjsoncpp-dev \
-  libsqlite3-dev \
   liblmdb-dev \
   libcurl4-openssl-dev \
   libssl-dev \
@@ -37,6 +36,15 @@ RUN apt -y update && apt -y install --no-install-recommends \
 
 # Number of parallel cores to use for make builds.
 ARG N=1
+
+# Build and install sqlite3 with custom flags.
+ARG SQLITE_VERSION="version-3.52.0"
+WORKDIR /usr/src/sqlite3
+RUN git clone https://github.com/sqlite/sqlite . \
+  && git checkout "${SQLITE_VERSION}" \
+  && ./configure --enable-session CFLAGS="-DSQLITE_ENABLE_SNAPSHOT" \
+  && make -j${N} \
+  && make install
 
 # We need to install libjson-rpc-cpp from source.
 ARG JSONRPCCPP_VERSION="v1.4.1"

--- a/README.md
+++ b/README.md
@@ -52,9 +52,12 @@ for the configuration and/or build to be successful:
 - [`zlib`](https://zlib.net):
   Available in Debian as `zlib1g-dev`.
 - [SQLite3](https://www.sqlite.org/) with the
-  [session extension](https://www.sqlite.org/sessionintro.html).
-  In Debian, the `libsqlite3-dev` package can be installed.
-  Alternatively, build from source and configure with `--enable-session`.
+  [session extension](https://www.sqlite.org/sessionintro.html)
+  and [snapshot extension](https://sqlite.org/c3ref/snapshot.html).
+  In Debian, the `libsqlite3-dev` package can not be used, as it misses
+  the snapshot extension.
+  Build from source and configure with `--enable-session`
+  and `CFLAGS="-DSQLITE_ENABLE_SNAPSHOT"`.
 - [LMDB](https://symas.com/lmdb):  Available for Debian in the
   `liblmdb-dev` package.
 - [`glog`](https://github.com/google/glog):

--- a/xayagame/sqlitegame.cpp
+++ b/xayagame/sqlitegame.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2024 The Xaya developers
+// Copyright (C) 2018-2026 The Xaya developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -708,7 +708,7 @@ SQLiteGame::GameStateUpdated (const GameStateData& state,
   std::shared_ptr<SQLiteDatabase> snapshot;
   if (upToDate)
     {
-      auto uniqueSnapshot = database->GetSnapshot ();
+      auto uniqueSnapshot = database->GetDatabase ().GetSnapshot ();
       if (uniqueSnapshot != nullptr
             && database->CheckCurrentState (*uniqueSnapshot, state))
         snapshot.reset (uniqueSnapshot.release ());
@@ -750,7 +750,7 @@ SQLiteGame::InstanceStateChanged (const Json::Value& state)
 
       const auto state = database->GetCurrentGameState ();
       EnsureCurrentState (state);
-      snapshot = database->GetSnapshot ();
+      snapshot = database->GetDatabase ().GetSnapshot ();
       if (snapshot == nullptr
             || !database->CheckCurrentState (*snapshot, state))
         {

--- a/xayagame/sqlitegame.cpp
+++ b/xayagame/sqlitegame.cpp
@@ -103,6 +103,11 @@ private:
    * The database snapshot for reading the game state.  May be null even if
    * there is a current snapshot, in which case it means that there is no game
    * state, just an instance state.
+   *
+   * This is a shared_ptr so that in-flight RPC calls (which hold a copy of
+   * this pointer) can keep the level-1 anchor connection alive independently
+   * of when a new block is processed and the snapshot replaced here.  This
+   * means Set() never needs to wait for ongoing RPC calls to finish.
    */
   std::shared_ptr<const SQLiteDatabase> database;
 
@@ -119,6 +124,9 @@ public:
   /**
    * Returns a "copy" (that can then be used without locks) of the current
    * snapshot data.  If no snapshot is stored, returns false.
+   *
+   * The database is returned as a shared_ptr; callers must keep it alive and
+   * then call GetSnapshot() on it to obtain a private per-call connection.
    */
   bool
   Get (Json::Value& inst, std::shared_ptr<const SQLiteDatabase>& db,
@@ -780,20 +788,32 @@ SQLiteGame::GetCustomStateData (
   /* If we have a state snapshot, use it to retrieve the data without
      locking the Game's lock at all.  */
   Json::Value res;
-  std::shared_ptr<const SQLiteDatabase> snapshotDb;
+  std::shared_ptr<const SQLiteDatabase> anchorDb;
   uint64_t snapshotHeight = std::numeric_limits<uint64_t>::max ();
   uint256 snapshotHash;
-  if (stateSnapshot->Get (res, snapshotDb, snapshotHeight, snapshotHash))
+  if (stateSnapshot->Get (res, anchorDb, snapshotHeight, snapshotHash))
     {
       VLOG (1) << "Using state snapshot for GetCustomStateData";
 
+      if (anchorDb == nullptr)
+        {
+          /* No actual state is present at the moment.  */
+          return res;
+        }
+
+      /* Take a fresh per-call child snapshot so that this RPC call has
+         its own private connection and does not compete for locks with
+         other RPC calls.  */
+      auto snapshotDb = anchorDb->GetSnapshot ();
       if (snapshotDb != nullptr)
         {
           CHECK_LT (snapshotHeight, std::numeric_limits<uint64_t>::max ());
           res[jsonField] = cb (*snapshotDb, snapshotHash, snapshotHeight);
+          return res;
         }
 
-      return res;
+      /* If we failed to make a copy of the snapshot to use in lock-free
+         RPC processing, fall through to the main-lock code path below.  */
     }
 
   /* Otherwise use Game::GetCustomStateData to retrieve the state

--- a/xayagame/sqlitegame.hpp
+++ b/xayagame/sqlitegame.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2024 The Xaya developers
+// Copyright (C) 2018-2026 The Xaya developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/xayagame/sqlitegame_tests.cpp
+++ b/xayagame/sqlitegame_tests.cpp
@@ -1226,6 +1226,21 @@ TEST_F (UnblockedStateExtractionTests, LongBlockUpdate)
   EXPECT_EQ (GetLastMessage ("domob", 1), "new");
 }
 
+TEST_F (UnblockedStateExtractionTests, WalCheckpointing)
+{
+  /* This test verifies that WAL checkpointing (which waits for all
+     open snapshots) correctly works also with the state snapshot stored by
+     SQLiteGame itself, and this does not lead to a deadlock.  */
+
+  FLAGS_xaya_sqlite_wal_truncate_ms = 1;
+  const auto delay
+      = std::chrono::milliseconds (2 * FLAGS_xaya_sqlite_wal_truncate_ms);
+
+  AttachBlock (game, BlockHash (12), ChatGame::Moves ({{"domob", "new"}}));
+  std::this_thread::sleep_for (delay);
+  AttachBlock (game, BlockHash (13), ChatGame::Moves ({{"andy", "new"}}));
+}
+
 /* ************************************************************************** */
 
 /**

--- a/xayagame/sqliteproc_tests.cpp
+++ b/xayagame/sqliteproc_tests.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2023 The Xaya developers
+// Copyright (C) 2022-2026 The Xaya developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -136,7 +136,6 @@ public:
   }
 
   using SQLiteStorage::GetDatabase;
-  using SQLiteStorage::GetSnapshot;
 
 };
 
@@ -201,7 +200,7 @@ protected:
     std::shared_ptr<SQLiteDatabase> snapshot;
     if (useSnapshot)
       {
-        auto uniqueSnapshot = storage.GetSnapshot ();
+        auto uniqueSnapshot = storage.GetDatabase ().GetSnapshot ();
         CHECK (uniqueSnapshot != nullptr);
         snapshot.reset (uniqueSnapshot.release ());
       }

--- a/xayagame/sqlitestorage.cpp
+++ b/xayagame/sqlitestorage.cpp
@@ -94,7 +94,6 @@ bool
 SQLiteDatabase::Statement::Step ()
 {
   CHECK (db != nullptr) << "Statement has no associated database";
-  std::lock_guard<std::mutex> lock(db->mutDb);
 
   PerformanceTimer timer;
   const int rc = sqlite3_step (**this);
@@ -338,13 +337,17 @@ SQLiteDatabase::SQLiteDatabase (const std::string& file, const int flags)
       else
         LOG (INFO) << "Configured SQLite error handler";
 
-      CHECK_EQ (sqlite3_config (SQLITE_CONFIG_MULTITHREAD, nullptr), SQLITE_OK)
-          << "Failed to enable multi-threaded mode for SQLite";
-
       sqliteInitialised = true;
     }
 
-  const int rc = sqlite3_open_v2 (file.c_str (), &db, flags, nullptr);
+  /* We open the database connection with full internal locking by SQLite
+     to make sure everything is thread safe and we do not need to worry about
+     this ourselves in edge cases.  However, between threads in libxayagame,
+     we typically use entirely separate connections anyway, such as one
+     for writing during block processing, and one for each read as part
+     of an RPC request.  */
+  const int rc = sqlite3_open_v2 (file.c_str (), &db,
+                                  flags | SQLITE_OPEN_FULLMUTEX, nullptr);
   if (rc != SQLITE_OK)
     LOG (FATAL) << "Failed to open SQLite database: " << file;
 
@@ -377,7 +380,6 @@ SQLiteDatabase::~SQLiteDatabase ()
 
   ClearStatementCache ();
 
-  std::lock_guard<std::mutex> lock(mutDb);
   CHECK (db != nullptr);
   const int rc = sqlite3_close (db);
   if (rc != SQLITE_OK)
@@ -481,13 +483,10 @@ SQLiteDatabase::PrepareRo (const std::string& sql) const
      before inserting into the map of course).  */
 
   sqlite3_stmt* stmt = nullptr;
-  ReadDatabase ([&stmt, &sql] (sqlite3* h)
-    {
-      CHECK_EQ (sqlite3_prepare_v2 (h, sql.c_str (), sql.size () + 1,
-                                    &stmt, nullptr),
-                SQLITE_OK)
-          << "Failed to prepare SQL statement";
-    });
+  CHECK_EQ (sqlite3_prepare_v2 (db, sql.c_str (), sql.size () + 1,
+                                &stmt, nullptr),
+            SQLITE_OK)
+      << "Failed to prepare SQL statement";
 
   auto entry = std::make_unique<CachedStatement> (stmt);
   entry->used.test_and_set ();

--- a/xayagame/sqlitestorage.cpp
+++ b/xayagame/sqlitestorage.cpp
@@ -320,7 +320,7 @@ SQLiteErrorLogger (void* arg, const int errCode, const char* msg)
 bool SQLiteDatabase::sqliteInitialised = false;
 
 SQLiteDatabase::SQLiteDatabase (const std::string& file, const int flags)
-  : db(nullptr)
+  : filename(file)
 {
   if (!sqliteInitialised)
     {
@@ -329,6 +329,11 @@ SQLiteDatabase::SQLiteDatabase (const std::string& file, const int flags)
           << " (library version: " << sqlite3_libversion () << ")";
       CHECK_EQ (SQLITE_VERSION_NUMBER, sqlite3_libversion_number ())
           << "Mismatch between header and library SQLite versions";
+
+      CHECK (sqlite3_compileoption_used ("ENABLE_SESSION")
+              && sqlite3_compileoption_used ("ENABLE_PREUPDATE_HOOK"))
+          << "SQLite must be compiled with SQLITE_ENABLE_SESSION"
+              " and SQLITE_ENABLE_PREUPDATE_HOOK";
 
       const int rc
           = sqlite3_config (SQLITE_CONFIG_LOG, &SQLiteErrorLogger, nullptr);
@@ -346,7 +351,7 @@ SQLiteDatabase::SQLiteDatabase (const std::string& file, const int flags)
      we typically use entirely separate connections anyway, such as one
      for writing during block processing, and one for each read as part
      of an RPC request.  */
-  const int rc = sqlite3_open_v2 (file.c_str (), &db,
+  const int rc = sqlite3_open_v2 (filename.c_str (), &db,
                                   flags | SQLITE_OPEN_FULLMUTEX, nullptr);
   if (rc != SQLITE_OK)
     LOG (FATAL) << "Failed to open SQLite database: " << file;
@@ -372,6 +377,8 @@ SQLiteDatabase::SQLiteDatabase (const std::string& file, const int flags)
 
 SQLiteDatabase::~SQLiteDatabase ()
 {
+  WaitForSnapshots ();
+
   if (parent != nullptr)
     {
       LOG (INFO) << "Ending snapshot read transaction";
@@ -400,7 +407,7 @@ SQLiteDatabase::CachedStatement::~CachedStatement ()
 }
 
 void
-SQLiteDatabase::SetReadonlySnapshot (const SQLiteStorage& p)
+SQLiteDatabase::SetReadonlySnapshot (const SQLiteDatabase& p)
 {
   CHECK (parent == nullptr);
   parent = &p;
@@ -502,6 +509,93 @@ SQLiteDatabase::PrepareRo (const std::string& sql) const
   return res;
 }
 
+void
+SQLiteDatabase::WaitForSnapshots ()
+{
+  std::unique_lock<std::mutex> lock(mutSnapshots);
+  LOG_IF (INFO, snapshots > 0)
+      << "Waiting for outstanding snapshots to be finished...";
+  waitingForSnapshots = true;
+  while (snapshots > 0)
+    cvSnapshots.wait (lock);
+  waitingForSnapshots = false;
+}
+
+std::unique_ptr<SQLiteDatabase>
+SQLiteDatabase::GetSnapshot () const
+{
+  if (!IsWalMode ())
+    {
+      LOG (WARNING) << "Snapshot is not possible for non-WAL database";
+      return nullptr;
+    }
+
+  std::lock_guard<std::mutex> lock(mutSnapshots);
+  if (waitingForSnapshots)
+    {
+      LOG (WARNING) << "Waiting for snapshots to close, can't open new one";
+      return nullptr;
+    }
+  ++snapshots;
+
+  auto res = std::make_unique<SQLiteDatabase> (filename, SQLITE_OPEN_READONLY);
+  res->SetReadonlySnapshot (*this);
+
+  return res;
+}
+
+void
+SQLiteDatabase::UnrefSnapshot () const
+{
+  std::lock_guard<std::mutex> lock(mutSnapshots);
+  CHECK_GT (snapshots, 0);
+  --snapshots;
+  if (snapshots == 0)
+    cvSnapshots.notify_all ();
+}
+
+void
+SQLiteDatabase::WalCheckpoint ()
+{
+  if (!IsWalMode ())
+    {
+      LOG_FIRST_N (WARNING, 1) << "Database is not in WAL mode";
+      return;
+    }
+
+  WaitForSnapshots ();
+  /* Make sure to clear also all prepared statements, so that the
+     database does not consider some operations still in progress
+     that might contradict the WAL truncation.  */
+  ClearStatementCache ();
+
+  /* In theory, the code above ensures that we are good to do a checkpoint,
+     with no existing open locks on the database.  However, in some usage
+     scenarios, external processes might read the database file directly,
+     and we have no control over that (but want to support these cases).
+
+     For them, the WAL checkpointing might fail with SQLITE_BUSY.  In this
+     case (and only this case), we fail gracefully, and just don't checkpoint;
+     this is not a critical issue, as we might be able to just checkpoint
+     later, and it won't cause any immediate difference to the database.  */
+  const int res = sqlite3_wal_checkpoint_v2 (db, nullptr,
+                                             SQLITE_CHECKPOINT_TRUNCATE,
+                                             nullptr, nullptr);
+  switch (res)
+    {
+    case SQLITE_BUSY:
+      LOG (WARNING)
+          << "Failed to checkpoint WAL file,"
+             " another process might be reading the database";
+      break;
+    case SQLITE_OK:
+      LOG (INFO) << "Checkpointed and truncated WAL file successfully";
+      break;
+    default:
+      LOG (FATAL) << "Error checkpointing the WAL file: " << res;
+    }
+}
+
 /* ************************************************************************** */
 
 SQLiteStorage::~SQLiteStorage ()
@@ -523,11 +617,7 @@ SQLiteStorage::OpenDatabase ()
 void
 SQLiteStorage::WaitForSnapshots ()
 {
-  std::unique_lock<std::mutex> lock(mutSnapshots);
-  LOG_IF (INFO, snapshots > 0)
-      << "Waiting for outstanding snapshots to be finished...";
-  while (snapshots > 0)
-    cvSnapshots.wait (lock);
+  db->WaitForSnapshots ();
 }
 
 void
@@ -550,34 +640,6 @@ SQLiteStorage::GetDatabase () const
 {
   CHECK (db != nullptr);
   return *db;
-}
-
-std::unique_ptr<SQLiteDatabase>
-SQLiteStorage::GetSnapshot () const
-{
-  CHECK (db != nullptr);
-  if (!db->IsWalMode ())
-    {
-      LOG (WARNING) << "Snapshot is not possible for non-WAL database";
-      return nullptr;
-    }
-
-  std::lock_guard<std::mutex> lock(mutSnapshots);
-  ++snapshots;
-
-  auto res = std::make_unique<SQLiteDatabase> (filename, SQLITE_OPEN_READONLY);
-  res->SetReadonlySnapshot (*this);
-
-  return res;
-}
-
-void
-SQLiteStorage::UnrefSnapshot () const
-{
-  std::lock_guard<std::mutex> lock(mutSnapshots);
-  CHECK_GT (snapshots, 0);
-  --snapshots;
-  cvSnapshots.notify_all ();
 }
 
 void
@@ -775,55 +837,17 @@ SQLiteStorage::CommitTransaction ()
       const auto intv
           = std::chrono::milliseconds (FLAGS_xaya_sqlite_wal_truncate_ms);
       if (lastWalCheckpoint + intv <= Clock::now ())
-        WalCheckpoint ();
-    }
-}
-
-void
-SQLiteStorage::WalCheckpoint ()
-{
-  CHECK (db != nullptr);
-  CHECK (!startedTransaction);
-
-  LOG (INFO) << "Attempting periodic WAL checkpointing...";
-  lastWalCheckpoint = Clock::now ();
-
-  if (!db->IsWalMode ())
-    {
-      LOG_FIRST_N (WARNING, 1) << "Database is not in WAL mode";
-      return;
-    }
-
-  WaitForSnapshots ();
-  /* Make sure to clear also all prepared statements, so that the
-     database does not consider some operations still in progress
-     that might contradict the WAL truncation.  */
-  db->ClearStatementCache ();
-
-  /* In theory, the code above ensures that we are good to do a checkpoint,
-     with no existing open locks on the database.  However, in some usage
-     scenarios, external processes might read the database file directly,
-     and we have no control over that (but want to support these cases).
-
-     For them, the WAL checkpointing might fail with SQLITE_BUSY.  In this
-     case (and only this case), we fail gracefully, and just don't checkpoint;
-     this is not a critical issue, as we might be able to just checkpoint
-     later, and it won't cause any immediate difference to the database.  */
-  const int res = sqlite3_wal_checkpoint_v2 (db->db, nullptr,
-                                             SQLITE_CHECKPOINT_TRUNCATE,
-                                             nullptr, nullptr);
-  switch (res)
-    {
-    case SQLITE_BUSY:
-      LOG (WARNING)
-          << "Failed to checkpoint WAL file,"
-             " another process might be reading the database";
-      break;
-    case SQLITE_OK:
-      LOG (INFO) << "Checkpointed and truncated WAL file successfully";
-      break;
-    default:
-      LOG (FATAL) << "Error checkpointing the WAL file: " << res;
+        {
+          LOG (INFO) << "Attempting periodic WAL checkpointing...";
+          lastWalCheckpoint = Clock::now ();
+          /* SQLiteDatabase::WalCheckpoint waits for outstanding snapshots,
+             but in SQLiteGame, we also have the long-lived state snapshot
+             and waiting for it would deadlock.  Our own WaitForSnapshots
+             method clears that snapshot explicitly, which is what we need
+             here to prevent the deadlock.  */
+          WaitForSnapshots ();
+          db->WalCheckpoint ();
+        }
     }
 }
 

--- a/xayagame/sqlitestorage.cpp
+++ b/xayagame/sqlitestorage.cpp
@@ -334,6 +334,8 @@ SQLiteDatabase::SQLiteDatabase (const std::string& file, const int flags)
               && sqlite3_compileoption_used ("ENABLE_PREUPDATE_HOOK"))
           << "SQLite must be compiled with SQLITE_ENABLE_SESSION"
               " and SQLITE_ENABLE_PREUPDATE_HOOK";
+      CHECK (sqlite3_compileoption_used ("ENABLE_SNAPSHOT"))
+          << "SQLite must be compiled with SQLITE_ENABLE_SNAPSHOT";
 
       const int rc
           = sqlite3_config (SQLITE_CONFIG_LOG, &SQLiteErrorLogger, nullptr);
@@ -367,6 +369,14 @@ SQLiteDatabase::SQLiteDatabase (const std::string& file, const int flags)
     {
       LOG (INFO) << "Set database to WAL mode";
       walMode = true;
+
+      /* Disable automatic checkpointing.  We handle WAL truncation explicitly
+         via WalCheckpoint(), which coordinates with snapshot creation via the
+         mutSnapshots lock.  SQLite's built-in autocheckpoint fires at arbitrary
+         commit points and holds the exclusive CKPT lock without any
+         coordination with our snapshot machinery, which causes SQLITE_BUSY
+         errors in sqlite3_snapshot_open().  */
+      CHECK_EQ (sqlite3_wal_autocheckpoint (db, 0), SQLITE_OK);
     }
   else
     {
@@ -383,6 +393,12 @@ SQLiteDatabase::~SQLiteDatabase ()
     {
       LOG (INFO) << "Ending snapshot read transaction";
       PrepareRo ("ROLLBACK").Execute ();
+    }
+
+  if (sqliteSnapshot != nullptr && ownsSqliteSnapshot)
+    {
+      sqlite3_snapshot_free (sqliteSnapshot);
+      sqliteSnapshot = nullptr;
     }
 
   ClearStatementCache ();
@@ -407,18 +423,59 @@ SQLiteDatabase::CachedStatement::~CachedStatement ()
 }
 
 void
-SQLiteDatabase::SetReadonlySnapshot (const SQLiteDatabase& p)
+SQLiteDatabase::SetReadonlySnapshot (const SQLiteDatabase& p,
+                                     sqlite3_snapshot* atSnap)
 {
-  CHECK (parent == nullptr);
+  CHECK (parent == nullptr && sqliteSnapshot == nullptr);
   parent = &p;
   LOG (INFO) << "Starting read transaction for snapshot";
 
-  /* There is no way to do an "immediate" read transaction.  Thus we have
-     to start a default deferred one, and then issue some SELECT query
-     that we don't really care about and that is guaranteed to work.  */
-
+  /* We need to exit auto-commit mode and start a deferred read transaction
+     for the entire lifespan of this snapshot (it is ROLLBACK'ed in the
+     destructor).  */
   PrepareRo ("BEGIN").Execute ();
 
+  /* If we want to anchor the transaction to a particular snapshot
+     from the parent database, open it now.  */
+  if (atSnap != nullptr)
+    CHECK_EQ (sqlite3_snapshot_open (db, "main", atSnap), SQLITE_OK)
+        << "Failed to open parent snapshot position";
+
+  /* Get a WAL snapshot for this exact state of the database.  This is used
+     for getting future child snapshots of this database, which should be
+     exact "copies".  This locks in the actual WAL position and starts the
+     read transaction deferred above.  */
+  CHECK (IsWalMode ()) << "Read-only snapshots only work in WAL mode";
+  if (atSnap == nullptr)
+    {
+      /* Fresh snapshot from the live database: ask SQLite for the current
+         WAL position.  This may fail, for instance if there is no physical
+         WAL file on disk yet.  In that case, we cannot record a WAL token;
+         the snapshot itself is valid and can be used, but it cannot be
+         "copied" to child snapshots.  */
+      const int sqliteRes = sqlite3_snapshot_get (db, "main", &sqliteSnapshot);
+      if (sqliteRes != SQLITE_OK)
+        {
+          LOG (WARNING) << "Failed to record SQLite snapshot: " << sqliteRes;
+          sqliteSnapshot = nullptr;
+        }
+      ownsSqliteSnapshot = true;
+    }
+  else
+    {
+      /* This connection was opened at an existing snapshot via
+         sqlite3_snapshot_open.  sqlite3_snapshot_get does not work after
+         snapshot_open on the same connection.  Instead, we store a non-owning
+         pointer to the parent's snapshot token directly: the parent is
+         guaranteed to outlive this connection by the snapshots reference
+         count, so the pointer remains valid for as long as we need it.  */
+      sqliteSnapshot = atSnap;
+      ownsSqliteSnapshot = false;
+    }
+
+  /* Make sure to start a read transaction, in case we didn't do so yet
+     with the sqlite3_snapshot_get call, which may not have happened
+     or succeeded in all code paths.  */
   auto stmt = PrepareRo ("SELECT COUNT(*) FROM `sqlite_master`");
   CHECK (stmt.Step ());
   CHECK (!stmt.Step ());
@@ -530,6 +587,14 @@ SQLiteDatabase::GetSnapshot () const
       return nullptr;
     }
 
+  /* If this is a snapshot itself but has no SQLite WAL snapshot token, we
+     cannot produce a copy of it.  */
+  if (parent != nullptr && sqliteSnapshot == nullptr)
+    {
+      LOG (WARNING) << "Snapshot without WAL snapshot token cannot be copied";
+      return nullptr;
+    }
+
   std::lock_guard<std::mutex> lock(mutSnapshots);
   if (waitingForSnapshots)
     {
@@ -539,7 +604,7 @@ SQLiteDatabase::GetSnapshot () const
   ++snapshots;
 
   auto res = std::make_unique<SQLiteDatabase> (filename, SQLITE_OPEN_READONLY);
-  res->SetReadonlySnapshot (*this);
+  res->SetReadonlySnapshot (*this, sqliteSnapshot);
 
   return res;
 }

--- a/xayagame/sqlitestorage.cpp
+++ b/xayagame/sqlitestorage.cpp
@@ -566,16 +566,25 @@ SQLiteDatabase::PrepareRo (const std::string& sql) const
   return res;
 }
 
-void
+SQLiteDatabase::SnapshotGate::SnapshotGate (SQLiteDatabase& d)
+  : db(d), lock(d.mutSnapshots)
+{
+  LOG_IF (INFO, db.snapshots > 0)
+      << "Waiting for outstanding snapshots to be finished...";
+  db.waitingForSnapshots = true;
+  while (db.snapshots > 0)
+    db.cvSnapshots.wait (lock);
+}
+
+SQLiteDatabase::SnapshotGate::~SnapshotGate ()
+{
+  db.waitingForSnapshots = false;
+}
+
+std::unique_ptr<SQLiteDatabase::SnapshotGate>
 SQLiteDatabase::WaitForSnapshots ()
 {
-  std::unique_lock<std::mutex> lock(mutSnapshots);
-  LOG_IF (INFO, snapshots > 0)
-      << "Waiting for outstanding snapshots to be finished...";
-  waitingForSnapshots = true;
-  while (snapshots > 0)
-    cvSnapshots.wait (lock);
-  waitingForSnapshots = false;
+  return std::make_unique<SnapshotGate> (*this);
 }
 
 std::unique_ptr<SQLiteDatabase>
@@ -628,7 +637,11 @@ SQLiteDatabase::WalCheckpoint ()
       return;
     }
 
-  WaitForSnapshots ();
+  /* Hold the gate for the entire duration of the checkpoint to ensure
+     that no new snapshots are created until after the checkpointing
+     operation is finished.  */
+  const auto gate = WaitForSnapshots ();
+
   /* Make sure to clear also all prepared statements, so that the
      database does not consider some operations still in progress
      that might contradict the WAL truncation.  */

--- a/xayagame/sqlitestorage.hpp
+++ b/xayagame/sqlitestorage.hpp
@@ -64,6 +64,24 @@ private:
   const SQLiteDatabase* parent = nullptr;
 
   /**
+   * If this is a read-only snapshot of a parent database, then this
+   * records the SQLite-level WAL snapshot data it corresponds to.
+   *
+   * In some situations (such as no WAL file present on disk when snapshotting),
+   * taking a snapshot fails, so this may be null even if this instance is
+   * itself a snapshot.  Then the snapshot by itself works, but cannot be
+   * "copied" any further.
+   */
+  sqlite3_snapshot* sqliteSnapshot = nullptr;
+
+  /**
+   * Whether or not the sqliteSnapshot is owned by this instance (should be
+   * free'd in the destructor) or is just a reference to the parent's
+   * snapshot instead.
+   */
+  bool ownsSqliteSnapshot;
+
+  /**
    * Mutex protecting the statement cache (but not the statements
    * themselves inside, which are given out thread local).
    */
@@ -99,8 +117,11 @@ private:
    * called, this starts a read transaction to ensure that the current view is
    * preserved for all future queries.  It also registers this as outstanding
    * snapshot with the parent.
+   *
+   * Optionally, an existing snapshot (from the parent) can be used to
+   * anchor the read transaction for this snapshot to.
    */
-  void SetReadonlySnapshot (const SQLiteDatabase& p);
+  void SetReadonlySnapshot (const SQLiteDatabase& p, sqlite3_snapshot* atSnap);
 
   /**
    * Clears the cache of prepared statements.

--- a/xayagame/sqlitestorage.hpp
+++ b/xayagame/sqlitestorage.hpp
@@ -21,8 +21,6 @@
 namespace xaya
 {
 
-class SQLiteStorage;
-
 /**
  * Wrapper around an SQLite database connection.  This object mostly holds
  * an sqlite3* handle (that is owned and managed by it), but it also
@@ -43,11 +41,17 @@ private:
   static bool sqliteInitialised;
 
   /**
+   * Filename of the underlying SQLite file.  This is used to re-open it for
+   * snapshots.
+   */
+  const std::string filename;
+
+  /**
    * The SQLite database handle, which is owned and managed by the
    * current instance.  It will be opened in the constructor, and
    * finalised in the destructor.
    */
-  sqlite3* db;
+  sqlite3* db = nullptr;
 
   /**
    * Whether or not we have WAL mode on the database.  This is required
@@ -56,8 +60,8 @@ private:
    */
   bool walMode;
 
-  /** The "parent" storage if this is a read-only snapshot.  */
-  const SQLiteStorage* parent = nullptr;
+  /** The "parent" database if this is a read-only snapshot.  */
+  const SQLiteDatabase* parent = nullptr;
 
   /**
    * Mutex protecting the statement cache (but not the statements
@@ -74,17 +78,39 @@ private:
       preparedStatements;
 
   /**
-   * Marks this is a read-only snapshot (with the given parent storage).  When
+   * Number of outstanding snapshots.  This has to drop to zero before
+   * we can close the database.
+   */
+  mutable unsigned snapshots = 0;
+
+  /**
+   * Set to true while waiting for snapshots to drop to zero (WaitForSnapshots),
+   * prevents new snapshots from being created.
+   */
+  bool waitingForSnapshots = false;
+
+  /** Mutex for the snapshot number.  */
+  mutable std::mutex mutSnapshots;
+  /** Condition variable for waiting for snapshot unrefs.  */
+  mutable std::condition_variable cvSnapshots;
+
+  /**
+   * Marks this is a read-only snapshot (with the given parent database).  When
    * called, this starts a read transaction to ensure that the current view is
    * preserved for all future queries.  It also registers this as outstanding
    * snapshot with the parent.
    */
-  void SetReadonlySnapshot (const SQLiteStorage& p);
+  void SetReadonlySnapshot (const SQLiteDatabase& p);
 
   /**
    * Clears the cache of prepared statements.
    */
   void ClearStatementCache ();
+
+  /**
+   * Decrements the count of outstanding snapshots.
+   */
+  void UnrefSnapshot () const;
 
   /**
    * Returns whether or not the database is using WAL mode.
@@ -94,8 +120,6 @@ private:
   {
     return walMode;
   }
-
-  friend class SQLiteStorage;
 
 public:
 
@@ -158,6 +182,24 @@ public:
    * is meant for statements that are read-only, i.e. SELECT.
    */
   Statement PrepareRo (const std::string& sql) const;
+
+  /**
+   * Performs an explicit WAL checkpoint.
+   */
+  void WalCheckpoint ();
+
+  /**
+   * Blocks until no child snapshots are open.
+   */
+  void WaitForSnapshots ();
+
+  /**
+   * Creates a read-only snapshot of the underlying database and returns
+   * the corresponding SQLiteDatabase instance.  May return NULL if the
+   * underlying database is not using WAL mode (e.g. in-memory) or some
+   * other condition prevents snapshot creation.
+   */
+  std::unique_ptr<SQLiteDatabase> GetSnapshot () const;
 
 };
 
@@ -350,17 +392,6 @@ private:
    */
   bool startedTransaction = false;
 
-  /**
-   * Number of outstanding snapshots.  This has to drop to zero before
-   * we can close the database.
-   */
-  mutable unsigned snapshots = 0;
-
-  /** Mutex for the snapshot number.  */
-  mutable std::mutex mutSnapshots;
-  /** Condition variable for waiting for snapshot unrefs.  */
-  mutable std::condition_variable cvSnapshots;
-
   /** Clock used for timing the WAL checkpointing.  */
   using Clock = std::chrono::steady_clock;
   /** Last time when we did a WAL checkpoint.  */
@@ -371,18 +402,6 @@ private:
    * database is already opened.
    */
   void OpenDatabase ();
-
-  /**
-   * Decrements the count of outstanding snapshots.
-   */
-  void UnrefSnapshot () const;
-
-  /**
-   * Performs an explicit WAL checkpoint.
-   */
-  void WalCheckpoint ();
-
-  friend class SQLiteDatabase;
 
 protected:
 
@@ -414,13 +433,6 @@ protected:
    * Returns the underlying SQLiteDatabase instance.
    */
   const SQLiteDatabase& GetDatabase () const;
-
-  /**
-   * Creates a read-only snapshot of the underlying database and returns
-   * the corresponding SQLiteDatabase instance.  May return NULL if the
-   * underlying database is not using WAL mode (e.g. in-memory).
-   */
-  std::unique_ptr<SQLiteDatabase> GetSnapshot () const;
 
   /**
    * Returns the current block hash (if any) for the given database connection.

--- a/xayagame/sqlitestorage.hpp
+++ b/xayagame/sqlitestorage.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2023 The Xaya developers
+// Copyright (C) 2018-2026 The Xaya developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -43,14 +43,6 @@ private:
   static bool sqliteInitialised;
 
   /**
-   * Mutex for access to db itself.  We configure the database to be in
-   * multi-thread mode (rather than serialised) since statements are
-   * created for single-thread use anyway, and thus have to explicitly
-   * synchronise any direct access to db.
-   */
-  mutable std::mutex mutDb;
-
-  /**
    * The SQLite database handle, which is owned and managed by the
    * current instance.  It will be opened in the constructor, and
    * finalised in the destructor.
@@ -69,13 +61,13 @@ private:
 
   /**
    * Mutex protecting the statement cache (but not the statements
-   * themselves inside, which have their own locks).
+   * themselves inside, which are given out thread local).
    */
   mutable std::mutex mutPreparedStatements;
 
   /**
    * A cache of prepared statements (mapping from the SQL command to the
-   * statement plus lock).  One SQL string may point to multiple cached
+   * statement).  One SQL string may point to multiple cached
    * entries, in case some of them are currently in use.
    */
   mutable std::multimap<std::string, std::unique_ptr<CachedStatement>>
@@ -119,15 +111,14 @@ public:
   ~SQLiteDatabase ();
 
   /**
-   * Executes a given callback with access to the raw database handle, ensuring
-   * necessary locking.  This should typically only be used for select use
-   * cases; most operations should go through Prepare instead.
+   * Executes a given callback with access to the raw database handle.
+   * This should typically only be used for select use cases; most operations
+   * should go through Prepare instead.
    */
   template <typename Fcn>
     auto
     AccessDatabase (const Fcn& cb)
   {
-    std::lock_guard<std::mutex> lock(mutDb);
     return cb (db);
   }
 
@@ -140,7 +131,6 @@ public:
     auto
     ReadDatabase (const Fcn& cb) const
   {
-    std::lock_guard<std::mutex> lock(mutDb);
     return cb (db);
   }
 

--- a/xayagame/sqlitestorage.hpp
+++ b/xayagame/sqlitestorage.hpp
@@ -36,6 +36,7 @@ public:
 private:
 
   struct CachedStatement;
+  class SnapshotGate;
 
   /** Whether or not we have already initialised SQLite.  */
   static bool sqliteInitialised;
@@ -210,9 +211,13 @@ public:
   void WalCheckpoint ();
 
   /**
-   * Blocks until no child snapshots are open.
+   * Blocks until no child snapshots are open, then returns a SnapshotGate
+   * that keeps the gate closed (preventing new snapshots from being created)
+   * for as long as the caller holds the returned object.  Discarding the
+   * return value immediately closes the gate again, which is the right
+   * behaviour for callers that only need to drain existing snapshots.
    */
-  void WaitForSnapshots ();
+  std::unique_ptr<SnapshotGate> WaitForSnapshots ();
 
   /**
    * Creates a read-only snapshot of the underlying database and returns
@@ -253,6 +258,29 @@ struct SQLiteDatabase::CachedStatement
    * Cleans up the SQLite statement and ensures the statement is not in use.
    */
   ~CachedStatement ();
+
+};
+
+/**
+ * RAII gate that keeps waitingForSnapshots=true and mutSnapshots locked
+ * for its entire lifetime.  Constructed only by WaitForSnapshots().
+ */
+class SQLiteDatabase::SnapshotGate
+{
+
+private:
+
+  SQLiteDatabase& db;
+  std::unique_lock<std::mutex> lock;
+
+public:
+
+  explicit SnapshotGate (SQLiteDatabase& db);
+  ~SnapshotGate ();
+
+  SnapshotGate () = delete;
+  SnapshotGate (const SnapshotGate&) = delete;
+  void operator= (const SnapshotGate&) = delete;
 
 };
 

--- a/xayagame/sqlitestorage_tests.cpp
+++ b/xayagame/sqlitestorage_tests.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2024 The Xaya developers
+// Copyright (C) 2018-2026 The Xaya developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -370,7 +370,12 @@ protected:
 
     using SQLiteStorage::SQLiteStorage;
     using SQLiteStorage::GetDatabase;
-    using SQLiteStorage::GetSnapshot;
+
+    std::unique_ptr<SQLiteDatabase>
+    GetSnapshot () const
+    {
+      return GetDatabase ().GetSnapshot ();
+    }
 
   };
 
@@ -501,56 +506,6 @@ TEST_F (SQLiteStorageSnapshotTests, StatementsMustAllBeDestructed)
      should CHECK fail.  At the end of the test scope, the statement
      will be destructed before the snapshot, which is fine.  */
   EXPECT_DEATH (s.reset (), "statement is still in use");
-}
-
-TEST_F (SQLiteStorageSnapshotTests, OneSnapshotMultipleThreads)
-{
-  /* It is possible to use one snapshot from multiple threads, and this should
-     not cause any specific congestion.  Just when a statement is prepared
-     should there be a lock, but then processing a statement should not block
-     other threads from also doing something on the snapshot.  */
-
-  Storage storage(file.GetName ());
-  storage.Initialise ();
-  storage.GetDatabase ().Execute (R"(
-    CREATE TABLE `foo` (`id` INTEGER NOT NULL PRIMARY KEY);
-    INSERT INTO `foo` (`id`) VALUES (1), (2), (3);
-  )");
-
-  auto snapshot = storage.GetSnapshot ();
-  storage.GetDatabase ().Execute (R"(
-    DELETE FROM `foo`
-  )");
-
-  constexpr auto sleep = std::chrono::milliseconds (100);
-
-  PerformanceTimer timer;
-  std::vector<std::thread> threads;
-  for (unsigned i = 0; i < 10; ++i)
-    threads.emplace_back ([&] ()
-      {
-        auto stmt = snapshot->PrepareRo (R"(
-          SELECT `id`
-            FROM `foo`
-            ORDER BY `id`
-        )");
-
-        for (unsigned j = 1; j <= 3; ++j)
-          {
-            std::this_thread::sleep_for (sleep);
-            ASSERT_TRUE (stmt.Step ());
-            ASSERT_EQ (stmt.Get<int64_t> (0), j);
-          }
-
-        ASSERT_FALSE (stmt.Step ());
-      });
-  for (auto& t : threads)
-    t.join ();
-  timer.Stop ();
-
-  const auto dur = timer.Get<std::chrono::milliseconds> ();
-  EXPECT_GT (dur, 2 * sleep);
-  EXPECT_LT (dur, 4 * sleep);
 }
 
 /* ************************************************************************** */

--- a/xayagame/sqlitestorage_tests.cpp
+++ b/xayagame/sqlitestorage_tests.cpp
@@ -449,10 +449,16 @@ TEST_F (SQLiteStorageSnapshotTests, MultipleSnapshots)
   storage.CommitTransaction ();
   auto s4 = storage.GetSnapshot ();
 
+  /* Get a second-level snapshot ("copy" of existing snapshot s2),
+     which should reflect the original state of that snapshot in a new
+     database instance.  */
+  auto s5 = s2->GetSnapshot ();
+
   ExpectDatabaseState (*s1, "");
   ExpectDatabaseState (*s2, "first");
   ExpectDatabaseState (*s3, "first");
   ExpectDatabaseState (*s4, "second");
+  ExpectDatabaseState (*s5, "first");
   ExpectDatabaseState (storage.GetDatabase (), "second");
 }
 


### PR DESCRIPTION
The existing logic had some issues when many concurrent RPC calls were using the same read-only SQLite database snapshot for their logic (lock contention for some operations, and missing locks / race conditions for some others).  This set of changes provides a comprehensive fix:

- We use `FULLMUTEX` mode for all SQLite databases (SQLite handles locking correctly) instead of our own custom locking logic.  This prevents actual locking bugs and race conditions.
- We use the [SQLite snapshot extension](https://sqlite.org/c3ref/snapshot.html), which allows us to effectively "copy" an existing read snapshot.  With this, we give each RPC processor its own, private database connection, so that there is no lock contention with any other RPC threads.

Both changes together should make the code more robust and stable on one hand, and also more performant on the other.