### PR TITLE
Add GetCustomInstanceStateJson hook

### DIFF
--- a/xayagame/game.cpp
+++ b/xayagame/game.cpp
@@ -780,6 +780,15 @@ Game::UnlockedGetInstanceStateJson (uint256& hash, unsigned& height) const
   res["blockhash"] = hash.ToHex ();
   res["height"] = height;
 
+  if (rules != nullptr)
+    {
+      const auto gameState = storage->GetCurrentGameState ();
+      const Json::Value custom
+          = rules->GetCustomInstanceStateJson (hash, height, gameState);
+      if (!custom.isNull ())
+        res["custom"] = custom;
+    }
+
   return res;
 }
 

--- a/xayagame/game_tests.cpp
+++ b/xayagame/game_tests.cpp
@@ -777,6 +777,7 @@ TEST_F (GetCurrentJsonStateTests, WhenUpToDate)
   EXPECT_EQ (state["blockhash"], BlockHash (11).ToHex ());
   EXPECT_EQ (state["height"].asInt (), 11);
   EXPECT_EQ (state["gamestate"]["state"], "a0b1");
+  EXPECT_FALSE (state.isMember ("custom"));
 }
 
 TEST_F (GetCurrentJsonStateTests, HeightResolvedViaRpc)
@@ -854,6 +855,7 @@ TEST_F (GetCurrentJsonStateTests, NullStateUnblocked)
   EXPECT_EQ (nullState["blockhash"], BlockHash (11).ToHex ());
   EXPECT_EQ (nullState["height"].asInt (), 11);
   EXPECT_FALSE (nullState.isMember ("data"));
+  EXPECT_FALSE (nullState.isMember ("custom"));
 
   longCall.join ();
 }
@@ -895,6 +897,50 @@ TEST_F (GetCurrentJsonStateTests, CallbackUnblocked)
 
   EXPECT_FALSE (firstDone);
   first.join ();
+}
+
+TEST_F (GetCurrentJsonStateTests, CustomInstanceState)
+{
+  class : public TestGame
+  {
+  public:
+
+    using TestGame::TestGame;
+
+    Json::Value
+    GetCustomInstanceStateJson (const uint256& hash, unsigned height,
+                                const GameStateData& state) override
+    {
+      Json::Value res(Json::objectValue);
+      res["data"] = "custom-value";
+      res["hash"] = hash.ToHex ();
+      return res;
+    }
+
+  } customRules;
+
+  mockXayaServer->SetBestBlock (GAME_GENESIS_HEIGHT,
+                                TestGame::GenesisBlockHash ());
+  ReinitialiseState (g);
+
+  Game freshGame(GAME_ID);
+  ConnectToMockRpc (freshGame);
+  freshGame.SetStorage (storage);
+  freshGame.SetGameLogic (customRules);
+
+  ReinitialiseState (freshGame);
+  SetStartingBlock (GAME_GENESIS_HEIGHT, TestGame::GenesisBlockHash ());
+  AttachBlock (freshGame, BlockHash (10), Moves ("a0"));
+  ForceState (freshGame, State::UP_TO_DATE);
+
+  const Json::Value currentState = freshGame.GetCurrentJsonState ();
+  ASSERT_TRUE (currentState.isMember ("custom"));
+  EXPECT_EQ (currentState["custom"]["data"], "custom-value");
+  EXPECT_EQ (currentState["custom"]["hash"], BlockHash (10).ToHex ());
+
+  const Json::Value nullState = freshGame.GetNullJsonState ();
+  ASSERT_TRUE (nullState.isMember ("custom"));
+  EXPECT_EQ (nullState["custom"], currentState["custom"]);
 }
 
 /* ************************************************************************** */

--- a/xayagame/gamelogic.hpp
+++ b/xayagame/gamelogic.hpp
@@ -414,6 +414,19 @@ public:
    */
   virtual Json::Value GameStateToJson (const GameStateData& state);
 
+  /**
+   * Constructs a custom portion of the instance state JSON.  The result,
+   * if non-null, is included as a "custom" field in the instance state JSON.
+   *
+   * The default returns null, which means no "custom" field is included.
+   */
+  virtual Json::Value
+  GetCustomInstanceStateJson (const uint256& hash, unsigned height,
+                              const GameStateData& state)
+  {
+    return Json::Value ();
+  }
+
 };
 
 /**

--- a/xayagame/sqlitegame.cpp
+++ b/xayagame/sqlitegame.cpp
@@ -457,7 +457,7 @@ SQLiteGame::SQLiteGame ()
 SQLiteGame::~SQLiteGame () = default;
 
 void
-SQLiteGame::EnsureCurrentState (const GameStateData& state)
+SQLiteGame::EnsureCurrentState (const GameStateData& state) const
 {
   CHECK (database != nullptr) << "SQLiteGame has not been initialised";
   CHECK (database->CheckCurrentState (database->GetDatabase (), state))
@@ -778,6 +778,22 @@ SQLiteGame::GameStateToJson (const GameStateData& state)
 {
   EnsureCurrentState (state);
   return GetStateAsJson (database->GetDatabase ());
+}
+
+Json::Value
+SQLiteGame::GetCustomInstanceStateJson (const uint256& hash, unsigned height,
+                                        const GameStateData& state)
+{
+  CHECK (database != nullptr) << "SQLiteGame has not been initialised";
+  EnsureCurrentState (state);
+  return GetCustomInstanceState (database->GetDatabase (), hash, height);
+}
+
+Json::Value
+SQLiteGame::GetCustomInstanceState (const SQLiteDatabase& db,
+                                    const uint256& hash, unsigned height)
+{
+  return Json::Value ();
 }
 
 Json::Value

--- a/xayagame/sqlitegame.hpp
+++ b/xayagame/sqlitegame.hpp
@@ -117,7 +117,7 @@ private:
    * Ensures that the current state of the database matches the passed in
    * "fake game state".
    */
-  void EnsureCurrentState (const GameStateData& state);
+  void EnsureCurrentState (const GameStateData& state) const;
 
 protected:
 
@@ -182,6 +182,18 @@ protected:
   virtual Json::Value GetStateAsJson (const SQLiteDatabase& db) = 0;
 
   /**
+   * Constructs a custom portion of the instance state JSON from the
+   * database.  This can be overridden by subclasses to add custom data
+   * to the instance state.
+   *
+   * The default implementation returns null, meaning no custom data
+   * is included.
+   */
+  virtual Json::Value GetCustomInstanceState (
+      const SQLiteDatabase& db,
+      const uint256& hash, unsigned height);
+
+  /**
    * Returns a handle to an AutoId instance for a given named key.  That can
    * be used to generate a consistent sequence of integer IDs.
    */
@@ -241,6 +253,9 @@ protected:
   GameStateData ProcessBackwardsInternal (const GameStateData& newState,
                                           const Json::Value& blockData,
                                           const UndoData& undo) override;
+
+  Json::Value GetCustomInstanceStateJson (const uint256& hash, unsigned height,
+                                          const GameStateData& state) override;
 
 public:
 

--- a/xayagame/sqlitegame_tests.cpp
+++ b/xayagame/sqlitegame_tests.cpp
@@ -616,6 +616,13 @@ TEST_F (MovingTests, ErrorHandling)
   });
 }
 
+TEST_F (MovingTests, InstanceStateHasNoCustomField)
+{
+  AttachBlock (game, BlockHash (11), ChatGame::Moves ({}));
+  const Json::Value state = game.GetCurrentJsonState ();
+  EXPECT_FALSE (state.isMember ("custom"));
+}
+
 /* ************************************************************************** */
 
 /**
@@ -768,6 +775,49 @@ using SchemaVersionTests = SQLiteGameTests<ChatWithSchemaVersion>;
 TEST_F (SchemaVersionTests, VersionSet)
 {
   EXPECT_EQ (rules.GetSchemaVersion (), "schema");
+}
+
+/* ************************************************************************** */
+
+class CustomStateChatGame : public ChatGame
+{
+
+public:
+
+  Json::Value
+  GetCustomInstanceState (const SQLiteDatabase& db,
+                                const uint256& hash,
+                                unsigned height) override
+  {
+    const auto state = GetState (db);
+    const auto mit = state.find ("customuser");
+    if (mit == state.end ())
+      return Json::Value ();
+
+    Json::Value res(Json::objectValue);
+    res["msg"] = mit->second;
+    return res;
+  }
+
+};
+
+using CustomStateTests = SQLiteGameTests<CustomStateChatGame>;
+
+TEST_F (CustomStateTests, NoCustomFieldWhenUserMissing)
+{
+  AttachBlock (game, BlockHash (11),
+               ChatGame::Moves ({{"otheruser", "irrelevant"}}));
+  const Json::Value state = game.GetCurrentJsonState ();
+  EXPECT_FALSE (state.isMember ("custom"));
+}
+
+TEST_F (CustomStateTests, CustomFieldWhenUserExists)
+{
+  AttachBlock (game, BlockHash (11),
+               ChatGame::Moves ({ {"customuser", "hello"} }));
+  const Json::Value state = game.GetCurrentJsonState ();
+  ASSERT_TRUE (state.isMember ("custom"));
+  EXPECT_EQ (state["custom"]["msg"], "hello");
 }
 
 /* ************************************************************************** */


### PR DESCRIPTION
This adds `GetCustomInstanceStateJson` as a new hook to `GameLogic`, which subclasses can use to provide custom data returned as part of the "instance state" (such as getnullstate or any other RPC methods).

`SQLiteGame` has its own implementation and hook, which allows subclasses to extract the data from the SQLite database.