### PR TITLE
Do not crash on shutdown if untracking the game fails (fixes #154)

### DIFF
--- a/xayagame/game.cpp
+++ b/xayagame/game.cpp
@@ -1072,7 +1072,17 @@ Game::Stop ()
   connectionChecker.reset ();
 
   zmq.Stop ();
-  UntrackGame ();
+  try
+    {
+      UntrackGame ();
+    }
+  catch (const std::exception& exc)
+    {
+      /* If the block source is unavailable (e.g. because it is itself
+         already shut down), untracking the game fails.  This should not
+         prevent a clean shutdown of the GSP.  */
+      LOG (ERROR) << "Failed to untrack game on shutdown: " << exc.what ();
+    }
   CHECK (state == State::DISCONNECTED);
 
   /* Make sure to wake up all listeners waiting for a state update (as there

--- a/xayagame/game_tests.cpp
+++ b/xayagame/game_tests.cpp
@@ -41,6 +41,7 @@ using testing::_;
 using testing::AnyNumber;
 using testing::InSequence;
 using testing::Return;
+using testing::Throw;
 
 constexpr const char GAME_ID[] = "test-game";
 
@@ -2670,6 +2671,21 @@ TEST_F (GameProbeAndFixConnectionTests, DisconnectAndReconnect)
   EXPECT_EQ (GetState (g), State::UP_TO_DATE);
   EXPECT_EQ (rules.GetLastInstanceState ()["state"].asString (), "up-to-date");
   EXPECT_TRUE (GameTestFixture::GetZmq (g).IsRunning ());
+}
+
+TEST_F (GameProbeAndFixConnectionTests, StopSurvivesUntrackGameError)
+{
+  ExpectPings (0);
+
+  /* If the block source is down when the game is stopped, the untracking
+     RPC fails.  This should not crash the process but still result in a
+     clean shutdown (see issue #154).  */
+  EXPECT_CALL (*mockXayaServer, trackedgames ("remove", GAME_ID))
+      .WillOnce (Throw (
+          jsonrpc::JsonRpcException (jsonrpc::Errors::ERROR_RPC_INTERNAL_ERROR)));
+
+  g.Stop ();
+  EXPECT_EQ (GetState (g), State::DISCONNECTED);
 }
 
 /* ************************************************************************** */


### PR DESCRIPTION
Game::Stop() calls UntrackGame(), which performs a trackedgames RPC without any exception handling,  adding a try / catch to se what was the error exactly