### PR TITLE
Make getnullstate unblocked

### DIFF
--- a/xayagame/game.cpp
+++ b/xayagame/game.cpp
@@ -789,7 +789,18 @@ Game::NotifyInstanceStateChanged () const
   uint256 hash;
   unsigned height;
   const auto state = UnlockedGetInstanceStateJson (hash, height);
+  /* InstanceStateChanged must be called first, before updating the cache.
+     This is because InstanceStateChanged (e.g. in SQLiteGame) is where the
+     read-only database snapshot gets updated to reflect the new block.  If we
+     updated cachedNullState first, a concurrent GetNullJsonState caller could
+     observe the new block hash in the cache and immediately call a state RPC,
+     which would still read the old snapshot and return inconsistent data.  */
   rules->InstanceStateChanged (state);
+  {
+    std::lock_guard<std::mutex> lock(mutNullState);
+    VLOG (1) << "Updating cached instance 'null' state:\n" << state;
+    cachedNullState = state;
+  }
 }
 
 Json::Value
@@ -860,6 +871,14 @@ Game::GetCurrentJsonState () const
 Json::Value
 Game::GetNullJsonState () const
 {
+  {
+    std::lock_guard<std::mutex> lock(mutNullState);
+    if (!cachedNullState.isNull ())
+      return cachedNullState;
+  }
+
+  /* Fall back to the full locked path if the cache is not yet populated
+     (i.e. before the first call to NotifyInstanceStateChanged).  */
   Json::Value res = GetCustomStateData ("data",
       [] (const GameStateData& state)
         {

--- a/xayagame/game.hpp
+++ b/xayagame/game.hpp
@@ -218,6 +218,26 @@ private:
   /** The coprocessor batch we use to handle coprocessors during blocks.  */
   CoprocessorBatch coproc;
 
+  /**
+   * Mutex protecting cachedNullState.  This is a separate, subordinate lock
+   * that is only ever acquired while mut is already held (when writing) or
+   * instead of mut (when reading in GetNullJsonState).  This ensures that
+   * GetNullJsonState never needs to acquire the main mut lock.
+   */
+  mutable std::mutex mutNullState;
+
+  /**
+   * Cached result of the last GetNullJsonState-equivalent computation, i.e.
+   * the instance state JSON (gameid, chain, state, blockhash, height).
+   * Updated in NotifyInstanceStateChanged while mut is held.  Empty until
+   * the first call to NotifyInstanceStateChanged.
+   *
+   * We use a cache here to provide fast, unblocked (on main game lock)
+   * access to getnullstate, e.g. for state polling, which works well
+   * even when catching up.
+   */
+  mutable Json::Value cachedNullState;
+
   void BlockAttach (const std::string& id, const Json::Value& data,
                     bool seqMismatch) override;
   void BlockDetach (const std::string& id, const Json::Value& data,

--- a/xayagame/game_tests.cpp
+++ b/xayagame/game_tests.cpp
@@ -809,6 +809,55 @@ TEST_F (GetCurrentJsonStateTests, HeightResolvedViaRpc)
   EXPECT_EQ (state["gamestate"]["state"], "");
 }
 
+TEST_F (GetCurrentJsonStateTests, NullStateUnblocked)
+{
+  mockXayaServer->SetBestBlock (GAME_GENESIS_HEIGHT,
+                                TestGame::GenesisBlockHash ());
+  ReinitialiseState (g);
+  SetStartingBlock (GAME_GENESIS_HEIGHT, TestGame::GenesisBlockHash ());
+  AttachBlock (g, BlockHash (11), Moves ("a0b1"));
+
+  std::atomic<bool> longCallStarted;
+  std::atomic<bool> longCallDone;
+  longCallStarted = false;
+  longCallDone = false;
+
+  /* Hold the game lock for a long time with a slow GetCustomStateData
+     call, simulating a long block update or slow RPC handler.  */
+  std::thread longCall([&] ()
+    {
+      g.GetCustomStateData ("data",
+          [&] (const GameStateData& state,
+               const uint256& hash, const unsigned height,
+               std::unique_lock<std::mutex> lock)
+          {
+            LOG (INFO) << "Long call: holding lock";
+            longCallStarted = true;
+            std::this_thread::sleep_for (std::chrono::milliseconds (100));
+            LOG (INFO) << "Long call: releasing lock";
+            return Json::Value ();
+          });
+      longCallDone = true;
+    });
+
+  while (!longCallStarted)
+    std::this_thread::sleep_for (std::chrono::milliseconds (1));
+
+  /* GetNullJsonState must return immediately from the cache without waiting
+     for the long call to release the game lock.  */
+  const Json::Value nullState = g.GetNullJsonState ();
+  EXPECT_FALSE (longCallDone);
+
+  EXPECT_EQ (nullState["gameid"], GAME_ID);
+  EXPECT_EQ (nullState["chain"], "main");
+  EXPECT_EQ (nullState["state"], "up-to-date");
+  EXPECT_EQ (nullState["blockhash"], BlockHash (11).ToHex ());
+  EXPECT_EQ (nullState["height"].asInt (), 11);
+  EXPECT_FALSE (nullState.isMember ("data"));
+
+  longCall.join ();
+}
+
 TEST_F (GetCurrentJsonStateTests, CallbackUnblocked)
 {
   mockXayaServer->SetBestBlock (GAME_GENESIS_HEIGHT,


### PR DESCRIPTION
This updates `Game::GetNullJsonState()` to use a cached JSON value of the basic state, similar to the general database snapshot / cache used with SQLite games.

With this, most of the time (including when the GSP is catching up) `getnullstate` will be able to return without waiting for the main game mutex, which is useful for instance for state polling.