### PR TITLE
gamechannel: let games restrict the required signers of unanchored state proofs

### DIFF
--- a/gamechannel/boardrules.cpp
+++ b/gamechannel/boardrules.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 The Xaya developers
+// Copyright (C) 2019-2026 The Xaya developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -8,6 +8,15 @@ namespace xaya
 {
 
 constexpr int ParsedBoardState::NO_TURN;
+
+std::set<int>
+ParsedBoardState::RequiredSignatures () const
+{
+  std::set<int> res;
+  for (int i = 0; i < meta.participants_size (); ++i)
+    res.insert (i);
+  return res;
+}
 
 Json::Value
 ParsedBoardState::ToJson () const

--- a/gamechannel/boardrules.hpp
+++ b/gamechannel/boardrules.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2022 The Xaya developers
+// Copyright (C) 2019-2026 The Xaya developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -13,6 +13,7 @@
 #include <json/json.h>
 
 #include <memory>
+#include <set>
 #include <string>
 
 namespace xaya
@@ -141,6 +142,16 @@ public:
    * context of the given old state).
    */
   virtual bool ApplyMove (const BoardMove& mv, BoardState& newState) const = 0;
+
+  /**
+   * Returns the set of participant indices whose signatures are required
+   * for a state proof that does not start from the on-chain state.  By
+   * default all participants are required.  Games whose participants can be
+   * removed from play by on-chain events (so that they provably can no
+   * longer sign) may exclude those seats when this state is the on-chain
+   * reinit state; the framework only ever calls this on the reinit state.
+   */
+  virtual std::set<int> RequiredSignatures () const;
 
   /**
    * Returns a JSON representation of the current board state.  This is used

--- a/gamechannel/stateproof.cpp
+++ b/gamechannel/stateproof.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2022 The Xaya developers
+// Copyright (C) 2019-2026 The Xaya developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -137,14 +137,32 @@ VerifyStateProof (const SignatureVerifier& verifier, const BoardRules& rules,
       return true;
     }
 
-  for (int i = 0; i < meta.participants_size (); ++i)
+  /* The set of signatures required for a proof not anchored at the on-chain
+     state is determined by the game from the parsed reinit state.  Since that
+     state comes from on-chain data (not the proof itself), a malicious proof
+     cannot influence the set.  If the reinit state fails to parse (which
+     should not happen for on-chain data), we fall back to requiring all
+     participants.  */
+  std::set<int> required;
+  const auto parsedReinit = rules.ParseState (channelId, meta, reinitState);
+  if (parsedReinit == nullptr)
+    {
+      LOG (WARNING)
+          << "Failed to parse reinit state, requiring all signatures";
+      for (int i = 0; i < meta.participants_size (); ++i)
+        required.insert (i);
+    }
+  else
+    required = parsedReinit->RequiredSignatures ();
+
+  for (const int i : required)
     if (signatures.count (i) == 0)
       {
         LOG (WARNING) << "StateProof has no signature of player " << i;
         return false;
       }
 
-  VLOG (1) << "StateProof has signatures by all players and is valid";
+  VLOG (1) << "StateProof has all required signatures and is valid";
   return true;
 }
 

--- a/gamechannel/stateproof_tests.cpp
+++ b/gamechannel/stateproof_tests.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2022 The Xaya developers
+// Copyright (C) 2019-2026 The Xaya developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -379,6 +379,237 @@ TEST_F (StateProofTests, MultiSignedLaterState)
       }
   )"));
   EXPECT_EQ (endState, "43 6");
+}
+
+TEST_F (StateProofTests, DefaultRequiredSignaturesIsAllParticipants)
+{
+  /* Without an overridden RequiredSignatures, an unanchored proof needs
+     signatures of all participants (the historic rule).  */
+  EXPECT_FALSE (VerifyProof ("0 1", R"(
+    initial_state:
+      {
+        data: "42 5"
+        signatures: "sgn0"
+      }
+  )"));
+
+  ASSERT_TRUE (VerifyProof ("0 1", R"(
+    initial_state:
+      {
+        data: "42 5"
+        signatures: "sgn0"
+        signatures: "sgn1"
+      }
+  )"));
+  EXPECT_EQ (endState, "42 5");
+}
+
+/* ************************************************************************** */
+
+/**
+ * A ParsedBoardState that wraps a state of the addition game, but reports
+ * a custom set of required signatures.
+ */
+class SignerSetState : public ParsedBoardState
+{
+
+private:
+
+  /** The underlying parsed addition-game state.  */
+  std::unique_ptr<ParsedBoardState> inner;
+
+  /** The set of required signatures to report.  */
+  const std::set<int> required;
+
+public:
+
+  explicit SignerSetState (const BoardRules& r, const uint256& id,
+                           const proto::ChannelMetadata& m,
+                           std::unique_ptr<ParsedBoardState> i,
+                           const std::set<int>& req)
+    : ParsedBoardState(r, id, m), inner(std::move (i)), required(req)
+  {}
+
+  bool
+  Equals (const BoardState& other) const override
+  {
+    return inner->Equals (other);
+  }
+
+  int
+  WhoseTurn () const override
+  {
+    return inner->WhoseTurn ();
+  }
+
+  unsigned
+  TurnCount () const override
+  {
+    return inner->TurnCount ();
+  }
+
+  bool
+  ApplyMove (const BoardMove& mv, BoardState& newState) const override
+  {
+    return inner->ApplyMove (mv, newState);
+  }
+
+  std::set<int>
+  RequiredSignatures () const override
+  {
+    return required;
+  }
+
+};
+
+/**
+ * Board rules that behave like the addition game, except that all parsed
+ * states report a configurable set of required signatures.
+ */
+class SignerSetRules : public BoardRules
+{
+
+private:
+
+  /** The underlying addition-game rules.  */
+  AdditionRules base;
+
+public:
+
+  /** The set of required signatures reported by all parsed states.  */
+  std::set<int> required;
+
+  std::unique_ptr<ParsedBoardState>
+  ParseState (const uint256& channelId, const proto::ChannelMetadata& meta,
+              const BoardState& s) const override
+  {
+    auto inner = base.ParseState (channelId, meta, s);
+    if (inner == nullptr)
+      return nullptr;
+    return std::make_unique<SignerSetState> (*this, channelId, meta,
+                                             std::move (inner), required);
+  }
+
+  ChannelProtoVersion
+  GetProtoVersion (const proto::ChannelMetadata& meta) const override
+  {
+    return base.GetProtoVersion (meta);
+  }
+
+};
+
+class SignerSetStateProofTests : public GeneralStateProofTests
+{
+
+protected:
+
+  SignerSetRules rules;
+
+  BoardState endState;
+
+  SignerSetStateProofTests ()
+  {
+    meta.add_participants ()->set_address ("addr2");
+    verifier.SetValid ("sgn2", "addr2");
+  }
+
+  /**
+   * Calls VerifyStateProof with the custom rules based on the given
+   * on-chain state and the proof proto loaded from text format.
+   */
+  bool
+  VerifyProof (const BoardState& chainState, const std::string& proof)
+  {
+    return VerifyStateProof (verifier, rules, gameId, channelId, meta,
+                             chainState, TextProof (proof), endState);
+  }
+
+};
+
+TEST_F (SignerSetStateProofTests, ExcludedSeatNotNeeded)
+{
+  rules.required = {0, 2};
+  ASSERT_TRUE (VerifyProof ("0 1", R"(
+    initial_state:
+      {
+        data: "42 5"
+        signatures: "sgn0"
+        signatures: "sgn2"
+      }
+  )"));
+  EXPECT_EQ (endState, "42 5");
+}
+
+TEST_F (SignerSetStateProofTests, SignaturesAccumulateAcrossTransitions)
+{
+  rules.required = {0, 2};
+  ASSERT_TRUE (VerifyProof ("0 1", R"(
+    initial_state:
+      {
+        data: "42 5"
+        signatures: "sgn2"
+      }
+    transitions:
+      {
+        move: "1"
+        new_state:
+          {
+            data: "43 6"
+            signatures: "sgn0"
+          }
+      }
+  )"));
+  EXPECT_EQ (endState, "43 6");
+}
+
+TEST_F (SignerSetStateProofTests, MissingRequiredSeat)
+{
+  rules.required = {0, 2};
+  EXPECT_FALSE (VerifyProof ("0 1", R"(
+    initial_state:
+      {
+        data: "42 5"
+        signatures: "sgn0"
+        signatures: "sgn1"
+      }
+  )"));
+}
+
+TEST_F (SignerSetStateProofTests, OnChainAcceptedRegardless)
+{
+  rules.required = {0, 1, 2};
+  ASSERT_TRUE (VerifyProof ("42 5", R"(
+    initial_state:
+      {
+        data: "42 5"
+        signatures: "sgn42"
+      }
+  )"));
+  EXPECT_EQ (endState, "42 5");
+}
+
+TEST_F (SignerSetStateProofTests, UnparseableReinitRequiresAll)
+{
+  rules.required = {0};
+
+  EXPECT_FALSE (VerifyProof ("invalid", R"(
+    initial_state:
+      {
+        data: "42 5"
+        signatures: "sgn0"
+      }
+  )"));
+
+  ASSERT_TRUE (VerifyProof ("invalid", R"(
+    initial_state:
+      {
+        data: "42 5"
+        signatures: "sgn0"
+        signatures: "sgn1"
+        signatures: "sgn2"
+      }
+  )"));
+  EXPECT_EQ (endState, "42 5");
 }
 
 /* ************************************************************************** */

--- a/gamechannel/stateproof_tests.cpp
+++ b/gamechannel/stateproof_tests.cpp
@@ -614,6 +614,117 @@ TEST_F (SignerSetStateProofTests, UnparseableReinitRequiresAll)
 
 /* ************************************************************************** */
 
+/**
+ * Board rules like SignerSetRules, except that the required signatures
+ * depend on the content of the parsed state itself:  the state matching
+ * a configured content requires all participants, while every other
+ * state requires only seat 0.  This makes the reinit state and the states
+ * inside a proof report different sets, so that tests can pin down which
+ * of them the verification derives the required set from.
+ */
+class ContentSignerRules : public BoardRules
+{
+
+private:
+
+  /** The underlying addition-game rules.  */
+  AdditionRules base;
+
+public:
+
+  /** The state content whose parsed state requires all participants.  */
+  BoardState allSignersContent;
+
+  std::unique_ptr<ParsedBoardState>
+  ParseState (const uint256& channelId, const proto::ChannelMetadata& meta,
+              const BoardState& s) const override
+  {
+    auto inner = base.ParseState (channelId, meta, s);
+    if (inner == nullptr)
+      return nullptr;
+
+    std::set<int> required;
+    if (inner->Equals (allSignersContent))
+      for (int i = 0; i < meta.participants_size (); ++i)
+        required.insert (i);
+    else
+      required.insert (0);
+
+    return std::make_unique<SignerSetState> (*this, channelId, meta,
+                                             std::move (inner), required);
+  }
+
+  ChannelProtoVersion
+  GetProtoVersion (const proto::ChannelMetadata& meta) const override
+  {
+    return base.GetProtoVersion (meta);
+  }
+
+};
+
+class ContentSignerStateProofTests : public GeneralStateProofTests
+{
+
+protected:
+
+  ContentSignerRules rules;
+
+  BoardState endState;
+
+  ContentSignerStateProofTests ()
+  {
+    meta.add_participants ()->set_address ("addr2");
+    verifier.SetValid ("sgn2", "addr2");
+  }
+
+  /**
+   * Calls VerifyStateProof with the custom rules based on the given
+   * on-chain state and the proof proto loaded from text format.
+   */
+  bool
+  VerifyProof (const BoardState& chainState, const std::string& proof)
+  {
+    return VerifyStateProof (verifier, rules, gameId, channelId, meta,
+                             chainState, TextProof (proof), endState);
+  }
+
+};
+
+TEST_F (ContentSignerStateProofTests, RequiredSetDerivedFromReinitState)
+{
+  rules.allSignersContent = "0 1";
+
+  /* The reinit state ("0 1") requires all three participants, while the
+     proof's own states require just seat 0.  The required set must be
+     derived from the reinit state and never from the proof's content, so
+     a proof signed only by seat 0 is missing seats 1 and 2 and gets
+     rejected — even though the set derived from the proof's end state
+     would be satisfied.  */
+  EXPECT_FALSE (VerifyProof ("0 1", R"(
+    initial_state:
+      {
+        data: "42 5"
+        signatures: "sgn0"
+      }
+  )"));
+
+  /* With all three signatures present, the same proof is fine.  This
+     ensures the rejection above is really due to the reinit-derived set
+     and not some other defect.  */
+  ASSERT_TRUE (VerifyProof ("0 1", R"(
+    initial_state:
+      {
+        data: "42 5"
+        signatures: "sgn0"
+        signatures: "sgn1"
+        signatures: "sgn2"
+      }
+  )"));
+  EXPECT_EQ (endState, "42 5");
+}
+
+/* ************************************************************************** */
+
 using UnverifiedProofEndStateTests = testing::Test;
 
 TEST_F (UnverifiedProofEndStateTests, InitialState)


### PR DESCRIPTION
## Problem

`VerifyStateProof` accepts a state proof that is not anchored at the on-chain reinit state only if the accumulated signatures cover every participant in the channel metadata. That rule assumes every participant can keep signing for the whole life of the channel.

For N-player channel games that assumption can break mid-channel: when a participant is removed from play by an on-chain event — e.g. a dispute timeout ejecting one seat while the channel continues for the remaining players — that participant provably never signs again, yet it stays in the metadata. From that point on:

* no later unanchored proof can ever become valid, so peers cannot prune their proofs past the ejected seat's last signature;
* the working proof grows by one transition per move for the rest of the channel (measured live: a 3-player game degraded from 8.3 to 1.5 moves/s within a minute of an elimination, with proofs growing past 64 KiB);
* filing a dispute late in such a channel means putting the whole grown proof on chain (an 88 KiB proof cost ~21M gas to submit), so participants effectively lose the ability to defend.

## Change

* `ParsedBoardState` gains a virtual `RequiredSignatures ()`, returning the set of participant indices whose signatures are required for an unanchored proof. The default returns all participants, so behaviour is unchanged for every existing game.
* `VerifyStateProof` derives that set from the parsed **on-chain reinit state** instead of hard-coding all participants. If the reinit state fails to parse (which should not happen for on-chain data), it falls back to requiring all participants. Everything else — the anchored-at-reinit fast path, per-transition mover-signature checks, signature accumulation — is unchanged.

A game whose participants can be eliminated by on-chain events can then override the method to exclude those seats when parsing its reinit state, restoring proof pruning for the remaining players.

## Security considerations

* The required set is derived only from the caller-supplied on-chain reinit state, never from proof contents, so a malicious proof cannot shrink it. One of the new tests pins exactly this: a fixture whose reported set depends on the state content proves that taking the set from the proof's end state instead would be caught.
* The relaxation only ever removes the veto of a seat the game itself declares excluded based on on-chain data. For the motivating case (timeout-ejected seats) that seat's outcome is already sealed by the on-chain event; any fabricated unanchored base state still needs signatures from every remaining required participant.
* Parse failure of the reinit state fails closed to the historic all-participants rule.

## What about a participant eliminated by gameplay alone (no on-chain event)?

Nothing changes for that seat: it remains a required signer. Elimination by
gameplay is a fact that exists only inside the (attacker-controllable) proof
content, so it must never influence the required set — only on-chain data
may. A game that wants eliminated-but-still-present participants not to
block proof pruning should handle it in its rules instead, e.g. by keeping
such seats in the turn rotation restricted to signed no-op moves until an
on-chain event (such as a dispute-timeout ejection reflected in the reinit
state) actually removes them. The override in this PR is only the second
half of that pattern.

## Compatibility

Games that do not override the virtual get byte-for-byte the previous accept/reject behaviour (the default set is identical to the old all-participants loop, including the first-missing-signature warning). The only observable additions on the unanchored path are one `ParseState` call on the reinit state and log wording.

Note for downstreams that ship prebuilt objects: the new virtual changes the `ParsedBoardState` vtable, so dependents must be rebuilt against the updated library.

## Tests

`gamechannel_tests` grows 172 → 179, all passing:

* default `RequiredSignatures` behaves identically to the previous rule;
* an unanchored proof covering a reduced required set is accepted, and the identical proof is still rejected when a required seat's signature is missing;
* signatures accumulate across the initial state and transitions as before;
* anchored-at-reinit proofs remain valid with no coverage requirement;
* unparseable reinit state falls back to requiring all participants;
* the required set provably derives from the reinit state, not from proof content (fails if the call site is switched to the proof's end state).