### PR TITLE
Catch RPC errors during initial ConnectToZmq

### DIFF
--- a/xayagame/game.cpp
+++ b/xayagame/game.cpp
@@ -1025,7 +1025,15 @@ Game::TrackGame ()
   std::lock_guard<std::mutex> lock(mut);
   CHECK (rpcProvider != nullptr && *rpcProvider)
       << "RPC client is not yet set up";
+
+  if (gameTracked)
+    {
+      VLOG (1) << "Game " << gameId << " is already tracked";
+      return;
+    }
+
   (**rpcProvider).trackedgames ("add", gameId);
+  gameTracked = true;
   LOG (INFO) << "Added " << gameId << " to tracked games";
 }
 
@@ -1035,6 +1043,16 @@ Game::UntrackGame ()
   std::lock_guard<std::mutex> lock(mut);
   CHECK (rpcProvider != nullptr && *rpcProvider)
       << "RPC client is not yet set up";
+
+  if (!gameTracked)
+    {
+      VLOG (1) << "Game " << gameId << " is not tracked";
+      return;
+    }
+
+  /* Clear the flag before the RPC call so that it is cleared even if
+     the RPC throws.  */
+  gameTracked = false;
   (**rpcProvider).trackedgames ("remove", gameId);
   LOG (INFO) << "Removed " << gameId << " from tracked games";
 }
@@ -1061,7 +1079,20 @@ Game::ConnectToZmq ()
 void
 Game::Start ()
 {
-  ConnectToZmq ();
+  try
+    {
+      ConnectToZmq ();
+    }
+  catch (const std::exception& exc)
+    {
+      LOG (ERROR) << "Exception during initial ConnectToZmq: " << exc.what ();
+      if (zmq.IsRunning ())
+        zmq.RequestStop ();
+
+      std::lock_guard<std::mutex> lock(mut);
+      state = State::DISCONNECTED;
+      NotifyInstanceStateChanged ();
+    }
 
   if (FLAGS_xaya_connection_check_ms > 0)
     connectionChecker = std::make_unique<ConnectionCheckerThread> (*this);

--- a/xayagame/game.hpp
+++ b/xayagame/game.hpp
@@ -137,6 +137,14 @@ private:
   std::atomic<State> state;
 
   /**
+   * Whether or not this game has been registered with the Xaya daemon
+   * as a tracked game (via "trackedgames add").  This is used to avoid
+   * duplicate RPC calls, which would lead to many more tracks than the one
+   * "untrack" we do in Stop().
+   */
+  bool gameTracked = false;
+
+  /**
    * The game's genesis height, if known already.  We cache that from the
    * first call to GetInitialState, so that we can avoid calling it all
    * over again on each block before we reach the genesis height.


### PR DESCRIPTION
In `Game::Start`, gracefully handle an RPC error from Xaya X during `ConnectToZmq`.  In that case, we mark the state as `DISCONNECTED` but still start the connection checker, which will eventually recover the GSP.

Note that errors before `Game::Start()` is even called still crash the GSP, that is on purpose, so a wrongly configured RPC URL will be caught.

Errors that happen later during ZMQ processing are already caught by the ZMQ thread, which also leads ultimately to `DISCONNECTED` and eventual restart/recovery.

We also fix a big with tracking games -- `TrackGame()` was called on every ZMQ reconnect, while `UntrackGame()` only on shutdown.  This used to make game trackings "pile up" and not be cleaned up entirely in some cases.

We now use a flag to know if we already tracked the game (successfully) or not, and make sure we have exactly one pair of track/untrack around the main ZMQ logic.

Fixes #133.