### PR TITLE
Don't consider ZMQ stale while processing

### DIFF
--- a/xayagame/zmqsubscriber.cpp
+++ b/xayagame/zmqsubscriber.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2022 The Xaya developers
+// Copyright (C) 2018-2026 The Xaya developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -219,7 +219,10 @@ ZmqSubscriber::Listen (ZmqSubscriber* self)
         {
         case TopicType::ATTACH:
         case TopicType::DETACH:
-          self->lastBlockUpdate = Clock::now ();
+          {
+            std::lock_guard<std::shared_mutex> lock(self->mutProcessing);
+            self->lastBlockUpdate = Clock::now ();
+          }
           break;
         default:
           break;
@@ -228,6 +231,11 @@ ZmqSubscriber::Listen (ZmqSubscriber* self)
       const auto range = self->listeners.equal_range (gameId);
       if (range.first == self->listeners.end ())
         continue;
+
+      {
+        std::lock_guard<std::shared_mutex> lock(self->mutProcessing);
+        self->processingMessage = true;
+      }
 
       Json::Value data;
       std::string parseErrs;
@@ -261,9 +269,24 @@ ZmqSubscriber::Listen (ZmqSubscriber* self)
               << "Exception while processing ZMQ update: " << exc.what ();
           break;
         }
+
+      /* Make sure that after potentially a long processing step, we don't
+         introduce a window of time where the connection will look stale just
+         because the processing took long.  We want to reset the "busy" flag
+         only after/atomically with updating the last updated timestamp
+         to the current time.  */
+      {
+        std::lock_guard<std::shared_mutex> lock(self->mutProcessing);
+        self->lastBlockUpdate = Clock::now ();
+        self->processingMessage = false;
+      }
     }
 
   self->running = false;
+  {
+    std::lock_guard<std::shared_mutex> lock(self->mutProcessing);
+    self->processingMessage = false;
+  }
   for (auto& l : self->listeners)
     l.second->HasStopped ();
 }

--- a/xayagame/zmqsubscriber.hpp
+++ b/xayagame/zmqsubscriber.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2022 The Xaya developers
+// Copyright (C) 2018-2026 The Xaya developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -15,6 +15,7 @@
 #include <atomic>
 #include <chrono>
 #include <memory>
+#include <shared_mutex>
 #include <string>
 #include <thread>
 #include <unordered_map>
@@ -107,8 +108,19 @@ private:
   /** Last sequence numbers for each topic.  */
   std::unordered_map<std::string, uint32_t> lastSeq;
 
+  /**
+   * Mutex to protect lastBlockUpdate and processingMessage, and make sure
+   * writes to them occur in the right order and synchronised.  A write lock
+   * on the mutex is held only very briefly to actually assign the values
+   * in the right order, never for a long period of time.
+   */
+  mutable std::shared_mutex mutProcessing;
+
   /** The time-point when the last block notification was received.  */
   Clock::time_point lastBlockUpdate;
+
+  /** Set to true while running a block/pending callback.  */
+  bool processingMessage = false;
 
   /** The running ZMQ listener thread, if any.  */
   std::unique_ptr<std::thread> worker;
@@ -192,12 +204,16 @@ public:
 
   /**
    * Returns the time since last block update, cast to the given
-   * duration type.
+   * duration type.  While a processing callback is running, we always
+   * return zero, i.e. never consider the connection stale in that case.
    */
   template <typename D>
     D
     GetBlockStaleness () const
   {
+    std::shared_lock<std::shared_mutex> lock(mutProcessing);
+    if (processingMessage)
+      return D (0);
     return std::chrono::duration_cast<D> (Clock::now () - lastBlockUpdate);
   }
 

--- a/xayagame/zmqsubscriber_tests.cpp
+++ b/xayagame/zmqsubscriber_tests.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2022 The Xaya developers
+// Copyright (C) 2018-2026 The Xaya developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -25,6 +25,7 @@ namespace
 using testing::_;
 using testing::AnyNumber;
 using testing::InSequence;
+using testing::Invoke;
 using testing::Throw;
 
 constexpr const char IPC_ENDPOINT[] = "ipc:///tmp/xayagame_zmqsubscriber_tests";
@@ -561,6 +562,32 @@ TEST_F (ZmqSubscriberTests, StalenessTimer)
   SleepSome ();
   EXPECT_LT (zmq.GetBlockStaleness<std::chrono::milliseconds> (),
              std::chrono::milliseconds (100));
+}
+
+TEST_F (ZmqSubscriberTests, NotStaleWhileBusy)
+{
+  Json::Value payload;
+  payload["test"] = 42;
+
+  EXPECT_CALL (mockListener, BlockAttach (GAME_ID, payload, _))
+      .Times (AnyNumber ())
+      .WillRepeatedly (Invoke ([] () {
+        std::this_thread::sleep_for (std::chrono::milliseconds (500));
+      }));
+
+  SendAttach (GAME_ID, payload, 1);
+  std::this_thread::sleep_for (std::chrono::milliseconds (200));
+
+  /* We are processing the long block, staleness should be zero.  */
+  EXPECT_EQ (zmq.GetBlockStaleness<std::chrono::milliseconds> (),
+             std::chrono::milliseconds (0));
+
+  /* At the end of the processing, the staleness has been reset once, but
+     will continue to increase from then on.  */
+  std::this_thread::sleep_for (std::chrono::milliseconds (500));
+  const auto staleness = zmq.GetBlockStaleness<std::chrono::milliseconds> ();
+  EXPECT_LT (staleness, std::chrono::milliseconds (500));
+  EXPECT_GT (staleness, std::chrono::milliseconds (100));
 }
 
 /* ************************************************************************** */


### PR DESCRIPTION
When we process a block attach/detach or pending transaction in the callback from `ZmqSubscriber`, don't consider the connection stale in any case, even if the processing takes longer than the staleness timeout.

This avoids spurious (false positive) detections of staleness and reconnects e.g. during Soccerverse match days or other expensive-to-process blocks that may occur.

Fixes #147.