### PR TITLE
Fix potential issue with fromblock==toblock

### DIFF
--- a/xayagame/game.cpp
+++ b/xayagame/game.cpp
@@ -1162,13 +1162,19 @@ Game::SyncFromCurrentState (const Json::Value& blockchainInfo,
 
   /* If an error is returned, such as when Xaya X is not yet synced to
      our "fromblock", reset the ZMQ connection so it gets restored and
-     the sync retried later.  */
+     the sync retried later.
+
+     In an edge case (load-balanced RPC node or a reorg race condition
+     with the "best chain tip" we checked against above), it may also happen
+     that there is no real error returned, but the server is not able to
+     provide any step towards our target.  In this case, we also fall back
+     to the retry logic.  */
   const auto errValue = upd["error"];
-  if (errValue.isBool () && errValue.asBool ())
+  if ((errValue.isBool () && errValue.asBool ())
+        || (currentHash.ToHex () == upd["toblock"].asString ()))
     {
       LOG (ERROR)
-          << "Game blocks update request returned error,"
-          << " resetting ZMQ connection...";
+          << "Game blocks update request failed, resetting ZMQ connection...";
       zmq.RequestStop ();
       return;
     }


### PR DESCRIPTION
When the Xaya X RPC server returns `fromblock == toblock` after we requested updates (which can happen due to a race condition or load-balanced nodes that are not exactly in sync), make sure to treat this as an "error" that we retry later.

Otherwise, the GSP will get stuck in "catching up" state waiting for a target block (`catchingUpTarget`) that will never arrive.

This fixes #150.