### PR TITLE
Make coprocessor transaction handling exception-safe (fixes #151)

### DIFF
--- a/xayagame/coprocessor.cpp
+++ b/xayagame/coprocessor.cpp
@@ -32,10 +32,16 @@ void
 CoprocessorBatch::CommitTransaction ()
 {
   CHECK (activeTransaction) << "There is no active transaction";
-  activeTransaction = false;
 
+  /* Only clear the flag after all processors have committed successfully.
+     If one of them throws, the flag remains set, so that a subsequent
+     AbortTransaction call actually rolls back the processors that still
+     have an open transaction (rather than being a no-op) and the
+     operation can be retried.  */
   for (auto& p : processors)
     p.second->CommitTransaction ();
+
+  activeTransaction = false;
 }
 
 void

--- a/xayagame/transactionmanager.cpp
+++ b/xayagame/transactionmanager.cpp
@@ -97,7 +97,6 @@ TransactionManager::BeginTransaction ()
   CHECK (!commitFailed);
 
   CHECK (!inTransaction);
-  inTransaction = true;
 
   VLOG (1) << "Starting new transaction on the TransactionManager";
 
@@ -105,9 +104,30 @@ TransactionManager::BeginTransaction ()
     {
       LOG (INFO) << "No pending commits, starting new underlying transaction";
       storage->BeginTransaction ();
-      if (coproc != nullptr)
-        coproc->BeginTransaction ();
+      try
+        {
+          if (coproc != nullptr)
+            coproc->BeginTransaction ();
+        }
+      catch (...)
+        {
+          /* If the coprocessors fail to begin their transaction, make sure
+             not to leave the storage transaction (nor any coprocessors that
+             have already begun) open, so that the whole operation can be
+             retried cleanly afterwards.  */
+          storage->RollbackTransaction ();
+          if (coproc != nullptr)
+            coproc->AbortTransaction ();
+          throw;
+        }
     }
+
+  /* Only mark the transaction as active after the underlying transactions
+     have been started successfully.  If one of them throws, the exception
+     escapes the ActiveTransaction constructor, so its destructor (which
+     would do the rollback) never runs; thus we must not leave the manager
+     in an inconsistent state in that case.  */
+  inTransaction = true;
 }
 
 void

--- a/xayagame/transactionmanager_tests.cpp
+++ b/xayagame/transactionmanager_tests.cpp
@@ -23,6 +23,7 @@ namespace
 {
 
 using testing::InSequence;
+using testing::Throw;
 
 class MockedStorage : public TxMockedMemoryStorage
 {
@@ -131,6 +132,66 @@ TEST_F (TransactionManagerTests, BasicBatching)
 
   tm.BeginTransaction ();
   tm.CommitTransaction ();
+
+  tm.BeginTransaction ();
+  tm.CommitTransaction ();
+}
+
+TEST_F (TransactionManagerTests, ErrorInCoprocessorBegin)
+{
+  {
+    InSequence dummy;
+
+    EXPECT_CALL (storage, BeginTransactionMock ());
+    EXPECT_CALL (coproc, BeginTransaction ())
+        .WillOnce (Throw (std::runtime_error ("begin error")));
+    EXPECT_CALL (storage, RollbackTransactionMock ());
+    EXPECT_CALL (coproc, AbortTransaction ());
+
+    EXPECT_CALL (storage, BeginTransactionMock ());
+    EXPECT_CALL (coproc, BeginTransaction ());
+    EXPECT_CALL (coproc, CommitTransaction ());
+    EXPECT_CALL (storage, CommitTransactionMock ());
+  }
+
+  tm.SetBatchSize (1);
+
+  /* A failure to begin the coprocessor transaction should propagate, but
+     leave the manager (and storage) in a clean state, so that the operation
+     can be retried later (see issue #151).  */
+  EXPECT_THROW (tm.BeginTransaction (), std::runtime_error);
+
+  tm.BeginTransaction ();
+  tm.CommitTransaction ();
+}
+
+TEST_F (TransactionManagerTests, ErrorInCoprocessorCommit)
+{
+  {
+    InSequence dummy;
+
+    EXPECT_CALL (storage, BeginTransactionMock ());
+    EXPECT_CALL (coproc, BeginTransaction ());
+    EXPECT_CALL (coproc, CommitTransaction ())
+        .WillOnce (Throw (std::runtime_error ("commit error")));
+    EXPECT_CALL (storage, RollbackTransactionMock ());
+    EXPECT_CALL (coproc, AbortTransaction ());
+
+    EXPECT_CALL (storage, BeginTransactionMock ());
+    EXPECT_CALL (coproc, BeginTransaction ());
+    EXPECT_CALL (coproc, CommitTransaction ());
+    EXPECT_CALL (storage, CommitTransactionMock ());
+  }
+
+  tm.SetBatchSize (1);
+
+  tm.BeginTransaction ();
+  /* If a coprocessor fails to commit, the error should propagate, but a
+     subsequent rollback must actually abort the coprocessor transactions
+     that are still open, so that the block can be retried
+     (see issue #151).  */
+  EXPECT_THROW (tm.CommitTransaction (), std::runtime_error);
+  tm.RollbackTransaction ();
 
   tm.BeginTransaction ();
   tm.CommitTransaction ();


### PR DESCRIPTION
CoprocessorBatch::CommitTransaction cleared the activeTransaction flag before iterating the processors, so if one of them threw, a subsequent AbortTransaction was a no-op and processors were left with open transactions. 