### PR TITLE
Add Clear hook for co-processors

### DIFF
--- a/xayagame/coprocessor.cpp
+++ b/xayagame/coprocessor.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2024 The Xaya developers
+// Copyright (C) 2023-2026 The Xaya developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -54,6 +54,14 @@ CoprocessorBatch::AbortTransaction ()
 
   for (auto& p : processors)
     p.second->AbortTransaction ();
+}
+
+void
+CoprocessorBatch::Clear ()
+{
+  CHECK (!activeTransaction) << "There is an active transaction";
+  for (auto& p : processors)
+    p.second->Clear ();
 }
 
 Coprocessor::Block::Block (const Json::Value& d, const Op o)

--- a/xayagame/coprocessor.hpp
+++ b/xayagame/coprocessor.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2024 The Xaya developers
+// Copyright (C) 2023-2026 The Xaya developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -91,6 +91,18 @@ public:
   {}
 
   /**
+   * Requests that the coprocessor clears/resets all internal state data
+   * it has stored.  This is done if we need to reinitialise, before
+   * running a ForBlock "initialisation" operation.  This hook runs outside
+   * of the transaction logic, and can thus use explicit "wipe everything"
+   * semantics on a database without being constrained to live inside
+   * a transactional workflow.
+   */
+  virtual void
+  Clear ()
+  {}
+
+  /**
    * Constructs a block-processor instance for this coprocessor and the
    * given block data.
    */
@@ -136,6 +148,8 @@ public:
    * safely called if there is none, to ensure we clean up if needed.
    */
   void AbortTransaction ();
+
+  void Clear ();
 
 };
 

--- a/xayagame/game.cpp
+++ b/xayagame/game.cpp
@@ -230,6 +230,7 @@ Game::UpdateStateForDetach (const uint256& parent, const uint256& hash,
           << "Block " << hash.ToHex ()
           << " is being detached without undo data";
       storage->Clear ();
+      coproc.Clear ();
       return false;
     }
 
@@ -1243,6 +1244,7 @@ Game::ReinitialiseState ()
 
   transactionManager.TryAbortTransaction ();
   storage->Clear ();
+  coproc.Clear ();
 
   const std::string blockHashHex = (**rpcProvider).getblockhash (genesisHeight);
   uint256 blockHash;

--- a/xayagame/game_tests.cpp
+++ b/xayagame/game_tests.cpp
@@ -1805,16 +1805,34 @@ public:
     Coprocessor::Op op;
     uint64_t height;
 
+    /**
+     * True if this is a Clear() operation, which runs independent of a block
+     * or height.  If this is true, then only this matters, and the other fields
+     * are ignored.
+     */
+    bool isClear = false;
+
     friend bool
     operator== (const Record& a, const Record& b)
     {
-      return a.op == b.op && a.height == b.height;
+      if (a.isClear && b.isClear)
+        return true;
+
+      return a.isClear == b.isClear && a.op == b.op && a.height == b.height;
     }
 
     friend bool
     operator!= (const Record& a, const Record& b)
     {
       return !(a == b);
+    }
+
+    static Record
+    Clear ()
+    {
+      Record res;
+      res.isClear = true;
+      return res;
     }
 
   };
@@ -1875,6 +1893,13 @@ public:
     CHECK (transaction) << "No transaction to abort";
     transaction = false;
     pending.clear ();
+  }
+
+  void
+  Clear () override
+  {
+    CHECK (!transaction) << "A transaction is in progress";
+    records.push_back (Record::Clear ());
   }
 
   std::unique_ptr<Block> ForBlock (const Json::Value& blockData,
@@ -2051,6 +2076,7 @@ TEST_F (GameCoprocessorTests, CoprocessorCalled)
   DetachBlock (g);
 
   coproc.ExpectRecords ({
+    GameTestCoprocessor::Record::Clear (),
     {Coprocessor::Op::INITIALISATION, GAME_GENESIS_HEIGHT},
     {Coprocessor::Op::FORWARD, 11},
     {Coprocessor::Op::FORWARD, 12},
@@ -2066,9 +2092,35 @@ TEST_F (GameCoprocessorTests, Failure)
                 std::runtime_error);
 
   coproc.ExpectRecords ({
+    GameTestCoprocessor::Record::Clear (),
     {Coprocessor::Op::INITIALISATION, GAME_GENESIS_HEIGHT},
     {Coprocessor::Op::FORWARD, 11},
   });
+}
+
+TEST_F (GameCoprocessorTests, MissingUndoDetach)
+{
+  AttachBlock (g, BlockHash (11), Moves ("a0b1"));
+
+  storage.BeginTransaction ();
+  storage.ReleaseUndoData (BlockHash (11));
+  storage.CommitTransaction ();
+
+  DetachBlock (g);
+
+  coproc.ExpectRecords ({
+    GameTestCoprocessor::Record::Clear (),
+    {Coprocessor::Op::INITIALISATION, GAME_GENESIS_HEIGHT},
+    {Coprocessor::Op::FORWARD, 11},
+    /* This is the explicit clear from the missing undo data.  */
+    GameTestCoprocessor::Record::Clear (),
+    /* This is from state initialisation that happens after wiping the
+       data, and restarting the sync from scratch.  */
+    GameTestCoprocessor::Record::Clear (),
+    {Coprocessor::Op::INITIALISATION, GAME_GENESIS_HEIGHT},
+  });
+
+  ExpectGameState (TestGame::GenesisBlockHash (), "");
 }
 
 /* ************************************************************************** */


### PR DESCRIPTION
Add an explicit `Clear()` method / hook to the `Coprocessor` interface. This method is used to wipe storage if the state is fully reinitialised, and it lives outside the transaction workflow; this gives implementations more freedom in implementing a full "wipe database" semantic if useful for them, compared to the current system where applications need to wipe on "initialisation".

Fixes #163.