### PR TITLE
Release savepoint after rollback in SQLiteStorage (fixes #149)

### DIFF
--- a/xayagame/sqlitestorage.cpp
+++ b/xayagame/sqlitestorage.cpp
@@ -932,7 +932,12 @@ SQLiteStorage::CommitTransaction ()
 void
 SQLiteStorage::RollbackTransaction ()
 {
+  /* ROLLBACK TO just undoes the changes, but it keeps the savepoint
+     itself on the stack and the associated transaction open.  Thus we
+     have to RELEASE it as well, so that the transaction gets closed
+     and later commits on the same connection are actually persisted.  */
   db->Prepare ("ROLLBACK TO `xayagame-sqlitegame`").Execute ();
+  db->Prepare ("RELEASE `xayagame-sqlitegame`").Execute ();
   CHECK (startedTransaction);
   startedTransaction = false;
 }

--- a/xayagame/sqlitestorage_tests.cpp
+++ b/xayagame/sqlitestorage_tests.cpp
@@ -336,6 +336,40 @@ TEST_F (PersistentSQLiteStorageTests, PersistsData)
   }
 }
 
+TEST_F (PersistentSQLiteStorageTests, CommitAfterRollback)
+{
+  {
+    SQLiteStorage storage(file.GetName ());
+    storage.Initialise ();
+
+    /* A rolled back transaction should leave the connection in a clean
+       state, so that a following transaction can be committed and is
+       actually persisted (see issue #149).  */
+    storage.BeginTransaction ();
+    storage.SetCurrentGameState (hash, "wrong state");
+    storage.RollbackTransaction ();
+
+    storage.BeginTransaction ();
+    storage.SetCurrentGameState (hash, state);
+    storage.AddUndoData (hash, 42, undo);
+    storage.CommitTransaction ();
+  }
+
+  {
+    SQLiteStorage storage(file.GetName ());
+    storage.Initialise ();
+
+    uint256 h;
+    ASSERT_TRUE (storage.GetCurrentBlockHash (h));
+    EXPECT_TRUE (h == hash);
+    EXPECT_EQ (storage.GetCurrentGameState (), state);
+
+    UndoData val;
+    ASSERT_TRUE (storage.GetUndoData (hash, val));
+    EXPECT_EQ (val, undo);
+  }
+}
+
 TEST_F (PersistentSQLiteStorageTests, ClearWithOnDiskFile)
 {
   SQLiteStorage storage(file.GetName ());


### PR DESCRIPTION
ROLLBACK TO undoes the changes of a savepoint but keeps the savepoint on the stack and the transaction open. 


So, RollbackTransaction thus left the connection inside an open transaction, so that all later commits on the same connection were invisible to other connections and lost when the connection was closed.